### PR TITLE
feat: add --quiet flag

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -18,5 +18,9 @@ pub enum Command {
         /// Output format for violations. The default format is "concise"
         #[arg(value_enum, long = "output-format")]
         output_format: Option<Format>,
+
+        /// Only log errors
+        #[arg(long, default_value_t = false)]
+        quiet: bool,
     },
 }

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -17,6 +17,7 @@ use crate::Config;
 pub struct Options {
     pub config_path: Option<PathBuf>,
     pub output_format: Option<Format>,
+    pub quiet: bool,
 }
 
 impl Options {
@@ -30,6 +31,8 @@ impl Options {
         if let Some(format) = self.output_format {
             config.lint.output_format = format;
         }
+
+        config.lint.quiet = self.quiet;
 
         Ok(config)
     }
@@ -55,7 +58,10 @@ impl Checker {
         violations.sort_by(self.config.lint.output_format.sorter());
 
         if violations.is_empty() {
-            println!("All checks passed!");
+            if !self.config.lint.quiet {
+                println!("All checks passed!");
+            }
+
             return Ok(ExitCode::SUCCESS);
         }
 
@@ -96,6 +102,7 @@ mod tests {
         let options = Options {
             config_path: None,
             output_format: None,
+            quiet: false,
         };
         let actual = options.to_config().unwrap();
         let mut expected = Config::default();
@@ -109,6 +116,7 @@ mod tests {
         let options = Options {
             config_path: None,
             output_format: Some(Format::Mdl),
+            quiet: false,
         };
         let actual = options.to_config().unwrap();
         let mut expected = Config::default();
@@ -123,6 +131,7 @@ mod tests {
         let options = Options {
             config_path: Some(Path::new("mado.toml").to_path_buf()),
             output_format: None,
+            quiet: false,
         };
         let actual = options.to_config().unwrap();
         let mut expected = Config::default();
@@ -136,6 +145,7 @@ mod tests {
         let options = Options {
             config_path: Some(Path::new("mado.toml").to_path_buf()),
             output_format: Some(Format::Mdl),
+            quiet: false,
         };
         let actual = options.to_config().unwrap();
         let mut expected = Config::default();

--- a/src/config/lint.rs
+++ b/src/config/lint.rs
@@ -37,6 +37,7 @@ pub use md046::MD046;
 #[allow(clippy::exhaustive_structs)]
 pub struct Lint {
     pub output_format: Format,
+    pub quiet: bool,
     pub rules: Vec<RuleSet>,
     pub md002: MD002,
     pub md003: MD003,
@@ -102,6 +103,7 @@ impl Default for Lint {
     fn default() -> Self {
         Self {
             output_format: Format::Concise,
+            quiet: false,
             rules: vec![
                 RuleSet::MD001,
                 RuleSet::MD002,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,10 +32,12 @@ fn main() -> Result<ExitCode> {
         Some(Command::Check {
             files,
             output_format,
+            quiet,
         }) => {
             let options = Options {
                 output_format: output_format.clone(),
                 config_path: cli.config,
+                quiet: *quiet,
             };
             let config = options.to_config()?;
             let checker = Checker::new(files, config)?;


### PR DESCRIPTION
Add a  flag that silences non-errors when linting is successful.

