### PR TITLE
Add support for use as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+ - id: mado
+   name: mado
+   description: A fast Markdown linter written in Rust.
+   entry: mado check
+   language: rust
+   types: [markdown]


### PR DESCRIPTION
Supports use as a [pre-commit.com](https://pre-commit.com/) hook.

You can test this [interactively](https://pre-commit.com/#developing-hooks-interactively) if desired.