### PR TITLE
docs(readme): add install guide for archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ brew install mado
 nix profile install github:akiomik/mado
 ```
 
+### Arch Linux (Linux)
+
+```bash
+pacman -S mado
+```
+
 ### Scoop (Windows)
 
 ```bash


### PR DESCRIPTION
as i see, mado is maintained and available in the arch linux extra package repository. it will be nice if we add a short info about installing it on arch linux.

you can see it here: https://archlinux.org/packages/extra/x86_64/mado/

you can also see the maintainer there. also, i guess you know the maintainers
orhun is the creator of ratatui https://github.com/ratatui/ratatui and david https://github.com/dvzrv is an arch linux developer and maintainer of arch packages.
