### PR TITLE
fix: normalize leading "./" before matching --exclude patterns

### DIFF
--- a/src/config/lint.rs
+++ b/src/config/lint.rs
@@ -68,7 +68,10 @@ impl Lint {
     pub fn exclude_set(&self) -> Result<GlobSet> {
         let mut builder = GlobSetBuilder::new();
         for glob in &self.exclude {
-            builder.add(glob.clone());
+            // Strip a leading "./" so that e.g. "file.md" and "./file.md" are
+            // treated as the same pattern (see issue #168).
+            let pattern = glob.glob().trim_start_matches("./");
+            builder.add(Glob::new(pattern).into_diagnostic()?);
         }
         builder.build().into_diagnostic()
     }
@@ -392,6 +395,21 @@ mod tests {
         let set = config.exclude_set()?;
 
         assert_eq!(set.matches("foo/bar/test.md"), vec![0, 2]);
+        Ok(())
+    }
+
+    #[test]
+    fn exclude_set_strips_leading_current_dir() -> Result<()> {
+        let config = Lint {
+            exclude: vec![Glob::new("./test.md").into_diagnostic()?],
+            ..Lint::default()
+        };
+
+        let set = config.exclude_set()?;
+
+        // The "./" prefix is stripped when building the set, so it matches
+        // the same (already-normalized) candidates as "test.md" would.
+        assert_eq!(set.matches("test.md"), vec![0]);
         Ok(())
     }
 

--- a/src/config/lint.rs
+++ b/src/config/lint.rs
@@ -69,7 +69,10 @@ impl Lint {
         let mut builder = GlobSetBuilder::new();
         for glob in &self.exclude {
             // Strip a leading "./" so that e.g. "file.md" and "./file.md" are
-            // treated as the same pattern (see issue #168).
+            // treated as the same pattern (see issue #168). Keep this in sync
+            // with the walked-path normalization in
+            // MarkdownLintVisitor::visit_inner (src/service/visitor.rs) or the
+            // two sides stop agreeing on what a match is.
             let pattern = glob.glob().trim_start_matches("./");
             builder.add(Glob::new(pattern).into_diagnostic()?);
         }

--- a/src/service/visitor.rs
+++ b/src/service/visitor.rs
@@ -1,4 +1,5 @@
 use core::result::Result;
+use std::path::{Component, PathBuf};
 use std::sync::mpsc::SyncSender;
 
 use comrak::Arena;
@@ -29,15 +30,22 @@ impl MarkdownLintVisitor {
     fn visit_inner(&self, either_entry: Result<DirEntry, Error>) -> miette::Result<()> {
         let entry = either_entry.into_diagnostic()?;
         let path = entry.path();
-        if path.is_file()
-            && path.extension() == Some("md".as_ref())
-            && !self.exclusion.is_match(path)
-        {
-            let arena = Arena::new();
-            let doc = Document::open(&arena, path)?;
-            let violations = self.linter.check(&doc)?;
-            if !violations.is_empty() {
-                self.tx.send(violations).into_diagnostic()?;
+        if path.is_file() && path.extension() == Some("md".as_ref()) {
+            // Strip a leading "./" so that exclude patterns match regardless of
+            // whether the walked path carries one (depends on how the target
+            // argument was spelled on the command line, see issue #168).
+            let normalized_path: PathBuf = path
+                .components()
+                .skip_while(|component| matches!(component, Component::CurDir))
+                .collect();
+
+            if !self.exclusion.is_match(&normalized_path) {
+                let arena = Arena::new();
+                let doc = Document::open(&arena, path)?;
+                let violations = self.linter.check(&doc)?;
+                if !violations.is_empty() {
+                    self.tx.send(violations).into_diagnostic()?;
+                }
             }
         }
 

--- a/src/service/visitor.rs
+++ b/src/service/visitor.rs
@@ -33,7 +33,10 @@ impl MarkdownLintVisitor {
         if path.is_file() && path.extension() == Some("md".as_ref()) {
             // Strip a leading "./" so that exclude patterns match regardless of
             // whether the walked path carries one (depends on how the target
-            // argument was spelled on the command line, see issue #168).
+            // argument was spelled on the command line, see issue #168). Keep
+            // this in sync with the pattern normalization in
+            // Lint::exclude_set (src/config/lint.rs) or the two sides stop
+            // agreeing on what a match is.
             let normalized_path: PathBuf = path
                 .components()
                 .skip_while(|component| matches!(component, Component::CurDir))

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -131,3 +131,31 @@ fn check_exclusion() -> Result<()> {
         Ok(())
     })
 }
+
+#[test]
+fn check_exclusion_default_target_without_dot_slash_prefix() -> Result<()> {
+    with_tmp_file("test.md", "#Hello.", |path| {
+        let dir = path.parent().wrap_err("failed to get parent dir")?;
+        let mut cmd = Command::new(cargo_bin!("mado"));
+        let assert = cmd
+            .current_dir(dir)
+            .args(["check", "--exclude", "test.md"])
+            .assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_exclusion_default_target_with_dot_slash_prefix() -> Result<()> {
+    with_tmp_file("test.md", "#Hello.", |path| {
+        let dir = path.parent().wrap_err("failed to get parent dir")?;
+        let mut cmd = Command::new(cargo_bin!("mado"));
+        let assert = cmd
+            .current_dir(dir)
+            .args(["check", "--exclude", "./test.md"])
+            .assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -132,6 +132,20 @@ fn check_exclusion() -> Result<()> {
     })
 }
 
+// The next three tests each pin down a different half of the fix for #168.
+// `--exclude` patterns and walked file paths are only guaranteed to match
+// when both `Lint::exclude_set` (src/config/lint.rs) and
+// `MarkdownLintVisitor::visit_inner` (src/service/visitor.rs) strip a
+// leading "./" the same way. Dropping the normalization on just one side
+// makes at least one of these fail:
+//   - default target (walked path carries "./") + pattern without "./"
+//     needs visit_inner to normalize the walked path.
+//   - explicit target (walked path has no "./") + pattern with "./"
+//     needs exclude_set to normalize the pattern.
+//   - default target + pattern with "./"
+//     needs both sides to agree, since walked path and pattern both carry
+//     "./" and must be stripped the same way to still match afterwards.
+
 #[test]
 fn check_exclusion_default_target_without_dot_slash_prefix() -> Result<()> {
     with_tmp_file("test.md", "#Hello.", |path| {
@@ -140,6 +154,20 @@ fn check_exclusion_default_target_without_dot_slash_prefix() -> Result<()> {
         let assert = cmd
             .current_dir(dir)
             .args(["check", "--exclude", "test.md"])
+            .assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_exclusion_explicit_target_with_dot_slash_prefix() -> Result<()> {
+    with_tmp_file("test.md", "#Hello.", |path| {
+        let dir = path.parent().wrap_err("failed to get parent dir")?;
+        let mut cmd = Command::new(cargo_bin!("mado"));
+        let assert = cmd
+            .current_dir(dir)
+            .args(["check", "test.md", "--exclude", "./test.md"])
             .assert();
         assert.success().stdout("All checks passed!\n");
         Ok(())


### PR DESCRIPTION
## Summary

- `mado check --exclude file.md` and `mado check --exclude ./file.md` matched inconsistently. Non-wildcard globs require an exact string match, but the walked file path's `./` prefix depends on how the check target argument was spelled on the command line (default target is `.`, so walked entries come back as `./file.md`).
- Strip a leading `./` from both the configured exclude patterns (`Lint::exclude_set`) and the candidate file paths (`MarkdownLintVisitor::visit_inner`) before matching, so `file.md` and `./file.md` are treated as equivalent regardless of target spelling.

Fixes #168

## Test plan

- [x] `cargo test --all-features --workspace` passes
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes
- [x] `cargo fmt --all --check` / `taplo lint` pass
- [x] Added a unit test for `Lint::exclude_set` covering a `./`-prefixed pattern
- [x] Added integration tests reproducing the exact issue scenario (default target `.`, `--exclude test.md` vs `--exclude ./test.md`)
- [x] Manually reproduced the bug pre-fix and confirmed it's resolved post-fix