### PR TITLE
test: make color-dependent output assertions deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +941,7 @@ dependencies = [
  "rustc-hash",
  "scraper",
  "serde",
+ "serial_test",
  "tempfile",
  "tikv-jemallocator",
  "toml",
@@ -1138,6 +1174,12 @@ checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -1492,6 +1534,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,6 +1590,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ criterion = "0.8"
 indoc = "2"
 pretty_assertions = "1"
 rand = "0.10"
+serial_test = "3.5"
 tempfile = "3.27"
 
 [profile.release]

--- a/src/output/concise.rs
+++ b/src/output/concise.rs
@@ -58,8 +58,10 @@ impl Ord for Concise<'_> {
 mod tests {
     use std::path::Path;
 
+    use colored::control;
     use comrak::nodes::Sourcepos;
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
 
     use crate::rule::{Metadata, Tag};
 
@@ -73,12 +75,28 @@ mod tests {
     };
 
     #[test]
-    fn display_fmt() {
+    #[serial(colored)]
+    fn display_fmt_colorized() {
+        control::set_override(true);
         let path = Path::new("file.md").to_path_buf();
         let position = Sourcepos::from((0, 1, 3, 5));
         let violation = Violation::new(path, &METADATA, position);
         let actual = Concise::new(&violation).to_string();
         let expected = "\u{1b}[1mfile.md\u{1b}[0m\u{1b}[34m:\u{1b}[0m0\u{1b}[34m:\u{1b}[0m1\u{1b}[34m:\u{1b}[0m \u{1b}[1;31mname\u{1b}[0m description";
         assert_eq!(actual, expected);
+        control::unset_override();
+    }
+
+    #[test]
+    #[serial(colored)]
+    fn display_fmt_plain() {
+        control::set_override(false);
+        let path = Path::new("file.md").to_path_buf();
+        let position = Sourcepos::from((0, 1, 3, 5));
+        let violation = Violation::new(path, &METADATA, position);
+        let actual = Concise::new(&violation).to_string();
+        let expected = "file.md:0:1: name description";
+        assert_eq!(actual, expected);
+        control::unset_override();
     }
 }

--- a/src/output/markdownlint.rs
+++ b/src/output/markdownlint.rs
@@ -61,8 +61,10 @@ impl Ord for Markdownlint<'_> {
 mod tests {
     use std::path::Path;
 
+    use colored::control;
     use comrak::nodes::Sourcepos;
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
 
     use crate::rule::{Metadata, Tag};
 
@@ -76,12 +78,28 @@ mod tests {
     };
 
     #[test]
-    fn display_fmt() {
+    #[serial(colored)]
+    fn display_fmt_colorized() {
+        control::set_override(true);
         let path = Path::new("file.md").to_path_buf();
         let position = Sourcepos::from((0, 1, 3, 5));
         let violation = Violation::new(path, &METADATA, position);
         let actual = Markdownlint::new(&violation).to_string();
         let expected = "\u{1b}[31mfile.md:0:1 name/alias description\u{1b}[0m";
         assert_eq!(actual, expected);
+        control::unset_override();
+    }
+
+    #[test]
+    #[serial(colored)]
+    fn display_fmt_plain() {
+        control::set_override(false);
+        let path = Path::new("file.md").to_path_buf();
+        let position = Sourcepos::from((0, 1, 3, 5));
+        let violation = Violation::new(path, &METADATA, position);
+        let actual = Markdownlint::new(&violation).to_string();
+        let expected = "file.md:0:1 name/alias description";
+        assert_eq!(actual, expected);
+        control::unset_override();
     }
 }

--- a/src/output/mdl.rs
+++ b/src/output/mdl.rs
@@ -69,8 +69,10 @@ impl Ord for Mdl<'_> {
 mod tests {
     use std::path::Path;
 
+    use colored::control;
     use comrak::nodes::Sourcepos;
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
 
     use crate::rule::{Metadata, Tag};
 
@@ -84,12 +86,28 @@ mod tests {
     };
 
     #[test]
-    fn display_fmt() {
+    #[serial(colored)]
+    fn display_fmt_colorized() {
+        control::set_override(true);
         let path = Path::new("file.md").to_path_buf();
         let position = Sourcepos::from((0, 1, 3, 5));
         let violation = Violation::new(path, &METADATA, position);
         let actual = Mdl::new(&violation).to_string();
         let expected = "\u{1b}[1mfile.md\u{1b}[0m\u{1b}[34m:\u{1b}[0m0\u{1b}[34m:\u{1b}[0m \u{1b}[1;31mname\u{1b}[0m description";
         assert_eq!(actual, expected);
+        control::unset_override();
+    }
+
+    #[test]
+    #[serial(colored)]
+    fn display_fmt_plain() {
+        control::set_override(false);
+        let path = Path::new("file.md").to_path_buf();
+        let position = Sourcepos::from((0, 1, 3, 5));
+        let violation = Violation::new(path, &METADATA, position);
+        let actual = Mdl::new(&violation).to_string();
+        let expected = "file.md:0: name description";
+        assert_eq!(actual, expected);
+        control::unset_override();
     }
 }

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -61,7 +61,11 @@ fn check_quiet_with_config() -> Result<()> {
 #[test]
 fn check_stdin() {
     let mut cmd = Command::new(cargo_bin!("mado"));
-    let assert = cmd.write_stdin("#Hello.").args(["check"]).assert();
+    let assert = cmd
+        .env("CLICOLOR_FORCE", "1")
+        .write_stdin("#Hello.")
+        .args(["check"])
+        .assert();
     assert.failure().stdout(
         indoc! {"
             \u{1b}[1m(stdin)\u{1b}[0m\u{1b}[34m:\u{1b}[0m1\u{1b}[34m:\u{1b}[0m1\u{1b}[34m:\u{1b}[0m \u{1b}[1;31mMD018\u{1b}[0m No space after hash on atx style header
@@ -71,6 +75,23 @@ fn check_stdin() {
             Found 3 errors.
         "}
     );
+}
+
+#[test]
+fn check_stdin_no_color() {
+    let mut cmd = Command::new(cargo_bin!("mado"));
+    let assert = cmd
+        .env("NO_COLOR", "1")
+        .write_stdin("#Hello.")
+        .args(["check"])
+        .assert();
+    assert.failure().stdout(indoc! {"
+        (stdin):1:1: MD018 No space after hash on atx style header
+        (stdin):1:1: MD041 First line in file should be a top level header
+        (stdin):1:1: MD047 File should end with a single newline character
+
+        Found 3 errors.
+    "});
 }
 
 #[test]
@@ -85,7 +106,11 @@ fn check_empty_stdin_with_file() -> Result<()> {
     with_tmp_file("test.md", "#Hello.", |path| {
         let mut cmd = Command::new(cargo_bin!("mado"));
         let path_str = path.to_str().wrap_err("failed to convert string")?;
-        let assert = cmd.write_stdin("").args(["check", path_str]).assert();
+        let assert = cmd
+            .env("CLICOLOR_FORCE", "1")
+            .write_stdin("")
+            .args(["check", path_str])
+            .assert();
         assert.failure().stdout(
             formatdoc! {"
                 \u{1b}[1m{path_str}\u{1b}[0m\u{1b}[34m:\u{1b}[0m1\u{1b}[34m:\u{1b}[0m1\u{1b}[34m:\u{1b}[0m \u{1b}[1;31mMD018\u{1b}[0m No space after hash on atx style header
@@ -100,11 +125,33 @@ fn check_empty_stdin_with_file() -> Result<()> {
 }
 
 #[test]
+fn check_empty_stdin_with_file_no_color() -> Result<()> {
+    with_tmp_file("test.md", "#Hello.", |path| {
+        let mut cmd = Command::new(cargo_bin!("mado"));
+        let path_str = path.to_str().wrap_err("failed to convert string")?;
+        let assert = cmd
+            .env("NO_COLOR", "1")
+            .write_stdin("")
+            .args(["check", path_str])
+            .assert();
+        assert.failure().stdout(formatdoc! {"
+            {path_str}:1:1: MD018 No space after hash on atx style header
+            {path_str}:1:1: MD041 First line in file should be a top level header
+            {path_str}:1:1: MD047 File should end with a single newline character
+
+            Found 3 errors.
+        "});
+        Ok(())
+    })
+}
+
+#[test]
 fn check_stdin_with_file() -> Result<()> {
     with_tmp_file("test.md", "#Hello.", |path| {
         let mut cmd = Command::new(cargo_bin!("mado"));
         let path_str = path.to_str().wrap_err("failed to convert string")?;
         let assert = cmd
+            .env("CLICOLOR_FORCE", "1")
             .write_stdin("#Hello.")
             .args(["check", path_str])
             .assert();
@@ -117,6 +164,27 @@ fn check_stdin_with_file() -> Result<()> {
                 Found 3 errors.
             "}
         );
+        Ok(())
+    })
+}
+
+#[test]
+fn check_stdin_with_file_no_color() -> Result<()> {
+    with_tmp_file("test.md", "#Hello.", |path| {
+        let mut cmd = Command::new(cargo_bin!("mado"));
+        let path_str = path.to_str().wrap_err("failed to convert string")?;
+        let assert = cmd
+            .env("NO_COLOR", "1")
+            .write_stdin("#Hello.")
+            .args(["check", path_str])
+            .assert();
+        assert.failure().stdout(indoc! {"
+            (stdin):1:1: MD018 No space after hash on atx style header
+            (stdin):1:1: MD041 First line in file should be a top level header
+            (stdin):1:1: MD047 File should end with a single newline character
+
+            Found 3 errors.
+        "});
         Ok(())
     })
 }

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -81,6 +81,7 @@ fn check_stdin() {
 fn check_stdin_no_color() {
     let mut cmd = Command::new(cargo_bin!("mado"));
     let assert = cmd
+        .env_remove("CLICOLOR_FORCE")
         .env("NO_COLOR", "1")
         .write_stdin("#Hello.")
         .args(["check"])
@@ -130,6 +131,7 @@ fn check_empty_stdin_with_file_no_color() -> Result<()> {
         let mut cmd = Command::new(cargo_bin!("mado"));
         let path_str = path.to_str().wrap_err("failed to convert string")?;
         let assert = cmd
+            .env_remove("CLICOLOR_FORCE")
             .env("NO_COLOR", "1")
             .write_stdin("")
             .args(["check", path_str])
@@ -174,6 +176,7 @@ fn check_stdin_with_file_no_color() -> Result<()> {
         let mut cmd = Command::new(cargo_bin!("mado"));
         let path_str = path.to_str().wrap_err("failed to convert string")?;
         let assert = cmd
+            .env_remove("CLICOLOR_FORCE")
             .env("NO_COLOR", "1")
             .write_stdin("#Hello.")
             .args(["check", path_str])

--- a/tests/command_generate_shell_completion.rs
+++ b/tests/command_generate_shell_completion.rs
@@ -30,6 +30,7 @@ fn generate_shell_completion_invalid() {
 fn generate_shell_completion_invalid_no_color() {
     let mut cmd = Command::new(cargo_bin!("mado"));
     let assert = cmd
+        .env_remove("CLICOLOR_FORCE")
         .env("NO_COLOR", "1")
         .args(["generate-shell-completion", "foo"])
         .assert();

--- a/tests/command_generate_shell_completion.rs
+++ b/tests/command_generate_shell_completion.rs
@@ -12,13 +12,31 @@ fn generate_shell_completion_zsh() {
 #[test]
 fn generate_shell_completion_invalid() {
     let mut cmd = Command::new(cargo_bin!("mado"));
-    let assert = cmd.args(["generate-shell-completion", "foo"]).assert();
+    let assert = cmd
+        .env("CLICOLOR_FORCE", "1")
+        .args(["generate-shell-completion", "foo"])
+        .assert();
     assert
         .failure()
         .stderr(indoc! {"
             \u{1b}[1m\u{1b}[31merror:\u{1b}[0m invalid value \'\u{1b}[33mfoo\u{1b}[0m\' for \'\u{1b}[1m<SHELL>\u{1b}[0m\'
               [possible values: \u{1b}[32mbash\u{1b}[0m, \u{1b}[32melvish\u{1b}[0m, \u{1b}[32mfish\u{1b}[0m, \u{1b}[32mpowershell\u{1b}[0m, \u{1b}[32mzsh\u{1b}[0m]
-            
+
             For more information, try \'\u{1b}[1m--help\u{1b}[0m\'.
         "});
+}
+
+#[test]
+fn generate_shell_completion_invalid_no_color() {
+    let mut cmd = Command::new(cargo_bin!("mado"));
+    let assert = cmd
+        .env("NO_COLOR", "1")
+        .args(["generate-shell-completion", "foo"])
+        .assert();
+    assert.failure().stderr(indoc! {"
+        error: invalid value 'foo' for '<SHELL>'
+          [possible values: bash, elvish, fish, powershell, zsh]
+
+        For more information, try '--help'.
+    "});
 }

--- a/tests/command_invalid.rs
+++ b/tests/command_invalid.rs
@@ -25,7 +25,11 @@ fn unknown_command() {
 #[test]
 fn unknown_command_no_color() {
     let mut cmd = Command::new(cargo_bin!("mado"));
-    let assert = cmd.env("NO_COLOR", "1").args(["foobar"]).assert();
+    let assert = cmd
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
+        .args(["foobar"])
+        .assert();
     assert.failure().stderr(formatdoc! {"
         error: unrecognized subcommand 'foobar'
 

--- a/tests/command_invalid.rs
+++ b/tests/command_invalid.rs
@@ -12,12 +12,25 @@ fn no_command() {
 #[test]
 fn unknown_command() {
     let mut cmd = Command::new(cargo_bin!("mado"));
-    let assert = cmd.args(["foobar"]).assert();
+    let assert = cmd.env("CLICOLOR_FORCE", "1").args(["foobar"]).assert();
     assert.failure().stderr(formatdoc! {"
         \u{1b}[1m\u{1b}[31merror:\u{1b}[0m unrecognized subcommand \'\u{1b}[33mfoobar\u{1b}[0m\'
 
         \u{1b}[1m\u{1b}[4mUsage:\u{1b}[0m \u{1b}[1mmado\u{1b}[0m [OPTIONS] <COMMAND>
 
         For more information, try \'\u{1b}[1m--help\u{1b}[0m\'.
+    "});
+}
+
+#[test]
+fn unknown_command_no_color() {
+    let mut cmd = Command::new(cargo_bin!("mado"));
+    let assert = cmd.env("NO_COLOR", "1").args(["foobar"]).assert();
+    assert.failure().stderr(formatdoc! {"
+        error: unrecognized subcommand 'foobar'
+
+        Usage: mado [OPTIONS] <COMMAND>
+
+        For more information, try '--help'.
     "});
 }


### PR DESCRIPTION
## Summary

- `colored` and clap's `anstream` both auto-detect whether stdout/stderr is a tty and skip ANSI codes when it isn't (piped output, CI, non-interactive packaging builds like an Arch `makepkg` sandbox). The affected tests hardcoded colorized expected output, so they failed in any environment where the process wasn't attached to a real terminal.
- Instead of relying on ambient tty detection, each test now forces a specific mode and asserts both the colorized and plain forms:
  - unit tests (`output::{concise,mdl,markdownlint}::tests`) toggle `colored::control::set_override(...)`, guarded with `#[serial(colored)]` (via `serial_test`) since the override is a process-global flag and these tests can otherwise run concurrently on different threads
  - CLI integration tests (`tests/command_check.rs`, `tests/command_generate_shell_completion.rs`, `tests/command_invalid.rs`) set `CLICOLOR_FORCE=1` / `NO_COLOR=1` on the spawned `mado` subprocess's environment, which both `colored` and `anstream` honor

Fixes #140, and the color-related test failures reported in #141.

Note: #141 also reports `.gitignore` not being honored when there's no `.git` directory (e.g. an extracted source tarball), which is a separate root cause in the file walker and is intentionally left out of this PR.

## Test plan

- [x] `cargo test --all-features` passes locally
- [x] `cargo clippy --all-targets --all-features` is clean
- [x] Repeated `cargo test --lib output:: -- --test-threads=8` runs (5x) to confirm no flakiness from the shared `colored` override state across the new unit tests