### PR TITLE
build: switch Cargo.toml packaging from exclude to include allowlist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,13 @@ authors = ["Akiomi Kamakura <akiomik@gmail.com>"]
 keywords = ["markdown", "lint"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "README.md"
-exclude = [
-  "/action",
-  "/scripts",
-  "/tmp",
-  ".node-version",
-  ".ruby-version",
-  "action.yml",
-  "flamegraph.svg",
+include = [
+  "/src",
+  "/benches",
+  "/tests",
+  "/LICENSE",
+  "/README.md",
+  "/CHANGELOG.md",
 ]
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Replace the `exclude` list in `Cargo.toml` with an `include` allowlist so only files the crate actually needs are published, instead of relying on remembering to add every new non-shippable file to `exclude`.
- The allowlist covers `src` (library/binary), `benches` (required by the declared `[[bench]]` targets), `tests` (integration tests), and `LICENSE`/`README.md`/`CHANGELOG.md` (docs). `Cargo.toml`/`Cargo.lock` are always included by Cargo regardless of this setting.
- This drops previously-shipped-but-unneeded files from the package, e.g. `.github/`, `flake.nix`/`flake.lock`, `justfile`, `rust-toolchain.toml`, `HomebrewFormula/`, `pkg/` (other package managers' manifests), `mado.toml`.

## Test plan
- [x] `cargo package --list` shows only the intended files
- [x] `cargo package` succeeds, including the verification build of the `src`/`benches`/`tests` targets