### PR TITLE
fix: pin cross-compile toolchain to 1.91.1 in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,7 @@ jobs:
       with:
         command: build
         target: ${{ matrix.platform.target }}
+        toolchain: "1.91.1"
         args: "--locked --release"
         strip: true
     - name: Publish artifacts and release


### PR DESCRIPTION
## Summary

- The `Release - macOS-x86_64` job in the CD workflow failed with `error[E0463]: can't find crate for `core`` / "the `x86_64-apple-darwin` target may not be installed".
- `houseabsolute/actions-rust-cross` adds the requested target to the `stable` toolchain (its default), but this repo pins `rust-toolchain.toml` to `1.91.1`. Since `rust-toolchain.toml` overrides the toolchain for any `cargo`/`rustc` invocation in this directory, `cargo build` actually used `1.91.1`, which never had `x86_64-apple-darwin` added.
- This previously went unnoticed on Intel-based `macOS-latest` runners, where `x86_64-apple-darwin` was the host's native target (no target install needed). Since GitHub moved `macOS-latest` to Apple Silicon (arm64), it became a real cross-compile target and exposed the mismatch.
- Fix: pass `toolchain: "1.91.1"` to `houseabsolute/actions-rust-cross`, matching the convention already used in `ci.yml` (`dtolnay/rust-toolchain@1.91.1`), so the target is added to the toolchain that's actually used to build.

## Test plan

- [ ] CD workflow run (triggered by a version tag) builds `Release - macOS-x86_64` successfully