### PR TITLE
docs: add CD toolchain fix to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * fix: add missing header to winget schema by @akiomik in #242
 * fix: normalize leading "./" before matching --exclude patterns by @akiomik in
   #344
+* fix: pin cross-compile toolchain to 1.91.1 in CD by @akiomik in #349
 
 ### Other Changes
 


### PR DESCRIPTION
## Summary

- #349 merged before the v0.3.1 CHANGELOG entry could include it. Add `fix: pin cross-compile toolchain to 1.91.1 in CD by @akiomik in #349` to the `Bug Fixes` section for 0.3.1, alongside the other packaging/infra `fix:` entries (#242, #344).

## Test plan

- [x] `cargo run -- check CHANGELOG.md` passes (no MD013 line-length violations)