### PR TITLE
fix: pin houseabsolute/actions-rust-release to v0.0.8

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,7 @@ jobs:
         args: "--locked --release"
         strip: true
     - name: Publish artifacts and release
-      uses: houseabsolute/actions-rust-release@v1
+      uses: houseabsolute/actions-rust-release@v0.0.8
       with:
         executable-name: mado
         target: ${{ matrix.platform.target }}


### PR DESCRIPTION
## Summary

- The v0.3.1 release built successfully on all platforms, but no assets were attached to the GitHub Release.
- Root cause: `cd.yml` uses `houseabsolute/actions-rust-release@v1`. `v1` is a stale branch (not a semver tag) pinned to a commit with an upstream bug: `set-should-release.py` writes the `GITHUB_OUTPUT` key `should_release`, but the composite action's later steps check `steps.determine-if-releasing.outputs.match` instead. Since that key is never set, the `if:` condition guarding the "Publish GitHub release" step is always false, so it's silently skipped on every run regardless of whether the tag actually matches.
- `v0.0.8` (the latest real tagged release, and identical to the `v0` branch HEAD) already fixes this upstream with a simpler `if:` condition, no `should_release`/`match` mismatch.
- Fix: pin to the explicit tag `houseabsolute/actions-rust-release@v0.0.8` instead of the floating `v1` branch, so dependabot can track future proper releases from a known-good baseline.

## Test plan

- [ ] Re-tagging `v0.3.1` after this merges triggers a CD run where the GitHub Release actually gets binaries/checksums attached
