### PR TITLE
chore: bump packages to v0.3.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,17 +25,17 @@
         packages = {
           mado = pkgs.stdenv.mkDerivation rec {
             pname = "mado";
-            version = "0.3.0";
+            version = "0.3.1";
 
             src = pkgs.fetchzip {
               stripRoot = false;
               url = "https://github.com/akiomik/mado/releases/download/v${version}/mado-${os}-${arch}.tar.gz";
               sha256 =
                 {
-                  x86_64-linux = "10x000gza9hac6qs4pfihfbsvk6fwbnjhy7vwh6zdmwwbvf9ikis";
-                  aarch64-linux = "0qr12gib7j7h2dpxfbz02p2hfchdwkyb9xa5qlq9yyr4d3j4lvr8";
-                  x86_64-darwin = "0q33bdz2c2mjl1dn1rdy859kkkamd7m6mabsswjz0rb5cy1cyyd4";
-                  aarch64-darwin = "1cv6vqk2aq2rybhbl0ybpnrq3r2cxf03p4cd1572s8w3i4mq6rql";
+                  x86_64-linux = "1nwmvgl3dy89n543mip9y9rdrw70rrakz196706lnvphy87q2r79";
+                  aarch64-linux = "0phxxgfz7ddvlxjry2216k2sjfsbv7ma9v6w9h57f1aa8gxk7q15";
+                  x86_64-darwin = "0f0mfv152xfq4cg41bf9fnzpjgbxbn1m0aflm7kzph4yh38msl3c";
+                  aarch64-darwin = "0dfdg2d8znnvzwvf1qrkk0iv9jndc8ksqyi81vdzkzlifqjy2p0i";
                 }
                 .${system} or (throw "unsupported system ${system}");
             };

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
-prev_version := "0.2.2"
-version := "0.3.0"
+prev_version := "0.3.0"
+version := "0.3.1"
 tempdir := `mktemp -d`
 
 default: fmt test lint

--- a/pkg/homebrew/mado.rb
+++ b/pkg/homebrew/mado.rb
@@ -3,30 +3,30 @@
 class Mado < Formula
   desc "Fast Markdown linter written in Rust"
   homepage "https://github.com/akiomik/mado"
-  version "0.3.0"
+  version "0.3.1"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
       url "https://github.com/akiomik/mado/releases/download/v#{version}/mado-macOS-arm64.tar.gz"
-      sha256 "4000955c41799c839dbf1b4c3011ff1688bd31d0af88be282eec622a07ad9743"
+      sha256 "8043af62e1d2f726b34cb34c9f66fe74f9bc1750666351872318fb680f20cde6"
     end
 
     on_intel do
       url "https://github.com/akiomik/mado/releases/download/v#{version}/mado-macOS-x86_64.tar.gz"
-      sha256 "b8a3fb5cf3e84747c12a848fb87ce08c1c09dc5a957c1f74733bea6cb7f9d560"
+      sha256 "c7d0cc6665ca9d6535219a790222913a6d92d7a170aa4e7665cec4c2a1427646"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/akiomik/mado/releases/download/v#{version}/mado-Linux-gnu-arm64.tar.gz"
-      sha256 "ffcdd4845329a69bc729c0242abb6163f23495c0b04dbbaf608cbed43a2f4976"
+      sha256 "cb7df9feff1c117eeedc7b33267d853980192b7cffceb723794f74d54cde1522"
     end
 
     on_intel do
       url "https://github.com/akiomik/mado/releases/download/v#{version}/mado-Linux-gnu-x86_64.tar.gz"
-      sha256 "aad845cd23c8c0417cdf87b8376b75e131c38e1cb890124790567735306de6d7"
+      sha256 "403f72360876d42301b79f879344ba27bf320ca885069db2c697cd21acaf1f4d"
     end
   end
 

--- a/pkg/scoop/mado.json
+++ b/pkg/scoop/mado.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A fast Markdown linter written in Rust",
   "homepage": "https://github.com/akiomik/mado",
   "license": "Apache-2.0",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/akiomik/mado/releases/download/v0.3.0/mado-Windows-msvc-x86_64.zip",
-      "hash": "f79025f931642ea942182aa2717a91af911df122555cd0501c24a1a9bf40e08a"
+      "url": "https://github.com/akiomik/mado/releases/download/v0.3.1/mado-Windows-msvc-x86_64.zip",
+      "hash": "be65d19751bfe6702307f11c08ea6ade92da1d9a034bde85aefc979e2f0a700e"
     }
   },
   "bin": "mado.exe",

--- a/pkg/winget/mado.yml
+++ b/pkg/winget/mado.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.9.0.schema.json
 
 PackageIdentifier: AkiomiKamakura.Mado
-PackageVersion: 0.3.0
+PackageVersion: 0.3.1
 PackageLocale: en-US
 PackageName: Mado
 ShortDescription: A fast Markdown linter written in Rust.
@@ -19,7 +19,7 @@ UpgradeBehavior: install
 ReleaseDate: 2025-01-17
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/akiomik/mado/releases/download/v0.3.0/mado-Windows-msvc-x86_64.zip
-    InstallerSha256: f79025f931642ea942182aa2717a91af911df122555cd0501c24a1a9bf40e08a
+    InstallerUrl: https://github.com/akiomik/mado/releases/download/v0.3.1/mado-Windows-msvc-x86_64.zip
+    InstallerSha256: be65d19751bfe6702307f11c08ea6ade92da1d9a034bde85aefc979e2f0a700e
 ManifestType: singleton
 ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

- Update Homebrew, Scoop, WinGet, and Nix flake package definitions to v0.3.1, using `just update-homebrew`, `just update-scoop`, `just update-winget`, and `just update-flake` against the now-published v0.3.1 release assets.
- Verified the Scoop/WinGet sha256 matches the published `mado-Windows-msvc-x86_64.zip.sha256` asset.

## Test plan

- [x] `taplo format --check` / `taplo lint` pass
- [x] `nix fmt flake.nix` makes no further changes
- [x] `CI Package` workflow (Homebrew/Scoop/WinGet/Nix install tests) passes