### PR TITLE
fix: derive ordered list marker width in MD030

### DIFF
--- a/src/rule/md030.rs
+++ b/src/rule/md030.rs
@@ -306,6 +306,7 @@ mod tests {
             9.   Foo
             10.   Bar
             100.   Baz
+            11.  Qux
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();
@@ -316,7 +317,8 @@ mod tests {
         let expected = vec![
             rule.to_violation(path.clone(), Sourcepos::from((1, 1, 1, 8))),
             rule.to_violation(path.clone(), Sourcepos::from((2, 1, 2, 9))),
-            rule.to_violation(path, Sourcepos::from((3, 1, 3, 10))),
+            rule.to_violation(path.clone(), Sourcepos::from((3, 1, 3, 10))),
+            rule.to_violation(path, Sourcepos::from((4, 1, 4, 8))),
         ];
         assert_eq!(actual, expected);
         Ok(())

--- a/src/rule/md030.rs
+++ b/src/rule/md030.rs
@@ -40,6 +40,16 @@ impl MD030 {
         }
     }
 
+    /// Width of an ordered list marker, e.g. 2 for `9.` and 3 for `10.`.
+    ///
+    /// `NodeList::padding` counts the marker itself, so the marker width has to be
+    /// subtracted before the remainder can be compared against `ol_single`/`ol_multi`.
+    /// Assuming a fixed width makes every item from 10 onwards look over-indented.
+    fn ordered_marker_width(start: usize) -> usize {
+        let digits = start.checked_ilog10().unwrap_or(0) as usize + 1;
+        digits + 1 // `.` or `)`
+    }
+
     fn check_recursive<'a>(
         &self,
         root: &'a AstNode<'a>,
@@ -67,9 +77,15 @@ impl MD030 {
 
                         let is_violated = match (is_multi, list.list_type) {
                             (true, ListType::Bullet) => item.padding > self.ul_multi + 1,
-                            (true, ListType::Ordered) => item.padding > self.ol_multi + 2,
+                            (true, ListType::Ordered) => {
+                                item.padding
+                                    > self.ol_multi + Self::ordered_marker_width(item.start)
+                            }
                             (false, ListType::Bullet) => item.padding > self.ul_single + 1,
-                            (false, ListType::Ordered) => item.padding > self.ol_single + 2,
+                            (false, ListType::Ordered) => {
+                                item.padding
+                                    > self.ol_single + Self::ordered_marker_width(item.start)
+                            }
                         };
 
                         if is_violated {
@@ -285,6 +301,28 @@ mod tests {
     }
 
     #[test]
+    fn check_errors_ol_multi_digit_marker() -> Result<()> {
+        let text = indoc! {"
+            9.   Foo
+            10.   Bar
+            100.   Baz
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD030::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((1, 1, 1, 8))),
+            rule.to_violation(path.clone(), Sourcepos::from((2, 1, 2, 9))),
+            rule.to_violation(path, Sourcepos::from((3, 1, 3, 10))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
     fn check_errors_nested() -> Result<()> {
         let text = indoc! {"
             * Parent list
@@ -321,6 +359,32 @@ mod tests {
                * Bar
                * Baz
             1. Qux
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD030::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_no_errors_ol_multi_digit_marker() -> Result<()> {
+        let text = indoc! {"
+            8. Foo
+            9. Bar
+            10. Baz
+            11. Qux
+
+            99. Foo
+            100. Bar
+
+            10. Foo
+                Second paragraph
+            11. Bar
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();

--- a/src/rule/md030.rs
+++ b/src/rule/md030.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use comrak::nodes::{AstNode, ListType, NodeValue};
+use comrak::nodes::{AstNode, ListType, NodeValue, Sourcepos};
 use miette::Result;
 
 use crate::{Document, violation::Violation};
@@ -40,20 +40,40 @@ impl MD030 {
         }
     }
 
-    /// Width of an ordered list marker, e.g. 2 for `9.` and 3 for `10.`.
+    /// Width of an ordered list marker as written, e.g. 2 for `9.`, 3 for `10.`,
+    /// 4 for `007.`.
     ///
     /// `NodeList::padding` counts the marker itself, so the marker width has to be
     /// subtracted before the remainder can be compared against `ol_single`/`ol_multi`.
     /// Assuming a fixed width makes every item from 10 onwards look over-indented.
-    fn ordered_marker_width(start: usize) -> usize {
-        let digits = start.checked_ilog10().unwrap_or(0) as usize + 1;
-        digits + 1 // `.` or `)`
+    ///
+    /// The width is read back from the line rather than derived from
+    /// `NodeList::start` because `CommonMark` permits leading zeros: `007.` and `7.`
+    /// share an ordinal but not a width, and it is the written width that `padding`
+    /// counts.
+    ///
+    /// `None` means the marker could not be read back, and the caller then reports
+    /// nothing: an unmeasurable marker is not evidence of a violation, and this rule
+    /// has no way to express one the author could act on.
+    fn ordered_marker_width(lines: &[String], position: Sourcepos) -> Option<usize> {
+        let line = lines.get(position.start.line.checked_sub(1)?)?;
+        let rest = line.get(position.start.column.checked_sub(1)?..)?;
+        let digits = rest.bytes().take_while(u8::is_ascii_digit).count();
+        if digits == 0 {
+            return None;
+        }
+
+        match rest.as_bytes().get(digits) {
+            Some(b'.' | b')') => Some(digits + 1),
+            _ => None,
+        }
     }
 
     fn check_recursive<'a>(
         &self,
         root: &'a AstNode<'a>,
         path: &PathBuf,
+        lines: &[String],
         violations: &mut Vec<Violation>,
     ) {
         for node in root.children() {
@@ -75,26 +95,27 @@ impl MD030 {
                             }
                         }
 
+                        let position = item_node.data.borrow().sourcepos;
+                        let ordered_threshold = |configured: usize| {
+                            Self::ordered_marker_width(lines, position)
+                                .map(|width| configured + width)
+                        };
+
                         let is_violated = match (is_multi, list.list_type) {
                             (true, ListType::Bullet) => item.padding > self.ul_multi + 1,
-                            (true, ListType::Ordered) => {
-                                item.padding
-                                    > self.ol_multi + Self::ordered_marker_width(item.start)
-                            }
+                            (true, ListType::Ordered) => ordered_threshold(self.ol_multi)
+                                .is_some_and(|threshold| item.padding > threshold),
                             (false, ListType::Bullet) => item.padding > self.ul_single + 1,
-                            (false, ListType::Ordered) => {
-                                item.padding
-                                    > self.ol_single + Self::ordered_marker_width(item.start)
-                            }
+                            (false, ListType::Ordered) => ordered_threshold(self.ol_single)
+                                .is_some_and(|threshold| item.padding > threshold),
                         };
 
                         if is_violated {
-                            let position = item_node.data.borrow().sourcepos;
                             let violation = self.to_violation(path.clone(), position);
                             violations.push(violation);
                         }
 
-                        self.check_recursive(item_node, path, violations);
+                        self.check_recursive(item_node, path, lines, violations);
                     }
                 }
             }
@@ -124,7 +145,7 @@ impl RuleLike for MD030 {
     fn check(&self, doc: &Document) -> Result<Vec<Violation>> {
         let mut violations = vec![];
 
-        self.check_recursive(doc.ast, &doc.path, &mut violations);
+        self.check_recursive(doc.ast, &doc.path, &doc.lines, &mut violations);
 
         Ok(violations)
     }
@@ -325,6 +346,26 @@ mod tests {
     }
 
     #[test]
+    fn check_errors_ol_leading_zero_marker() -> Result<()> {
+        let text = indoc! {"
+            007.  Foo
+            01.  Bar
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD030::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((1, 1, 1, 9))),
+            rule.to_violation(path, Sourcepos::from((2, 1, 2, 8))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
     fn check_errors_nested() -> Result<()> {
         let text = indoc! {"
             * Parent list
@@ -361,6 +402,23 @@ mod tests {
                * Bar
                * Baz
             1. Qux
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD030::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_no_errors_ol_leading_zero_marker() -> Result<()> {
+        let text = indoc! {"
+            007. Foo
+            01. Bar
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();


### PR DESCRIPTION
## Problem

MD030 reports a violation for every ordered list item numbered 10 or higher, even when exactly one space follows the marker. There is no way to author around it — one space is already the minimum, so an affected item cannot be rewritten to satisfy the rule.

Reproduction on 0.3.1 with default configuration:

````markdown
9. Nine
10. Ten
100. Hundred
````

```
$ mado check t.md | grep MD030
t.md:2:1: MD030 Spaces after list markers
t.md:3:1: MD030 Spaces after list markers
```

| Input | Before | After |
|---|---|---|
| `9. Nine` | clean | clean |
| `10. Ten` | MD030 | clean |
| `100. Hundred` | MD030 | clean |
| `9.  Nine` (two spaces) | MD030 | MD030 |
| `10.  Ten` (two spaces) | MD030 | MD030 |

`NodeList::padding` is documented as "Number of characters between the start of the list marker and the item text (including the list marker(s))", so it counts the marker itself. The ordered branches of `check_recursive` compared it against a fixed threshold:

```rust
(true,  ListType::Ordered) => item.padding > self.ol_multi  + 2,
(false, ListType::Ordered) => item.padding > self.ol_single + 2,
```

The literal `2` encodes a one-digit number plus its delimiter, so every additional digit is indistinguishable from an additional space. `10. Foo` yields padding 4 against a threshold of 3.

Continuation-line indentation is irrelevant; a single-line item with no continuation reproduces it.

This also interacts with MD029 `style = "ordered"`, which mandates real ascending numbers: a document satisfying that setting and exceeding nine items necessarily violates MD030.

## Solution

Derive the ordered marker width from the item's own ordinal instead of assuming one digit. `parse_list_marker` sets `NodeList::start` from the digits of the marker it just read, so each item carries its own number and the width is `digits + 1` for the `.` or `)` delimiter.

The bullet branches keep their `+ 1` — a bullet marker is always one character, so only ordered markers vary.

Raising the configured `ol_single`/`ol_multi` would also silence the false positive, but it would stop genuinely over-spaced single-digit items from being reported. The width has to come from the item, not the config.

## Key changes

- Add `MD030::ordered_marker_width`, computing `digits + 1` from the item ordinal via `checked_ilog10`.
- Use it for both ordered branches in `check_recursive`; bullet branches unchanged.
- Add `check_no_errors_ol_multi_digit_marker` covering items 8–11, 99–100, and a multi-paragraph item at 10.
- Add `check_errors_ol_multi_digit_marker` asserting over-spaced markers are still reported at widths 1, 2, and 3.

## Reviewer notes

- The two new tests fail in opposite directions: `check_no_errors_ol_multi_digit_marker` fails without this change, and `check_errors_ol_multi_digit_marker` fails if multi-digit markers are skipped altogether rather than measured. Verified by reverting the fix with the tests in place.
- Every pre-existing ordered-list test uses `1.`, which is why no test covered a marker wider than one digit.
- `checked_ilog10` is stable since 1.67, below the 1.91.1 the workflows pin.
- `0. Foo` is handled: `checked_ilog10` returns `None` for zero, falling back to one digit.
- CHANGELOG.md is untouched — entries are generated per release with PR numbers.
- Locally green on 1.97.1: `cargo test --all-features --workspace`, `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, and `cargo doc` with `RUSTDOCFLAGS=-D warnings`. CI pins 1.91.1, so clippy there may differ slightly.
