### PR TITLE
fix: set HOMEBREW_TAP_NAME in CI Package to unbreak Test Homebrew

### DIFF
--- a/.github/workflows/ci-pkg.yml
+++ b/.github/workflows/ci-pkg.yml
@@ -13,12 +13,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@fd832223f9f99ebf0244dd20658680e5d4aca049 # 2026.08.03.2
         with:
-            test-bot: true
             stable: true
         env:
+            # NOTE: This repository is not named `homebrew-mado`, so setup-homebrew cannot
+            #       derive the tap variables itself and both must be set explicitly.
             HOMEBREW_TAP_REPOSITORY: /opt/homebrew/Library/Taps/akiomik/mado
+            HOMEBREW_TAP_NAME: akiomik/mado
       - name: Rename akiomik/mado to akiomik/homebrew-mado
         run: mv /opt/homebrew/Library/Taps/akiomik/mado /opt/homebrew/Library/Taps/akiomik/homebrew-mado
       - name: Checkout repository for updating HEAD


### PR DESCRIPTION
## Problem

`CI Package / Test Homebrew` has been failing on **every** branch since 2026-08-03 (last success: 2026-07-27). No change on our side caused it — it is a regression from an upstream `Homebrew/actions` update, reaching us because we referenced `@master`.

```
setup-homebrew/main.sh: line 211: HOMEBREW_TAP_NAME: unbound variable
##[error]The process '/bin/bash' failed with exit code 1
```

## Cause

`setup-homebrew/main.sh` runs under `set -euo pipefail` and derives its tap variables only for repositories named `<owner>/homebrew-<name>`:

```bash
# line 94-97
if [[ "$GITHUB_REPOSITORY" =~ ^([^/]+)/homebrew-(.+)$ ]]; then
    HOMEBREW_TAP_NAME=...
    HOMEBREW_TAP_REPOSITORY=...
fi
```

This repository is `akiomik/mado`, so the regex does not match and neither variable is derived — which is why we pass `HOMEBREW_TAP_REPOSITORY` explicitly via `env`. Upstream commit [`850067ef`](https://github.com/Homebrew/actions/commit/850067ef) ("setup-homebrew: output tap name", 2026-07-31) then added an **unguarded** `$HOMEBREW_TAP_NAME` reference inside the branch guarded by `${HOMEBREW_TAP_REPOSITORY-}`:

```bash
# line 209-212
if [[ -n "${HOMEBREW_TAP_REPOSITORY-}" ]]; then          # has a default -> true for us
    echo "repository-path=$HOMEBREW_TAP_REPOSITORY" >>"$GITHUB_OUTPUT"
    echo "tap-name=$HOMEBREW_TAP_NAME" >>"$GITHUB_OUTPUT" # no default -> aborts under set -u
fi
```

So the branch is entered with `HOMEBREW_TAP_NAME` unset and the script aborts. This is a usage problem on our side: setting `HOMEBREW_TAP_REPOSITORY` by hand now requires setting its counterpart too.

## Changes

- **Pass `HOMEBREW_TAP_NAME: akiomik/mado`** alongside `HOMEBREW_TAP_REPOSITORY` so the pair is complete. This also enables the `brew trust` step at line 219, which succeeds even before the tap directory exists (it only writes `trust.json`).
- **Drop `test-bot: true`** — no longer a valid input since [`8c478e7f`](https://github.com/Homebrew/actions/commit/8c478e7f) removed the `homebrew/test-bot` tap handling. It was silently ignored and only produced `##[warning]Unexpected input(s) 'test-bot'`.
- **Pin the action to the `2026.08.03.2` release SHA** — `@master` is deprecated and the warning becomes a hard error once Homebrew 5.2.0 ships. Pinning also prevents an upstream master push from breaking CI again with no change on our side; Dependabot already covers `github-actions`, so updates still arrive as PRs.

## Verification

This PR's own `CI Package / Test Homebrew` run is the test — it exercises the exact failing step. Locally confirmed that the pinned `2026.08.03.2` tree still contains the line 211 `tap-name` output, so the `HOMEBREW_TAP_NAME` addition (not the pin) is what actually fixes the failure; the pin only removes the deprecation warning and the unpinned-upstream risk.

No CHANGELOG entry added — this is CI-internal and there is no `Unreleased` section open. Happy to add one if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)