### PR TITLE
fix: check lists nested inside blockquotes in MD004, MD005, MD029 and MD030

### DIFF
--- a/src/rule/md004.rs
+++ b/src/rule/md004.rs
@@ -48,12 +48,10 @@ impl MD004 {
         root: &'a AstNode<'a>,
         path: &PathBuf,
         violations: &mut Vec<Violation>,
-        initial_maybe_list_char: Option<char>,
+        maybe_list_char: &mut Option<char>,
         levels: &mut FxHashMap<usize, char>,
         level: usize,
     ) {
-        let mut maybe_list_char = initial_maybe_list_char;
-
         for node in root.children() {
             if let NodeValue::List(_) = node.data.borrow().value {
                 for item_node in node.children() {
@@ -81,7 +79,7 @@ impl MD004 {
                         }
 
                         if maybe_list_char.is_none() {
-                            maybe_list_char = Some(bullet_char as char);
+                            *maybe_list_char = Some(bullet_char as char);
                         }
 
                         if self.style == ListStyle::Sublist {
@@ -98,6 +96,13 @@ impl MD004 {
                         level + 1,
                     );
                 }
+            } else {
+                // A blockquote (or any other non-item container) can hold a list
+                // too. The level is left untouched: a list at the top of a
+                // blockquote is a level-1 list, which is what `sublist` compares
+                // against, and `consistent` is document-wide, so the style picked
+                // up inside the container carries back out.
+                self.check_recursive(node, path, violations, maybe_list_char, levels, level);
             }
         }
     }
@@ -121,9 +126,17 @@ impl RuleLike for MD004 {
     #[inline]
     fn check(&self, doc: &Document) -> Result<Vec<Violation>> {
         let mut violations = vec![];
+        let mut maybe_list_char = None;
         let mut levels = FxHashMap::default();
 
-        self.check_recursive(doc.ast, &doc.path, &mut violations, None, &mut levels, 1);
+        self.check_recursive(
+            doc.ast,
+            &doc.path,
+            &mut violations,
+            &mut maybe_list_char,
+            &mut levels,
+            1,
+        );
 
         Ok(violations)
     }
@@ -248,6 +261,88 @@ mod tests {
             rule.to_violation(path.clone(), Sourcepos::from((10, 1, 10, 8))),
             rule.to_violation(path, Sourcepos::from((11, 1, 11, 8))),
         ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_in_blockquote() -> Result<()> {
+        let text = indoc! {"
+            > * Item 1
+            > + Item 2
+            > - Item 3
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD004::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((2, 3, 2, 10))),
+            rule.to_violation(path, Sourcepos::from((3, 3, 3, 10))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // `consistent` is document-wide, so the style set by the first list carries
+    // across the blockquote boundary in both directions.
+    #[test]
+    fn check_errors_for_consistent_with_style_set_inside_blockquote() -> Result<()> {
+        let text = indoc! {"
+            > * Item 1
+
+            + Item 2
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD004::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 1, 3, 8)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // A list at the top of a blockquote is a level 1 list, so `sublist` compares it
+    // against the top-level style rather than treating the blockquote as a level.
+    #[test]
+    fn check_errors_for_sublist_in_blockquote() -> Result<()> {
+        let text = indoc! {"
+            * Item 1
+              + Item 1a
+
+            > + Item 2
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD004::new(ListStyle::Sublist);
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((4, 3, 4, 10)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_no_errors_for_sublist_in_blockquote() -> Result<()> {
+        let text = indoc! {"
+            * Item 1
+              + Item 1a
+
+            > * Item 2
+            >   + Item 2a
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD004::new(ListStyle::Sublist);
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md005.rs
+++ b/src/rule/md005.rs
@@ -54,6 +54,20 @@ impl MD005 {
                         self.check_recursive(item_node, path, violations, levels, level + 1);
                     }
                 }
+            } else {
+                // Lists inside a blockquote (or any other non-item container) are
+                // checked too, but against their own baseline: `levels` records
+                // absolute columns, and every line inside a blockquote is shifted
+                // by the `> ` prefix. Sharing the outer map would make a correctly
+                // indented quoted list look inconsistent with an unquoted one.
+                //
+                // NOTE: markdownlint reports nothing inside a blockquote here. It
+                // measures indentation from the raw line, so `>   * Foo` counts as
+                // indent 0 and every quoted item looks equally indented. That is a
+                // side effect of how it measures rather than a decision about what
+                // MD005 means, so the deviation is deliberate on our side.
+                let mut scoped_levels = FxHashMap::default();
+                self.check_recursive(node, path, violations, &mut scoped_levels, level);
             }
         }
     }
@@ -174,6 +188,46 @@ mod tests {
             rule.to_violation(path.clone(), Sourcepos::from((7, 4, 7, 11))),
             rule.to_violation(path, Sourcepos::from((8, 4, 8, 11))),
         ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: markdownlint reports nothing here, see the comment in `check_recursive`.
+    #[test]
+    fn check_errors_in_blockquote() -> Result<()> {
+        let text = indoc! {"
+            > * Item 1
+            >  * Item 2
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD005::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 4, 2, 11)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // A blockquote shifts every line by its prefix, so quoted items must not be
+    // compared against unquoted ones at the same nesting depth.
+    #[test]
+    fn check_no_errors_for_blockquote_alongside_top_level_list() -> Result<()> {
+        let text = indoc! {"
+            * Item 1
+            * Item 2
+
+            > * Item 3
+            > * Item 4
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD005::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md029.rs
+++ b/src/rule/md029.rs
@@ -69,6 +69,11 @@ impl MD029 {
                         self.check_recursive(item_node, path, violations);
                     }
                 }
+            } else {
+                // Lists can also be reached through containers that are not list
+                // items, a blockquote being the common case. Descending into them
+                // keeps the rule from going silent on `> 1. Foo`.
+                self.check_recursive(node, path, violations);
             }
         }
     }
@@ -174,6 +179,44 @@ mod tests {
     }
 
     #[test]
+    fn check_errors_in_blockquote() -> Result<()> {
+        let text = indoc! {"
+            > 1. Do this.
+            > 2. Do that.
+            > 3. Done.
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD029::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((2, 3, 2, 13))),
+            rule.to_violation(path, Sourcepos::from((3, 3, 3, 10))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_in_nested_blockquote() -> Result<()> {
+        let text = indoc! {"
+            > > 1. Do this.
+            > > 2. Do that.
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD029::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 5, 2, 15)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
     fn check_no_errors_one() -> Result<()> {
         let text = indoc! {"
             1. Do this.
@@ -203,6 +246,24 @@ mod tests {
         let arena = Arena::new();
         let doc = Document::new(&arena, path, text)?;
         let rule = MD029::new(OrderedListStyle::Ordered);
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_no_errors_in_blockquote() -> Result<()> {
+        let text = indoc! {"
+            > 1. Do this.
+            > 1. Do that.
+            > 1. Done.
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD029::default();
         let actual = rule.check(&doc)?;
         let expected = vec![];
         assert_eq!(actual, expected);

--- a/src/rule/md030.rs
+++ b/src/rule/md030.rs
@@ -118,6 +118,12 @@ impl MD030 {
                         self.check_recursive(item_node, path, lines, violations);
                     }
                 }
+            } else {
+                // See the comment on the equivalent branch in MD029: lists reached
+                // through a blockquote or other non-item container must still be
+                // checked. `ordered_marker_width` needs no adjustment for them,
+                // because `sourcepos` columns already account for the `> ` prefix.
+                self.check_recursive(node, path, lines, violations);
             }
         }
     }
@@ -383,6 +389,67 @@ mod tests {
             rule.to_violation(path.clone(), Sourcepos::from((2, 5, 3, 24))),
             rule.to_violation(path, Sourcepos::from((4, 5, 4, 11))),
         ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_in_blockquote_ul() -> Result<()> {
+        let text = indoc! {"
+            > *   Foo
+            > *   Bar
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD030::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((1, 3, 1, 9))),
+            rule.to_violation(path, Sourcepos::from((2, 3, 2, 9))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // The marker width is read back from the source line, so this also covers the
+    // `> ` prefix being accounted for by `sourcepos` columns.
+    #[test]
+    fn check_errors_in_blockquote_ol_multi_digit_marker() -> Result<()> {
+        let text = indoc! {"
+            > 9.   Foo
+            > 10.   Bar
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD030::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((1, 3, 1, 10))),
+            rule.to_violation(path, Sourcepos::from((2, 3, 2, 11))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_no_errors_in_blockquote() -> Result<()> {
+        let text = indoc! {"
+            > * Foo
+            > * Bar
+            >
+            > 10. Baz
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD030::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
         assert_eq!(actual, expected);
         Ok(())
     }


### PR DESCRIPTION
Fixes #366.

## Problem

MD004, MD005, MD029 and MD030 share a traversal that only recurses through `Item` nodes, so a `List` reached through any other container is never visited. A blockquote is the common case — this reported nothing at all:

```markdown
> 1.   Foo
> 3. Bar
```

while the same list at the top level reports both MD030 and MD029.

## Change

Descend into non-`List` containers as well.

MD004, MD029 and MD030 need nothing beyond that. `sourcepos` columns already account for the `> ` prefix, so MD030's marker-width read-back from the source line (added in #363) keeps working unchanged inside a blockquote.

MD005 needs more. Its `levels` map is keyed by nesting depth and stores absolute columns, so a top-level item at column 1 and a quoted item at column 3 collided at the same level and produced a **false positive** on correct input:

```markdown
* Item 1
* Item 2

> * Item 3
> * Item 4
```

Each non-`List` container now gets its own map, so quoted items are compared against a quoted baseline. There is a regression test for exactly this shape.

MD004's `consistent` style now also propagates out of a container, which is why `check_recursive` takes `&mut Option<char>`. The style is document-wide, and previously a list inside a blockquote could not establish it for the lists that follow.

## Verification

Compared against `mdl` 0.17.0 (the implementation this project targets) and markdownlint-cli2 0.23.2, driving the built binary rather than only unit tests.

| Input | mdl | markdownlint-cli2 | mado before | mado after |
| --- | --- | --- | --- | --- |
| `> 1.   Foo` / `> 3. Bar` | MD030, MD029 | MD030, MD029 | none | MD030, MD029 |
| `> * Foo` / `> + Bar` | MD004 | MD004 | none | MD004 |
| top-level list + quoted list | none | none | none | none |
| `> * Item 1` / `>  * Item 2` | none | MD005 | none | MD005 |
| `> > 1.   Foo` | none | MD030 | none | MD030 |

Columns match markdownlint-cli2 exactly (`mdl` reports line numbers only).

### Deliberate deviations from `mdl`

Both are cases where `mdl` misses a violation because it measures from the raw source line, not because it intends to skip blockquotes — its MD004/MD029/MD030 do fire inside them.

- **MD005** measures indentation with `doc.indent_for(doc.element_line(b))`, so `>   * Foo` counts as indent 0 and every quoted item looks equally indented. It can never report a violation inside a blockquote.
- **MD030** strips a single literal `> ` with `line.gsub(/^> /, '')`, so `> > 1.   Foo` and an indented `  > 1.   A` fall through unreported.

markdownlint-cli2 reports all of these, and so do we now. The MD005 deviation is recorded in a comment next to the code it affects and on the test that covers it.

## Notes

- 12 new tests; 308 pass, none changed.
- No measurable cost: the gitlab benchmark corpus (1522 files) runs in 0.07s before and after, and its violation count is unchanged at 22590, so the blast radius on real-world documents is small.
- The new `else` branch is container-agnostic rather than blockquote-specific, but a blockquote is the only container that can hold a list under the extensions this project enables (`front_matter_delimiter` and `table`). Footnote definitions are not parsed as containers because the footnotes extension is off, and GFM table cells hold inline content only — neither shape reports anything today. Writing it this way means the rules stay correct if more extensions are enabled later.
- MD006 and MD032 also stay quiet inside blockquotes, but `mdl` does too, so that matches the reference and is out of scope. MD007 has the opposite bug — it false-positives inside blockquotes — tracked separately in #367.
