### PR TITLE
test: cover the defensive source lookups in MD007 and MD030

### DIFF
--- a/src/rule/md007.rs
+++ b/src/rule/md007.rs
@@ -27,6 +27,20 @@ impl MD007 {
         Self { indent }
     }
 
+    /// Indentation of a list item relative to the blockquote that contains it, i.e.
+    /// 0 for the `*` in `> * Foo` and 2 for the one in `>   * Foo`.
+    ///
+    /// `sourcepos` columns are absolute, so they count the `> ` prefix as
+    /// indentation. Measuring from the last `>` on the line instead is what keeps a
+    /// correctly indented quoted list from being reported. One space or tab after
+    /// the marker belongs to the prefix rather than to the indentation, per
+    /// `CommonMark`, so it is dropped.
+    ///
+    /// `None` means the line could not be read back, and the caller then skips the
+    /// item: a position we cannot measure is not evidence of a violation. No input
+    /// is known to produce it, since a list item inside a blockquote always carries
+    /// a `>` on its own start line, but the lookup stays checked rather than
+    /// relying on that.
     fn blockquote_indent(lines: &[String], position: Sourcepos) -> Option<usize> {
         let indent = position.start.column.checked_sub(1)?;
         let line = lines.get(position.start.line.checked_sub(1)?)?;
@@ -76,6 +90,9 @@ impl RuleLike for MD007 {
                     maybe_ancestor = ancestor.parent();
                 }
 
+                // An item whose indentation cannot be measured is skipped entirely,
+                // leaving `maybe_prev_indent` untouched so the next item is compared
+                // against the last position we could actually read.
                 let Some(indent) = maybe_indent else {
                     continue;
                 };
@@ -276,5 +293,49 @@ mod tests {
         let expected = vec![rule.to_violation(path, Sourcepos::from((2, 6, 2, 39)))];
         assert_eq!(actual, expected);
         Ok(())
+    }
+
+    // `blockquote_indent` returns `None` only for positions that `check` cannot
+    // produce, so those arms are exercised directly.
+    #[test]
+    fn blockquote_indent_measures_from_the_last_marker() {
+        let lines = vec![">   * Foo".to_owned()];
+        let position = Sourcepos::from((1, 5, 1, 9));
+        assert_eq!(MD007::blockquote_indent(&lines, position), Some(2));
+    }
+
+    #[test]
+    fn blockquote_indent_drops_one_tab_after_the_marker() {
+        let lines = vec![">\t* Foo".to_owned()];
+        let position = Sourcepos::from((1, 3, 1, 7));
+        assert_eq!(MD007::blockquote_indent(&lines, position), Some(0));
+    }
+
+    #[test]
+    fn blockquote_indent_without_marker() {
+        let lines = vec!["  * Foo".to_owned()];
+        let position = Sourcepos::from((1, 3, 1, 7));
+        assert_eq!(MD007::blockquote_indent(&lines, position), None);
+    }
+
+    #[test]
+    fn blockquote_indent_beyond_last_line() {
+        let lines = vec!["> * Foo".to_owned()];
+        let position = Sourcepos::from((2, 3, 2, 7));
+        assert_eq!(MD007::blockquote_indent(&lines, position), None);
+    }
+
+    #[test]
+    fn blockquote_indent_beyond_end_of_line() {
+        let lines = vec!["> ".to_owned()];
+        let position = Sourcepos::from((1, 9, 1, 9));
+        assert_eq!(MD007::blockquote_indent(&lines, position), None);
+    }
+
+    #[test]
+    fn blockquote_indent_inside_a_multibyte_character() {
+        let lines = vec!["\u{3042}> * Foo".to_owned()];
+        let position = Sourcepos::from((1, 3, 1, 7));
+        assert_eq!(MD007::blockquote_indent(&lines, position), None);
     }
 }

--- a/src/rule/md030.rs
+++ b/src/rule/md030.rs
@@ -523,4 +523,35 @@ mod tests {
         assert_eq!(actual, expected);
         Ok(())
     }
+
+    // The remaining arms of `ordered_marker_width` are unreachable through `check`,
+    // because comrak only produces an ordered item where a marker was actually
+    // written. They are exercised directly so the guards stay honest.
+    #[test]
+    fn ordered_marker_width_without_digits() {
+        let lines = vec!["* Foo".to_owned()];
+        let position = Sourcepos::from((1, 1, 1, 5));
+        assert_eq!(MD030::ordered_marker_width(&lines, position), None);
+    }
+
+    #[test]
+    fn ordered_marker_width_without_delimiter() {
+        let lines = vec!["1 Foo".to_owned()];
+        let position = Sourcepos::from((1, 1, 1, 5));
+        assert_eq!(MD030::ordered_marker_width(&lines, position), None);
+    }
+
+    #[test]
+    fn ordered_marker_width_beyond_last_line() {
+        let lines = vec!["1. Foo".to_owned()];
+        let position = Sourcepos::from((2, 1, 2, 6));
+        assert_eq!(MD030::ordered_marker_width(&lines, position), None);
+    }
+
+    #[test]
+    fn ordered_marker_width_with_paren_delimiter() {
+        let lines = vec!["10) Foo".to_owned()];
+        let position = Sourcepos::from((1, 1, 1, 7));
+        assert_eq!(MD030::ordered_marker_width(&lines, position), Some(3));
+    }
 }


### PR DESCRIPTION
Follow-up to #363 and #369.

## Problem

`ordered_marker_width` (#363) and `blockquote_indent` (#369) both read a source line back through
a `sourcepos` column and return `None` when that fails. Several of those guard arms cannot be
reached through `check`: comrak only produces an ordered item where a marker was actually written,
and only nests a list under a blockquote when the item's start line carries a `>`.

That left them permanently uncovered, so every PR touching this code pays for it in
`codecov/patch`. #369 failed that check for exactly this reason, on a guard it had been asked to
add.

## Change

Both are private associated functions, so the arms can be exercised directly rather than by
hunting for Markdown that reaches them:

- `ordered_marker_width`: missing digits, missing `.`/`)` delimiter, line out of range, plus a
  `)` delimiter case that was not covered before.
- `blockquote_indent`: no `>` on the line, line out of range, column past the end of the line, and
  a column landing inside a multi-byte character.

Also documents `blockquote_indent`, which was added without the rationale that
`ordered_marker_width` carries.

The diff is additive: 92 lines, no deletions, no executable line changed.

## Coverage

`src/rule/md030.rs:63` and `:68` are now covered. One line remains: the `continue` in MD007's
`check`, which runs only when `blockquote_indent` returns `None`.

Rewriting it as `if let` does not remove it. llvm-cov then charges the unexecuted arm to the
closing brace instead, which is where the same construct already leaves uncovered lines at
`md004.rs:88`, `md005.rs:55`, `md029.rs:70` and `md030.rs:119`. Since that trades a clear early
`continue` for extra nesting and gains nothing measurable, this PR leaves the code as it is.
