### PR TITLE
ci: migrate actions-rust-release to v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,14 @@ updates:
     directory: "/" # Location of workflow files
     schedule:
       interval: "weekly"
+    groups:
+      # CD calls `actions-rust-release` to package and its `publish` subaction to
+      # release, and the two only agree about archive names and artifact layout
+      # at the same version. While both are pinned to a tag, Dependabot names
+      # them after the repository alone and already updates them together; a
+      # switch to commit SHAs would make them two dependencies, and a PR raising
+      # only one of them would leave CD green and the release wrong, which is
+      # not visible until a tag is pushed. Group them so that stays impossible.
+      actions-rust-release:
+        patterns:
+          - "houseabsolute/actions-rust-release*"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  release-notes:
-    name: Check release notes
+  preflight:
+    name: Check the tag
     runs-on: ubuntu-latest
 
     steps:
@@ -21,6 +21,17 @@ jobs:
       uses: actions/checkout@v7
       with:
         persist-credentials: false
+    # CI compares the changelog against the version in `Cargo.toml`, and never
+    # sees the tag, so a tag ahead of `Cargo.toml` reaches here unnoticed and
+    # would release binaries reporting the version before it.
+    - name: Check the tag against Cargo.toml
+      shell: bash
+      run: |
+        version=$(grep -m 1 '^version = ' Cargo.toml | cut -d '"' -f 2)
+        if [ "$version" != "${GITHUB_REF_NAME#v}" ]; then
+          echo "$GITHUB_REF_NAME does not match version $version in Cargo.toml" >&2
+          exit 1
+        fi
     # The release body is this tag's changelog section, and the job that reads
     # it runs after the matrix. A tag the changelog does not name would fail
     # there, having built five platforms first, so find that out up front.
@@ -30,7 +41,7 @@ jobs:
 
   package:
     name: Package - ${{ matrix.platform.os-name }}
-    needs: release-notes
+    needs: preflight
     runs-on: ${{ matrix.platform.runs-on }}
 
     strategy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,8 +12,25 @@ permissions:
   contents: read
 
 jobs:
+  release-notes:
+    name: Check release notes
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    # The release body is this tag's changelog section, and the job that reads
+    # it runs after the matrix. A tag the changelog does not name would fail
+    # there, having built five platforms first, so find that out up front.
+    - name: Extract release notes
+      shell: bash
+      run: bash scripts/release/extract-changelog.sh "${GITHUB_REF_NAME#v}" > /dev/null
+
   package:
     name: Package - ${{ matrix.platform.os-name }}
+    needs: release-notes
     runs-on: ${{ matrix.platform.runs-on }}
 
     strategy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,11 +6,11 @@ on:
       - '[v]?[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
-    name: Release - ${{ matrix.platform.os-name }}
+  package:
+    name: Package - ${{ matrix.platform.os-name }}
     runs-on: ${{ matrix.platform.runs-on }}
 
     strategy:
@@ -44,19 +44,40 @@ jobs:
         toolchain: "1.91.1"
         args: "--locked --release"
         strip: true
-    # `actions-rust-release` uses `changes-file` verbatim as the release body,
-    # so it has to be this version's section rather than the whole changelog.
-    - name: Extract release notes
-      shell: bash
-      run: bash scripts/release/extract-changelog.sh "${GITHUB_REF_NAME#v}" > RELEASE_NOTES.md
-    - name: Publish artifacts and release
-      uses: houseabsolute/actions-rust-release@v0.0.9
+    # This action no longer creates the release, so its `changes-file` only
+    # picks a file to archive. Empty it, or the action looks for the `Changes.md`
+    # this repository does not have; `extra-files` says what the archive holds.
+    - name: Package artifacts
+      uses: houseabsolute/actions-rust-release@v1.0.1
       with:
         executable-name: mado
         target: ${{ matrix.platform.target }}
-        changes-file: RELEASE_NOTES.md
-        # Naming `changes-file` above replaced the default, which packaged
-        # CHANGELOG.md and README.md. The archive still wants both.
+        changes-file: ""
         extra-files: |
           CHANGELOG.md
           README.md
+
+  publish:
+    name: Publish GitHub release
+    # One release for the whole matrix, created once every platform has
+    # packaged, rather than one race per platform.
+    needs: package
+    runs-on: ubuntu-latest # The publish action refuses to run anywhere else.
+
+    permissions:
+      actions: read # Listing this run's artifacts.
+      contents: write # Creating the release.
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+    # The publish action uses `changes-file` verbatim as the release body, so it
+    # has to be this version's section rather than the whole changelog.
+    - name: Extract release notes
+      shell: bash
+      run: bash scripts/release/extract-changelog.sh "${GITHUB_REF_NAME#v}" > RELEASE_NOTES.md
+    - name: Publish release
+      uses: houseabsolute/actions-rust-release/publish@v1.0.1
+      with:
+        executable-name: mado
+        changes-file: RELEASE_NOTES.md

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,3 +81,8 @@ jobs:
       with:
         executable-name: mado
         changes-file: RELEASE_NOTES.md
+        # The tag trigger above admits a bare `0.4.0`, which the default regex
+        # would release under asset URLs the package manifests do not use, as
+        # they all spell the tag `v{version}`. v0 released on a `v` prefix, so
+        # keep that gate rather than widening it as part of this migration.
+        release-tag-regex: '^v\d+\.\d+\.\d+$'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,9 +12,9 @@ permissions:
   contents: read
 
 concurrency:
-  # Two runs for one tag race for the release, and the loser fails outright now
-  # that publishing refuses an existing release. Never cancel one part way
-  # through: it could be the run that has already created it.
+  # Publishing checks for an existing release and then creates one, so two runs
+  # for a tag can both pass that check and race. Queue them instead. Never
+  # cancel one part way through: it may be the run that has already published.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Build binary
       uses: houseabsolute/actions-rust-cross@v1
       with:
@@ -69,8 +71,13 @@ jobs:
       contents: write # Creating the release.
 
     steps:
+    # Nothing here pushes, and the steps after this one run third-party code
+    # while this job holds `contents: write`, so keep the token out of the
+    # checkout rather than leaving it in `.git/config` for them.
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     # The publish action uses `changes-file` verbatim as the release body, so it
     # has to be this version's section rather than the whole changelog.
     - name: Extract release notes

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,9 @@ name: CD # Continuous Deployment
 
 on:
   push:
+    # Whatever this admits, the publish job's `release-tag-regex` has to accept
+    # too, so edit the two together. A tag that only one of them matches builds
+    # every platform and then releases nothing, and the run still ends green.
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Two runs for one tag race for the release, and the loser fails outright now
+  # that publishing refuses an existing release. Never cancel one part way
+  # through: it could be the run that has already created it.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   preflight:
     name: Check the tag

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD # Continuous Deployment
 on:
   push:
     tags:
-      - '[v]?[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: read
@@ -81,8 +81,8 @@ jobs:
       with:
         executable-name: mado
         changes-file: RELEASE_NOTES.md
-        # The tag trigger above admits a bare `0.4.0`, which the default regex
-        # would release under asset URLs the package manifests do not use, as
-        # they all spell the tag `v{version}`. v0 released on a `v` prefix, so
-        # keep that gate rather than widening it as part of this migration.
+        # The default would also release a tag with no `v`, under asset URLs
+        # the package manifests cannot use, since they all spell the tag
+        # `v{version}`. The trigger above already says this, and saying it here
+        # too keeps a tag that reaches this job from publishing such a release.
         release-tag-regex: '^v\d+\.\d+\.\d+$'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,9 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
    `just update-scoop`, `just update-winget` and `just update-flake`.
 1. Tag the merged commit `vx.y.z` and push the tag.
 
-CD then builds the binaries and opens a draft release whose body is that
-version's changelog section, extracted by
-`scripts/release/extract-changelog.sh`. Review the draft and publish it.
+CD then builds the binaries for every platform and publishes a release once all
+of them are packaged. Its body is that version's changelog section, extracted by
+`scripts/release/extract-changelog.sh`.
 
 CI checks that the section for the version in `Cargo.toml` exists, so a bump
 without a changelog section fails before it reaches the tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,9 @@ Only a `vx.y.z` tag starts CD, and a tag without the `v` is ignored with no run
 to look at. It also stops before building anything if the tag disagrees with
 `version` in `Cargo.toml`, or if the changelog has no section for it.
 
-Re-running CD for a tag that already has a release fails rather than adding to
-it, because an immutable release cannot be changed at all. Delete the release
-first if you need to build it again.
+Re-running CD for a tag that already has a release fails: the publish action
+refuses to add to one, whether or not it could. Delete the release first if you
+need to build the tag again.
 
 CI checks that the section for the version in `Cargo.toml` exists, so a bump
 without a changelog section fails before it reaches the tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,5 +59,9 @@ CD then builds the binaries for every platform and publishes a release once all
 of them are packaged. Its body is that version's changelog section, extracted by
 `scripts/release/extract-changelog.sh`.
 
+Re-running CD for a tag that already has a release fails rather than adding to
+it, because an immutable release cannot be changed at all. Delete the release
+first if you need to build it again.
+
 CI checks that the section for the version in `Cargo.toml` exists, so a bump
 without a changelog section fails before it reaches the tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,10 @@ CD then builds the binaries for every platform and publishes a release once all
 of them are packaged. Its body is that version's changelog section, extracted by
 `scripts/release/extract-changelog.sh`.
 
+Only a `vx.y.z` tag starts CD, and a tag without the `v` is ignored with no run
+to look at. It also stops before building anything if the tag disagrees with
+`version` in `Cargo.toml`, or if the changelog has no section for it.
+
 Re-running CD for a tag that already has a release fails rather than adding to
 it, because an immutable release cannot be changed at all. Delete the release
 first if you need to build it again.


### PR DESCRIPTION
## Summary

Replaces #382. Dependabot only rewrites the `uses:` line, which is not enough
for this release: v1.0.0 splits the action in two.

- `houseabsolute/actions-rust-release` now only packages the executable and
  uploads it as a workflow artifact.
- `houseabsolute/actions-rust-release/publish` collects those artifacts and
  creates one release, from a job that runs after the whole matrix.

Merging #382 as-is would leave CD green while producing no release at all. The
packaging action still accepts `executable-name`, `target`, `changes-file` and
`extra-files`, so nothing errors — the release step just no longer exists. That
is the failure #351 dealt with: the second v0.3.1 run went green with every
platform built and attached nothing, and the release only got its assets once
that PR re-pinned the action and the tag was run again.

So the matrix job becomes `package` and a new `publish` job follows it. That
also buys what the split exists for: v0 created the release from inside the
matrix, so a platform that finished early could publish a release while the
other platforms were still building, and every leg raced to create it.

### Input changes

- `changes-file` means different things on the two actions now. On `package` it
  only picks a file to archive, and it fails if that file is missing, so it is
  emptied here rather than left at its `Changes.md` default — `extra-files`
  already says what the archive holds. On `publish` it is the release body,
  which is what the extracted changelog section is for, so `RELEASE_NOTES.md` is
  generated in the `publish` job now.
- The `publish` job needs `actions: read` to list the run's artifacts, has to
  run on Linux, and needs a checkout to read `RELEASE_NOTES.md`. The `package`
  job no longer needs `contents: write`, so the workflow default drops to
  `contents: read`.
- `release-tag-prefix` is replaced by `release-tag-regex`. Its default also
  accepts a version with no `v` prefix, which the tag trigger admits, so it is
  set to `^v\d+\.\d+\.\d+$` to keep the gate v0 had. A bare `0.4.0` tag would
  otherwise publish a release whose assets live under `/releases/download/0.4.0/`,
  while the Homebrew, Scoop, WinGet and flake manifests all spell it `v{version}`.
- Both `uses:` lines are grouped in `.github/dependabot.yml`. They are one
  dependency while tag-pinned, and two under SHA pins, so the group keeps the
  packaging action and its `publish` subaction on the same version either way.
- The tag trigger drops its optional `v`, so it now matches that regex. A bare
  `0.4.0` used to build all five platforms and then publish nothing while the
  run stayed green, which is the failure mode this PR exists to remove.
- A `preflight` job runs before the matrix. It extracts the changelog section,
  so a tag the changelog does not name fails in seconds rather than after five
  platform builds, and it compares the tag against `Cargo.toml`, which nothing
  did before: CI checks that version against the changelog on a pull request,
  where there is no tag, so `v0.4.0` on a commit still carrying `0.3.1` used to
  release binaries reporting the older version.
- A `concurrency` group serializes runs per ref, so two publish steps cannot
  both find no release and then race to create one. It does not make a tag
  moved mid-run safe: without cancellation the earlier run is the one that
  publishes, and the later one fails on the release it left behind.
- All checkouts pass `persist-credentials: false`. Nothing in CD pushes and no
  dependency is fetched over git, so there is no reason to leave the token in
  `.git/config` while third-party action code runs in the job holding
  `contents: write`.

## Not in scope

`CONTRIBUTING.md` also tells you to refresh the package manifests before pushing
the tag, which cannot work: those `just` recipes download `.sha256` assets of the
release CD has not created yet. That is pre-existing and unrelated to this
migration, so it is filed as #385 rather than fixed here.

Both `uses:` lines keep the tag pinning every other action in this repository
uses. Moving to commit SHAs would harden the job that holds `contents: write`,
but `actions/checkout` and `actions-rust-cross` run there and in the build too,
so it is a repository-wide decision: #386.

The tag glob and `release-tag-regex` state the same rule in two pattern
languages, and a comment on each is all that keeps them together. Nothing
enforces it, but a check that decides whether a glob and a regex accept the same
tags is not something worth writing, and the failure it would catch is a tag
that builds and does not release, which the comments name explicitly.

### What does not change

`make-archive.py` is byte for byte identical between v0.0.9 and v1.0.1, so the
archive names stay the same and the Homebrew, Scoop, winget and flake manifests
keep resolving. The `.sha256` files still ship: the packaging action uploads
`<archive>*` as the artifact, and `publish` attaches every file it downloads.

The `v1` this pins to is a real tag, not the stale `v1` branch #351 backed away
from. That branch carried an upstream bug where `set-should-release.py` wrote
`should_release` while the action checked `outputs.match`, so the release step
was always skipped. v1.0.1 writes `should-release` and reads the same key, with
a unit test covering what actually lands in `GITHUB_OUTPUT`.

### Documentation

CONTRIBUTING said CD opens a draft release to review before publishing. It never
did — v0 wrote its booleans as Python's `True`, which `softprops/action-gh-release`
did not recognise, so `draft` was silently ignored and every release went out
directly. v1 makes that input work, and it defaults to off, so the docs are
corrected to describe what CD has always done rather than changing the behaviour.

## Test plan

- [ ] The next release tag produces a single GitHub release with all five
      platforms' archives and their `.sha256` files attached, and a body holding
      only that version's changelog section

There is no way to exercise CD short of pushing a tag, so this is verified on
the next release.






