### PR TITLE
docs: put the manifest refresh after the release it reads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,19 +51,19 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
    `## [Unreleased]` above it, and update the link definitions at the bottom of
    the file.
 1. Bump the version in the files the tagged commit has to be right about:
-   `version` in `Cargo.toml` and `Cargo.lock`, `version` / `prev_version` in the
-   `justfile`, `VERSION` in `action/entrypoint.sh`, and the
-   `akiomik/mado@vx.y.z` pins in `README.md`. The GitHub Action downloads the
-   release `entrypoint.sh` names, so a tag that leaves it behind runs the
-   previous version's binary.
+   `version` in `Cargo.toml` and `Cargo.lock`, `VERSION` in
+   `action/entrypoint.sh`, and the `akiomik/mado@vx.y.z` pins in `README.md`.
+   The GitHub Action downloads the release `entrypoint.sh` names, so a tag that
+   leaves it behind runs the previous version's binary.
 1. Tag the merged commit `vx.y.z` and push the tag. That starts CD.
-1. Once CD has published the release, refresh the package manifests with
-   `just update-homebrew`, `just update-scoop`, `just update-winget` and
-   `just update-flake`, and open a pull request for them. Every one of these
-   recipes downloads assets of the release being packaged, so none of them can
-   run any earlier. This is also why `flake.nix` and everything under `pkg/`
-   still name the previous version at the moment the tag is pushed, and why
-   `nix run github:akiomik/mado/vx.y.z` gets the release before it.
+1. Once CD has published the release, set `version` / `prev_version` in the
+   `justfile`, refresh the package manifests with `just update-homebrew`,
+   `just update-scoop`, `just update-winget` and `just update-flake`, and open a
+   pull request for them. Every one of these recipes downloads assets of the
+   release being packaged, so none of them can run any earlier. This is also why
+   `flake.nix` and the manifests under `pkg/` still name the previous version at
+   the moment the tag is pushed, and why `nix run github:akiomik/mado/vx.y.z`
+   gets the release before it.
 
 CD builds the binaries for every platform and publishes one release once all of
 them are packaged. Its body is that version's changelog section, extracted by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,17 +50,20 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
 1. Rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD`, add a fresh empty
    `## [Unreleased]` above it, and update the link definitions at the bottom of
    the file.
-1. Bump the version in every file the tag has to carry it in: `version` in
-   `Cargo.toml` and `Cargo.lock`, `version` / `prev_version` in the `justfile`,
-   `VERSION` in `action/entrypoint.sh`, and the `akiomik/mado@vx.y.z` pins in
-   `README.md`. The GitHub Action downloads the release `entrypoint.sh` names,
-   so a tag that leaves it behind runs the previous version's binary.
+1. Bump the version in the files the tagged commit has to be right about:
+   `version` in `Cargo.toml` and `Cargo.lock`, `version` / `prev_version` in the
+   `justfile`, `VERSION` in `action/entrypoint.sh`, and the
+   `akiomik/mado@vx.y.z` pins in `README.md`. The GitHub Action downloads the
+   release `entrypoint.sh` names, so a tag that leaves it behind runs the
+   previous version's binary.
 1. Tag the merged commit `vx.y.z` and push the tag. That starts CD.
 1. Once CD has published the release, refresh the package manifests with
    `just update-homebrew`, `just update-scoop`, `just update-winget` and
    `just update-flake`, and open a pull request for them. Every one of these
    recipes downloads assets of the release being packaged, so none of them can
-   run any earlier.
+   run any earlier. This is also why `flake.nix` and everything under `pkg/`
+   still name the previous version at the moment the tag is pushed, and why
+   `nix run github:akiomik/mado/vx.y.z` gets the release before it.
 
 CD builds the binaries for every platform and publishes one release once all of
 them are packaged. Its body is that version's changelog section, extracted by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,17 +50,20 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
 1. Rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD`, add a fresh empty
    `## [Unreleased]` above it, and update the link definitions at the bottom of
    the file.
-1. Bump `version` in `Cargo.toml` and `version` / `prev_version` in the
-   `justfile`.
-1. Tag the merged commit `vx.y.z` and push the tag.
-1. Once the release is published, refresh the package manifests with
+1. Bump the version everywhere it is written down: `version` in `Cargo.toml`
+   and `Cargo.lock`, `version` / `prev_version` in the `justfile`, `VERSION` in
+   `action/entrypoint.sh`, and the `akiomik/mado@vx.y.z` pins in `README.md`.
+   The GitHub Action downloads the release `entrypoint.sh` names, so a tag that
+   leaves it behind runs the previous version's binary.
+1. Tag the merged commit `vx.y.z` and push the tag. That starts CD.
+1. Once CD has published the release, refresh the package manifests with
    `just update-homebrew`, `just update-scoop`, `just update-winget` and
    `just update-flake`, and open a pull request for them. Every one of these
    recipes downloads assets of the release being packaged, so none of them can
-   run before CD has published it.
+   run any earlier.
 
-CD then builds the binaries for every platform and publishes a release once all
-of them are packaged. Its body is that version's changelog section, extracted by
+CD builds the binaries for every platform and publishes one release once all of
+them are packaged. Its body is that version's changelog section, extracted by
 `scripts/release/extract-changelog.sh`.
 
 Only a `vx.y.z` tag starts CD, and a tag without the `v` is ignored with no run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,13 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
    `## [Unreleased]` above it, and update the link definitions at the bottom of
    the file.
 1. Bump `version` in `Cargo.toml` and `version` / `prev_version` in the
-   `justfile`, then refresh the package manifests with `just update-homebrew`,
-   `just update-scoop`, `just update-winget` and `just update-flake`.
+   `justfile`.
 1. Tag the merged commit `vx.y.z` and push the tag.
+1. Once the release is published, refresh the package manifests with
+   `just update-homebrew`, `just update-scoop`, `just update-winget` and
+   `just update-flake`, and open a pull request for them. Every one of these
+   recipes downloads assets of the release being packaged, so none of them can
+   run before CD has published it.
 
 CD then builds the binaries for every platform and publishes a release once all
 of them are packaged. Its body is that version's changelog section, extracted by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,11 +50,11 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
 1. Rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD`, add a fresh empty
    `## [Unreleased]` above it, and update the link definitions at the bottom of
    the file.
-1. Bump the version everywhere it is written down: `version` in `Cargo.toml`
-   and `Cargo.lock`, `version` / `prev_version` in the `justfile`, `VERSION` in
-   `action/entrypoint.sh`, and the `akiomik/mado@vx.y.z` pins in `README.md`.
-   The GitHub Action downloads the release `entrypoint.sh` names, so a tag that
-   leaves it behind runs the previous version's binary.
+1. Bump the version in every file the tag has to carry it in: `version` in
+   `Cargo.toml` and `Cargo.lock`, `version` / `prev_version` in the `justfile`,
+   `VERSION` in `action/entrypoint.sh`, and the `akiomik/mado@vx.y.z` pins in
+   `README.md`. The GitHub Action downloads the release `entrypoint.sh` names,
+   so a tag that leaves it behind runs the previous version's binary.
 1. Tag the merged commit `vx.y.z` and push the tag. That starts CD.
 1. Once CD has published the release, refresh the package manifests with
    `just update-homebrew`, `just update-scoop`, `just update-winget` and


### PR DESCRIPTION
Closes #385.

## Summary

The release procedure told you to refresh the package manifests before pushing
the tag. That cannot work. `just update-homebrew`, `update-scoop` and
`update-winget` reach `download-hash`, which `wget`s
`releases/download/v{version}/<archive>.sha256`, and `update-flake` reaches
`nix-hash`, which runs `nix-prefetch-url` against the archive itself. Both want
assets of the release CD has not created yet, so step 2 gets a 404 and the
recipe aborts.

Practice was already the other way around: the v0.3.1 release was published at
2026-07-22T05:34:35Z and #352 (`chore: bump packages to v0.3.1`) merged at
05:45:04Z.

## What changed

The manifest refresh becomes its own step after the tag push, which is also
where it belongs procedurally: it is a second pull request, not part of the
version bump that gets tagged.

## Not in scope

Following step 2 leaves the bump pull request with a red Test Action check:
`ci-action.yml` runs `uses: ./`, which downloads the release `entrypoint.sh`
now names, and that release does not exist until the tag is pushed. Both runs
on the v0.3.1 bump branch failed this way and it was merged red. That is a gate
to fix rather than a caveat to write down, so it is filed as #389.

## Test plan

- [x] `mado check CONTRIBUTING.md` passes
- [ ] The next release follows the steps as written
