### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,10 @@ updates:
     groups:
       # CD calls `actions-rust-release` to package and its `publish` subaction to
       # release, and the two only agree about archive names and artifact layout
-      # at the same version. While both are pinned to a tag, Dependabot names
-      # them after the repository alone and already updates them together; a
-      # switch to commit SHAs would make them two dependencies, and a PR raising
-      # only one of them would leave CD green and the release wrong, which is
-      # not visible until a tag is pushed. Group them so that stays impossible.
+      # at the same version. Pinned to commit SHAs they are two dependencies to
+      # Dependabot, which would raise them one at a time, and a PR that moves
+      # only one half leaves CD green and the release wrong — invisible until a
+      # tag is pushed. Group them so they can only move together.
       actions-rust-release:
         patterns:
           - "houseabsolute/actions-rust-release*"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     # CI compares the changelog against the version in `Cargo.toml`, and never
@@ -73,11 +73,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Build binary
-      uses: houseabsolute/actions-rust-cross@v1
+      uses: houseabsolute/actions-rust-cross@21b0f18dc621b25bfae556ff2791fca4173121e8 # v1.0.8
       with:
         command: build
         target: ${{ matrix.platform.target }}
@@ -88,7 +88,7 @@ jobs:
     # picks a file to archive. Empty it, or the action looks for the `Changes.md`
     # this repository does not have; `extra-files` says what the archive holds.
     - name: Package artifacts
-      uses: houseabsolute/actions-rust-release@v1.0.1
+      uses: houseabsolute/actions-rust-release@9e126fd5fc18f4cecf358b3909f3991ad59663dc # v1.0.1
       with:
         executable-name: mado
         target: ${{ matrix.platform.target }}
@@ -113,7 +113,7 @@ jobs:
     # while this job holds `contents: write`, so keep the token out of the
     # checkout rather than leaving it in `.git/config` for them.
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     # The publish action uses `changes-file` verbatim as the release body, so it
@@ -122,7 +122,7 @@ jobs:
       shell: bash
       run: bash scripts/release/extract-changelog.sh "${GITHUB_REF_NAME#v}" > RELEASE_NOTES.md
     - name: Publish release
-      uses: houseabsolute/actions-rust-release/publish@v1.0.1
+      uses: houseabsolute/actions-rust-release/publish@9e126fd5fc18f4cecf358b3909f3991ad59663dc # v1.0.1
       with:
         executable-name: mado
         changes-file: RELEASE_NOTES.md

--- a/.github/workflows/ci-action.yml
+++ b/.github/workflows/ci-action.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Use local action
         uses: ./

--- a/.github/workflows/ci-pkg.yml
+++ b/.github/workflows/ci-pkg.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Rename akiomik/mado to akiomik/homebrew-mado
         run: mv /opt/homebrew/Library/Taps/akiomik/mado /opt/homebrew/Library/Taps/akiomik/homebrew-mado
       - name: Checkout repository for updating HEAD
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Show the latest commit
         run: git log -1
       - name: Run Homebrew info
@@ -39,9 +39,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository for updating HEAD
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Scoop
-        uses: MinoruSekine/setup-scoop@v5.0.1
+        uses: MinoruSekine/setup-scoop@f1cc59be496ed3a1801a5f64efe5c60ba3d6bb75 # v5.0.1
       - name: Install Mado via Scoop
         run: scoop install pkg\scoop\mado.json
 
@@ -50,11 +50,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # NOTE: Cyberboss/install-winget@1 may reach rate limit and not install winget,
       #       so use scoop instead
       - name: Setup Scoop
-        uses: MinoruSekine/setup-scoop@v5.0.1
+        uses: MinoruSekine/setup-scoop@f1cc59be496ed3a1801a5f64efe5c60ba3d6bb75 # v5.0.1
       - name: Install WinGet
         run: scoop install winget
       - name: Run winget validate
@@ -68,7 +68,7 @@ jobs:
     name: Test Nix
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v7
-        - uses: cachix/install-nix-action@v31
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         - run: nix build
         - run: nix flake check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # CD builds the release body out of this section, so a version bump that
       # leaves the changelog on `## [Unreleased]` has to fail here rather than
       # at the tag.
@@ -27,10 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.91.1
-      - uses: Swatinem/rust-cache@v2
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: "1.91.1"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Run tests
         run: cargo test --all-features --workspace
         env:
@@ -42,12 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.91.1
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
+          toolchain: "1.91.1"
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Check formatting
         run: cargo fmt --all --check
 
@@ -56,12 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.91.1
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
+          toolchain: "1.91.1"
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Clippy check
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
@@ -70,10 +74,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.91.1
-      - uses: Swatinem/rust-cache@v2
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: "1.91.1"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
@@ -86,19 +92,23 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.91.1
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: "1.91.1"
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: Swatinem/rust-cache@v2
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
+        with:
+          tool: cargo-llvm-cov
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
         env:
           CLICOLOR_FORCE: true
           TZ: 'Asia/Tokyo'
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/taplo.yml
+++ b/.github/workflows/taplo.yml
@@ -11,8 +11,8 @@ jobs:
   taplo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: uncenter/setup-taplo@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: uncenter/setup-taplo@b18c8c8302695fe63d6853bc004006215ac52b91 # v2
         with:
           version: "0.9.3"
       - name: Run Taplo

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -11,5 +11,5 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: crate-ci/typos@v1.50.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: crate-ci/typos@4d9c206a77c041268485162b8e2579ad7a5cb9a3 # v1.50.0


### PR DESCRIPTION
Closes #386.

## Summary

Every action from outside this repository was pinned to a tag, and two of them
to a *branch*: `houseabsolute/actions-rust-cross@v1` and
`dtolnay/rust-toolchain@1.91.1` are branch names, so CI and CD ran whatever
their tips happened to be that day. A tag moves just as easily.

This is not hypothetical here. #351 was exactly that failure: the release
action's `v1` branch carried a bug that made CD publish a release with no
assets while the run stayed green.

So every third-party action is now pinned to a commit with the version in a
trailing comment — the form `Homebrew/actions/setup-homebrew` already used, and
the one Dependabot reads and rewrites.

| Action | Pinned to |
| --- | --- |
| `actions/checkout` | v7.0.1 |
| `cachix/install-nix-action` | v31.11.1 |
| `codecov/codecov-action` | v7.0.0 |
| `crate-ci/typos` | v1.50.0 |
| `dtolnay/rust-toolchain` | v1 |
| `houseabsolute/actions-rust-cross` | v1.0.8 |
| `houseabsolute/actions-rust-release` (+ `/publish`) | v1.0.1 |
| `MinoruSekine/setup-scoop` | v5.0.1 |
| `Swatinem/rust-cache` | v2.9.2 |
| `taiki-e/install-action` | v2.87.4 |
| `uncenter/setup-taplo` | v2 |

## Two actions needed more than a SHA

Both took their configuration from the ref name, so pinning the commit alone
would have silently changed what they do:

- `dtolnay/rust-toolchain@1.91.1` bakes the toolchain into each version branch —
  that branch's `action.yml` has no `toolchain` input at all. The `v1` release
  does, so it moves there with `toolchain: "1.91.1"` written out.
- `taiki-e/install-action@cargo-llvm-cov` bakes the tool into each tool tag. It
  moves to v2.87.4 with `tool: cargo-llvm-cov`.

## One version actually changes

`actions-rust-cross` moves from the tip of the `v1` branch to v1.0.8, the newest
release. The branch was three commits ahead, and all three touch that
repository's own tooling — its tool pins, its typos config, its pre-commit hook
— not the action.

## Cost

Bumping any of these now means updating a SHA and its comment together, which is
what Dependabot's PRs do on their own. Bumping Rust means editing
`toolchain: "1.91.1"` in `ci.yml` and `cd.yml` rather than a ref name, alongside
`rust-toolchain.toml`.

## Test plan

- [x] Every workflow file still parses
- [ ] CI is green on this PR, which exercises every pinned action except the
      release ones