### PR TITLE
ci: gate the version instead of failing Test Action on every bump

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,17 +28,12 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    # CI compares the changelog against the version in `Cargo.toml`, and never
-    # sees the tag, so a tag ahead of `Cargo.toml` reaches here unnoticed and
-    # would release binaries reporting the version before it.
-    - name: Check the tag against Cargo.toml
+    # CI runs this on pull requests and never sees a tag, but a tag can be
+    # pushed at any commit, so the release is the last place a version the rest
+    # of the tree disagrees with can still be stopped.
+    - name: Check the tag against the version in the tree
       shell: bash
-      run: |
-        version=$(grep -m 1 '^version = ' Cargo.toml | cut -d '"' -f 2)
-        if [ "$version" != "${GITHUB_REF_NAME#v}" ]; then
-          echo "$GITHUB_REF_NAME does not match version $version in Cargo.toml" >&2
-          exit 1
-        fi
+      run: bash scripts/release/check-versions.sh "$GITHUB_REF_NAME"
     # The release body is this tag's changelog section, and the job that reads
     # it runs after the matrix. A tag the changelog does not name would fail
     # there, having built five platforms first, so find that out up front.

--- a/.github/workflows/ci-action.yml
+++ b/.github/workflows/ci-action.yml
@@ -21,7 +21,8 @@ jobs:
       # The action downloads the release it was published with, and a version
       # bump names that release before the tag creating it exists, so testing
       # the default made this job fail on every bump. Point it at a release
-      # that is there; the `version` job is what checks the default.
+      # that is there. The `version` job is what keeps the default from being
+      # left behind; nothing downloads it until it has a tag.
       - name: Find the newest release
         id: release
         run: |

--- a/.github/workflows/ci-action.yml
+++ b/.github/workflows/ci-action.yml
@@ -11,8 +11,29 @@ jobs:
   test:
     name: Test Action
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # Reading the newest release.
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # The action downloads the release it was published with, and a version
+      # bump names that release before the tag creating it exists, so testing
+      # the default made this job fail on every bump. Point it at a release
+      # that is there; the `version` job is what checks the default.
+      - name: Find the newest release
+        id: release
+        run: |
+          if ! tag=$(gh release view --repo akiomik/mado --json tagName --jq .tagName) ||
+            [ -z "$tag" ]; then
+            echo "found no published release to test the action against" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Use local action
         uses: ./
+        with:
+          version: ${{ steps.release.outputs.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,20 @@ jobs:
       # at the tag.
       - name: Check release notes for the current version
         run: |
-          version=$(grep -m 1 '^version = ' Cargo.toml | cut -d '"' -f 2)
+          version=$(bash scripts/release/version.sh)
           bash scripts/release/extract-changelog.sh "$version" > /dev/null
+
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # A tag whose `entrypoint.sh` or README pins were left behind ships the
+      # previous release's binary to everyone using the action, and CD cannot
+      # see it on its own: it only compares the tag against `Cargo.toml`.
+      - name: Check the version is the same everywhere the tag carries it
+        run: bash scripts/release/check-versions.sh
 
   test:
     name: Test Suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ parsed and therefore what gets reported.
 
 ## [Unreleased]
 
+### Added
+
+- The GitHub Action takes a `version` input, so a workflow can run a mado
+  release other than the one the action was published with (#390)
+
 ### Fixed
 
 - MD030: derive the marker width from the item's own ordinal, so ordered items

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,11 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
    `## [Unreleased]` above it, and update the link definitions at the bottom of
    the file.
 1. Bump the version in the files the tagged commit has to be right about:
-   `version` in `Cargo.toml` and `Cargo.lock`, `VERSION` in
+   `version` in `Cargo.toml` and `Cargo.lock`, `DEFAULT_VERSION` in
    `action/entrypoint.sh`, and the `akiomik/mado@vx.y.z` pins in `README.md`.
    The GitHub Action downloads the release `entrypoint.sh` names, so a tag that
-   leaves it behind runs the previous version's binary.
+   leaves it behind runs the previous version's binary. CI checks that these
+   agree with `Cargo.toml`, so forgetting one fails before the tag.
 1. Tag the merged commit `vx.y.z` and push the tag. That starts CD.
 1. Once CD has published the release, set `version` / `prev_version` in the
    `justfile`, refresh the package manifests with `just update-homebrew`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ them are packaged. Its body is that version's changelog section, extracted by
 `scripts/release/extract-changelog.sh`.
 
 Only a `vx.y.z` tag starts CD, and a tag without the `v` is ignored with no run
-to look at. It also stops before building anything if the tag disagrees with
-`version` in `Cargo.toml`, or if the changelog has no section for it.
+to look at. It also stops before building anything if the tag disagrees with any
+of the versions in step 2, or if the changelog has no section for it.
 
 Re-running CD for a tag that already has a release fails: the publish action
 refuses to add to one, whether or not it could. Delete the release first if you

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Mado is compatible with GitHub Actions.
     args: '--config path/to/mado.toml check path/to/*.md'
 ```
 
+The action downloads the mado release it was published with. Setting the
+`version` input names a different release to run; a pin from before the input
+was added ignores it.
+
 ## Development
 
 [just](https://github.com/casey/just/tree/master) is required.

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Arguments passed to Mado. Defaults to `check .`."
     required: false
     default: "check ."
+  version:
+    description: "Mado release to download, like `v0.3.1`. Defaults to the release this action was published with."
+    required: false
+    default: ""
 
 runs:
   using: 'composite'
@@ -20,3 +24,4 @@ runs:
       env:
         INSTALL_DIR: .
         INPUT_ARGS: ${{ inputs.args }}
+        INPUT_VERSION: ${{ inputs.version }}

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
 COMMAND="mado"
-VERSION="v0.3.1"
+# The release published alongside this version of the action. The `version`
+# input overrides it, because a version bump names its release before the tag
+# that creates it exists.
+DEFAULT_VERSION="v0.3.1"
+VERSION="${INPUT_VERSION:-$DEFAULT_VERSION}"
+# This ends up in a path and a URL, and a workflow can wire the input to
+# anything, so accept only something shaped like one of our tags.
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+  echo "'$VERSION' is not a mado release tag" >&2
+  exit 1
+fi
 INSTALL_DIR="$HOME/bin"
 COMMAND_PATH="$INSTALL_DIR/$COMMAND"
 

--- a/scripts/release/check-versions.sh
+++ b/scripts/release/check-versions.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Check that every file the release tag has to carry the version in agrees with
+# `Cargo.toml`. A tag whose `action/entrypoint.sh` or README pins were left
+# behind publishes cleanly and hands everyone using the GitHub Action the
+# previous release's binary.
+#
+# Given a tag, check that too, which is all CD can do about a tag pushed at a
+# commit no pull request ever checked.
+#
+# Usage: check-versions.sh [TAG]
+#
+#   $ scripts/release/check-versions.sh v0.3.1
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR/../.."
+
+version=$(bash "$SCRIPT_DIR/version.sh")
+
+mismatch=0
+
+if [ $# -gt 0 ]; then
+  tag="$1"
+  if [ "${tag#v}" != "$version" ]; then
+    echo "$0: tag $tag, Cargo.toml says $version" >&2
+    mismatch=1
+  fi
+fi
+
+entrypoint=$(sed -n 's/^DEFAULT_VERSION="\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' \
+  action/entrypoint.sh | head -1)
+if [ -z "$entrypoint" ]; then
+  echo "$0: no DEFAULT_VERSION this can read in action/entrypoint.sh" >&2
+  mismatch=1
+elif [ "$entrypoint" != "v$version" ]; then
+  echo "$0: action/entrypoint.sh says $entrypoint, Cargo.toml says $version" >&2
+  mismatch=1
+fi
+
+lock=$(sed -n '/^name = "mado"$/{n;s/^version = "\{0,1\}\([^"]*\)"\{0,1\}$/\1/p;}' \
+  Cargo.lock | head -1)
+if [ -z "$lock" ]; then
+  echo "$0: Cargo.lock has no mado package to check" >&2
+  mismatch=1
+elif [ "$lock" != "$version" ]; then
+  echo "$0: Cargo.lock says $lock, Cargo.toml says $version" >&2
+  mismatch=1
+fi
+
+# Every pin, not only the ones shaped like a version: `@main` or `@v0.3` has to
+# fail here too. Cut each one at the first character a ref cannot contain, so
+# the Markdown around it — a link, a backtick, a full stop — is not read as
+# part of the version.
+pins=$(grep -oE 'akiomik/mado@[^[:space:]]+' README.md |
+  cut -d '@' -f 2 | sed 's|[^A-Za-z0-9._/-].*$||; s/\.*$//' | sort -u || true)
+if [ -z "$pins" ]; then
+  echo "$0: README.md has no akiomik/mado pin to check" >&2
+  mismatch=1
+fi
+for pin in $pins; do
+  if [ "$pin" != "v$version" ]; then
+    echo "$0: README.md pins $pin, Cargo.toml says $version" >&2
+    mismatch=1
+  fi
+done
+
+exit $mismatch

--- a/scripts/release/check-versions.sh
+++ b/scripts/release/check-versions.sh
@@ -23,7 +23,7 @@ mismatch=0
 
 if [ $# -gt 0 ]; then
   tag="$1"
-  if [ "${tag#v}" != "$version" ]; then
+  if [ "$tag" != "v$version" ]; then
     echo "$0: tag $tag, Cargo.toml says $version" >&2
     mismatch=1
   fi

--- a/scripts/release/version.sh
+++ b/scripts/release/version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Print the version in `Cargo.toml`. Everything else a release carries a version
+# in has to agree with this one, so everything that needs it reads it here.
+#
+# Usage: version.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Take what is between the quotes, or the bare value if there are none, rather
+# than whatever `cut` makes of a line with no delimiter in it.
+version=$(sed -n '1,/^version = /s/^version = "\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' \
+  Cargo.toml | head -1)
+if [ -z "$version" ]; then
+  echo "$0: Cargo.toml has no version" >&2
+  exit 1
+fi
+
+printf '%s\n' "$version"


### PR DESCRIPTION
Closes #389.

## The problem

`ci-action.yml` runs `uses: ./`, which downloads the release named by `VERSION`
in `action/entrypoint.sh`. The release procedure bumps that before the tag is
pushed, so on a version bump pull request the release does not exist: both Test
Action runs on the v0.3.1 bump branch (#348) died with a 404 and the PR was
merged with the check red. A gate that is red exactly when the change it guards
lands teaches whoever is releasing to override it.

Meanwhile the failure actually worth catching was never checked at all: a tag
whose `entrypoint.sh` or README pins were left behind publishes cleanly and
hands everyone using `akiomik/mado@vx.y.z` the *previous* release's binary. CD's
preflight only compared the tag against `Cargo.toml`.

## What changed

- The action takes a `version` input, defaulting to the release it was published
  with, and `ci-action.yml` passes the newest existing release. The download and
  run path stays covered on every pull request, without depending on a release
  that is not there yet. The input is validated as a tag, since it reaches both
  a path and a URL.
- `scripts/release/check-versions.sh` compares `Cargo.toml` against
  `Cargo.lock`, `DEFAULT_VERSION` in `action/entrypoint.sh` and every
  `akiomik/mado@…` pin in `README.md`, and against the tag when given one. CI
  runs it on pull requests; CD runs it with the tag before building, since a tag
  can be pushed at a commit no pull request ever checked. That is the whole
  chain: tag = `Cargo.toml` = lockfile = action = README.
- `scripts/release/version.sh` is where the version is read from `Cargo.toml`,
  so the changelog job and the gate cannot disagree about it.

## Scope

This started as the same fix and grew a rewrite of `action/entrypoint.sh` —
checksums, caching, `PATH` publication, an arm64 fix, a breaking change to the
install path. That is out again, and filed as #392 (arm64 404), #393 (download
and install hardening) and #394 (what Test Action still does not cover). #393
carries a note on how that went wrong, so the next attempt does not repeat it.

## Test plan

- [x] `check-versions.sh` passes on this tree and fails with a readable message
      for a stale `DEFAULT_VERSION`, a stale or missing README pin, a stale
      `Cargo.lock`, a `Cargo.toml` with no version, and a mismatched tag
- [x] `entrypoint.sh` runs with the input set, without it, and refuses a value
      that is not a release tag
- [ ] Test Action passes here, which is what the old arrangement could not do on
      a bump