### PR TITLE
fix: map aarch64 to arm64 in the action's download

### DIFF
--- a/.github/workflows/ci-action.yml
+++ b/.github/workflows/ci-action.yml
@@ -55,7 +55,10 @@ jobs:
   test:
     name: Test Action
     needs: download
-    if: always() # A failed matrix would otherwise skip this, and a skipped required check never reports.
+    # Not `always()`: that reports a hard failure on `Test Action` when a run is
+    # cancelled. This still runs when the matrix fails, which is the case that
+    # would otherwise skip the gate and leave the required check unreported.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     permissions: {}

--- a/.github/workflows/ci-action.yml
+++ b/.github/workflows/ci-action.yml
@@ -9,8 +9,18 @@ on:
 jobs:
 
   test:
-    name: Test Action
-    runs-on: ubuntu-latest
+    name: Test Action - ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+
+    strategy:
+      fail-fast: false
+      # The entrypoint builds the asset name from `uname -m`, which differs
+      # between these two, so testing only one leaves the other's name
+      # unchecked. Both are free for public repositories.
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
 
     permissions:
       contents: read # Reading the newest release.

--- a/.github/workflows/ci-action.yml
+++ b/.github/workflows/ci-action.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
 
-  test:
-    name: Test Action - ${{ matrix.runs-on }}
+  download:
+    name: Download - ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
 
     strategy:
@@ -48,3 +48,24 @@ jobs:
         uses: ./
         with:
           version: ${{ steps.release.outputs.tag }}
+
+  # `Test Action` is a required status check on `main`, matched by name, so it
+  # has to stay one context however many runners the matrix grows to. This job
+  # is that name; the matrix reports under its own.
+  test:
+    name: Test Action
+    needs: download
+    if: always() # A failed matrix would otherwise skip this, and a skipped required check never reports.
+    runs-on: ubuntu-latest
+
+    permissions: {}
+
+    steps:
+      - name: Check the matrix result
+        env:
+          RESULT: ${{ needs.download.result }}
+        run: |
+          if [ "$RESULT" != "success" ]; then
+            echo "the action's download matrix did not pass: $RESULT" >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ parsed and therefore what gets reported.
   lists nested inside a blockquote are checked (#368)
 - MD007: measure indentation from the end of the blockquote prefix instead of
   the start of the line (#369)
+- The GitHub Action downloads the `arm64` release asset on arm64 Linux runners,
+  where it previously asked for an `aarch64` one that no release publishes and
+  failed (#395)
 
 ## [0.3.1] - 2026-07-22
 

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -15,6 +15,10 @@ fi
 INSTALL_DIR="$HOME/bin"
 COMMAND_PATH="$INSTALL_DIR/$COMMAND"
 
+# Known broken, tracked in #393: this tests `./mado`, not the `$COMMAND_PATH`
+# below, and the script has no `set -e`. A failed download therefore falls
+# through to whatever `$COMMAND_PATH` already is. Left alone here on purpose,
+# so this fix stays reviewable.
 if [[ ! -x "$COMMAND" ]]; then
   ARCH=$(uname -m)
   UNAME=$(uname -s)

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -18,6 +18,13 @@ COMMAND_PATH="$INSTALL_DIR/$COMMAND"
 if [[ ! -x "$COMMAND" ]]; then
   ARCH=$(uname -m)
   UNAME=$(uname -s)
+  # Linux reports `aarch64` where the release names the same architecture
+  # `arm64`; macOS reports `arm64` already. The asset names come from
+  # `houseabsolute/actions-rust-release` in `cd.yml`, so this mapping follows
+  # what that action publishes, not what `cd.yml` calls the platform.
+  if [[ "$ARCH" == "aarch64" ]]; then
+    ARCH="arm64"
+  fi
   if [[ "$UNAME" == "Darwin" ]]; then
     DOWNLOAD_FILE="mado-macOS-$ARCH.tar.gz"
   elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* || "$UNAME" == MSYS* ]]; then


### PR DESCRIPTION
Fixes #392.

`action/entrypoint.sh` built the asset name straight from `uname -m`:

```bash
DOWNLOAD_FILE="mado-Linux-gnu-$ARCH.tar.gz"
```

Linux reports `aarch64`; the release publishes `mado-Linux-gnu-arm64.tar.gz`.
So on an arm64 Linux runner the action asked for
`mado-Linux-gnu-aarch64.tar.gz`, which no release has, and `wget` 404d. macOS
was unaffected — `uname -m` is `arm64` there, matching the asset. This has been
true since the action was written; it matters now that `ubuntu-24.04-arm` is
free for public repositories.

## What changed

- Map `aarch64` to `arm64` before building the asset name. The mapping is
  unconditional rather than Linux-only: macOS never reports `aarch64`, and the
  Windows release has no arm asset to name either way.
- Run the action on `ubuntu-24.04-arm` as well as `ubuntu-latest`. Without it
  the job only ever exercised the x86_64 asset name, which is why this went
  unnoticed. `fail-fast: false` so one architecture failing still reports the
  other.
- Keep `Test Action` a single status context. It is required by name in the
  `main` ruleset, so naming the matrix legs after it left the required check
  unreported and blocked every pull request on a status that would never
  arrive. The matrix now reports as `Download - <runner>` and a job named
  `Test Action` gates on it, which also means adding a runner later does not
  touch the ruleset.

The asset names come from `houseabsolute/actions-rust-release`, not from
`cd.yml` — `cd.yml` calls the platform `Linux-aarch64` while the published file
says `arm64`. The comment in `entrypoint.sh` says so, because the next person
reading `cd.yml` would otherwise conclude the mapping is backwards.

## Verification

Locally, with `uname` stubbed, against the assets `gh release view` lists for
`v0.3.1`:

| `uname -s` | `uname -m` | asset named | exists |
| --- | --- | --- | --- |
| `Linux` | `aarch64` | `mado-Linux-gnu-arm64.tar.gz` | yes |
| `Linux` | `x86_64` | `mado-Linux-gnu-x86_64.tar.gz` | yes |
| `Darwin` | `arm64` | `mado-macOS-arm64.tar.gz` | yes |
| `Darwin` | `x86_64` | `mado-macOS-x86_64.tar.gz` | yes |
| `MINGW64_NT-10.0` | `x86_64` | `mado-Windows-msvc-x86_64.zip` | yes |

The first row is the regression; before this change it named
`mado-Linux-gnu-aarch64.tar.gz`. The `ubuntu-24.04-arm` leg of `Test Action` is
what keeps it from coming back.

## Out of scope, deliberately

`action/entrypoint.sh` has problems this pull request does not touch, all of
them tracked in #393 and now noted at the guard itself so the next reader finds
the issue rather than the bug:

- No `set -e`, and an install guard testing `./mado` instead of the
  `$COMMAND_PATH` it runs. A failed download falls through `tar` and `rm` and
  runs whatever `$HOME/bin/mado` already is — **exiting 0 on a 404** if an
  earlier step in the same job installed one. Reproduced and written up in
  https://github.com/akiomik/mado/issues/393#issuecomment-5537769613. This is
  why #392 surfaced as `./mado: not found` rather than a 404.
- `action.yml` passes `INSTALL_DIR: .`, which `entrypoint.sh` overwrites
  unconditionally. Dead env, and the reason the guard is relative. Also in that
  comment.

Both are one-line temptations, and both are why #390 turned into a 15-round
review: it started as one CI fix and accumulated this same script's hardening.
#393 exists to hold them, and one of its items (keying the install by version)
is a change to what the action promises, not a bug fix — so the set is worth
landing together, deliberately, rather than piecemeal here.

The matrix legs in this pull request each run one action step on a fresh
runner, so no stale binary could have masked the arm64 result above; the log
shows the `arm64` asset actually being fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWNoFSfDhBzXEX9UL68oqf
