### PR TITLE
fix: repair the acceptance and benchmark shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,38 @@ just test
 just lint
 ```
 
+### Acceptance Testing
+
+Compares what mado and [`mdl`](https://github.com/markdownlint/markdownlint)
+report for markdownlint's own rule fixtures. This needs `mdl`, `cargo` and
+`git` on `PATH`.
+
+```bash
+# Download the fixtures and set aside the ones written against their own style
+./scripts/acceptance/setup.sh
+
+# Write each tool's findings to tmp/mdl.txt and tmp/mado.txt
+./scripts/acceptance/test.sh
+
+diff tmp/mdl.txt tmp/mado.txt
+```
+
+That diff is not expected to be empty. Some of it is the two tools disagreeing
+and some of it is the two configurations differing, which is being worked out
+in [#401](https://github.com/akiomik/mado/issues/401).
+
 ### Benchmarking
+
+This needs [`hyperfine`](https://github.com/sharkdp/hyperfine),
+[`mdl`](https://github.com/markdownlint/markdownlint), `node`, `npm`, `cargo`
+and `git` on `PATH`.
 
 ```bash
 # Download Markdown dataset
 ./scripts/benchmarks/setup.sh
+
+# Install the markdownlint commands the comparison runs against
+npm --prefix scripts/benchmarks ci
 
 # Benchmark mado, mdl and markdownlint-cli using hyperfine
 ./scripts/benchmarks/comparison.sh

--- a/scripts/acceptance/setup.sh
+++ b/scripts/acceptance/setup.sh
@@ -1,21 +1,107 @@
 #!/bin/sh
 
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
+# `CDPATH=` because `cd` resolves a relative operand through it and echoes
+# where it landed, which would end up in this substitution.
+# shellcheck disable=SC1007  # `CDPATH=` is the point, not a typo
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd) || exit 1
 DATA_ROOT=$SCRIPT_DIR/data
+CLONE_DIR=$DATA_ROOT/markdownlint
 
-cd $DATA_ROOT
+# The only tool this script needs, asked for the way `test.sh` and
+# `comparison.sh` ask for theirs: absent, the clone below fails and the `cd`
+# after it points at a directory rather than at the missing `git`.
+if ! command -v git > /dev/null; then
+  echo "git is not installed" >&2
+  exit 1
+fi
+
+cd "$DATA_ROOT" || exit 1
 git clone --sparse --filter=blob:none https://github.com/markdownlint/markdownlint.git
-cd markdownlint
-git sparse-checkout set test/rule_tests
-git checkout
+# Everything below takes the repository the working directory belongs to, so
+# arriving here matters, and by absolute path: a relative one goes through
+# `CDPATH`. A directory that exists without being a repository still passes
+# this and sends those commands into mado itself; that is #399.
+cd "$CLONE_DIR" || exit 1
+# `cd` proves the directory is there, not that it is the clone, and git resolves
+# `.git` upward: against a directory that exists without being a repository,
+# the commands below reach mado's own and `sparse-checkout set` empties its
+# working tree. Testing for the directory, for a `.git` inside it, and setting
+# `GIT_CEILING_DIRECTORIES` all failed to catch that; #399 has why.
+#
+# Asking for the prefix rather than comparing paths: it is empty only when the
+# working directory *is* a repository's top level, and comparing
+# `--show-toplevel` against `pwd -P` would call a good clone bad wherever the
+# two spell the same directory differently, as Git for Windows does.
+if ! prefix=$(git rev-parse --show-prefix 2> /dev/null) || [ -n "$prefix" ]; then
+  echo "$CLONE_DIR is not a git repository; remove it and run this again" >&2
+  exit 1
+fi
 
-# TODO: Support each styles
-style_files=$(find data/markdownlint/test/rule_tests -name '*_style.rb')
-for style_file in $style_files; do
-  if [ $style_file -eq "data/markdownlint/test/rule_tests/default_test_style.rb" ]; then
-    continue
-  fi
+git sparse-checkout set test/rule_tests || exit 1
+git checkout || exit 1
 
-  markdown_file=$(echo $style_file | sed 's/_style.rb$/.md/')
-  mv $markdown_file $markdown_file.bak
-done
+# Set aside the fixtures that cannot be compared, leaving the ones both tools
+# can be pointed at.
+#
+# Upstream pairs some fixtures with an `X_style.rb`, and `test/test_rules.rb`
+# loads it to select the rules that fixture is checked against and to set their
+# parameters: `long_lines_100_style.rb` is `rule 'MD013', :line_length => 100`
+# beside a document written to that width. `test.sh` cannot reproduce it: it
+# runs each tool once, mdl under `.mdlrc` and mado under the `mado.toml` beside
+# it, and neither of those is the fixture's own style. The document would be
+# read at whatever width those two say, so comparing it there measures the
+# fixture's style rather than the two tools.
+#
+# TODO: apply the per-fixture styles instead of skipping them, and drop this.
+
+# Relative to the clone `cd`ed into above, not to the repository root.
+# `default_test_style.rb` is the fallback `test_rules.rb` uses for every fixture
+# without a style of its own, so it names no document.
+#
+# Handed to `find -exec` rather than iterated as a word list: an unquoted
+# expansion is not split at all under zsh, which would make the whole list one
+# iteration. `test.sh` reads the corpus the same way.
+# The body below is keyed on the document, not on the `.bak`: those are
+# untracked, so a `git restore` in the clone brings the documents back and
+# leaves them, and keying on them would skip every fixture in silence.
+#
+# Neither present means it derives no document from that style file. Not fatal,
+# there being nothing in the corpus to have left there, and upstream may add a
+# second shared style file beside the fallback.
+#
+# Written out here rather than inside the single-quoted body, where one
+# apostrophe in a later edit would close the quote and hand `find` a different
+# operand list.
+set_aside=$(
+  find test/rule_tests -name '*_style.rb' ! -name 'default_test_style.rb' \
+    -exec sh -c 'for style_file in "$@"; do
+      markdown_file=${style_file%_style.rb}.md
+
+      if [ -f "$markdown_file" ]; then
+        mv "$markdown_file" "$markdown_file.bak" || exit 1
+        printf .
+      elif [ -f "$markdown_file.bak" ]; then
+        printf .
+      else
+        echo "no document for $style_file" >&2
+      fi
+    done' _ {} +
+) || exit 1
+
+# Having set nothing aside must not pass for having done the job: a corpus with
+# no fixtures in it, or one holding only the fallback style file, would
+# otherwise exit 0.
+if [ -z "$set_aside" ]; then
+  echo "set nothing aside under $(pwd)/test/rule_tests" >&2
+  echo "if the documents are gone too, restore them with: git restore ." >&2
+  exit 1
+fi
+
+# Said out loud because the dots above are the count and are captured rather
+# than printed. What a re-run does print (`git clone` reporting the directory
+# already exists, and `git checkout` listing every set-aside document as
+# deleted) reads like a run that went wrong.
+#
+# A statement about the corpus, not about this run: the count includes the
+# fixtures a previous run set aside, which this one had nothing to do for.
+echo "$(printf %s "$set_aside" | wc -c | tr -d ' ') fixtures are set aside" >&2

--- a/scripts/acceptance/test.sh
+++ b/scripts/acceptance/test.sh
@@ -1,15 +1,194 @@
 #!/bin/sh
+#
+# Writes what mdl and mado each report for the acceptance corpus, to
+# `tmp/mdl.txt` and `tmp/mado.txt`. Comparing them is the caller's to do; this
+# says nothing about whether they agree.
 
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
-PROJECT_ROOT=($SCRIPT_DIR/../../)
+# shellcheck disable=SC1007  # `CDPATH=` is the point, not a typo
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd) || exit 1
+PROJECT_ROOT=$SCRIPT_DIR/../..
 DATA_ROOT=$SCRIPT_DIR/data
 DOC_PATH=$DATA_ROOT/markdownlint/test/rule_tests
 TEMP_PATH=$PROJECT_ROOT/tmp
+# Named once, so the guard below and the runs further down cannot drift apart:
+# checking a file the run does not use is the failure this guards against.
+MDL_CONFIG=$SCRIPT_DIR/.mdlrc
+MADO_CONFIG=$SCRIPT_DIR/../benchmarks/mado.toml
 
-mdl --config $SCRIPT_DIR/.mdlrc $DOC_PATH > $TEMP_PATH/mdl.txt
-cargo run check --output-format=mdl $DOC_PATH > $TEMP_PATH/mado.txt
+# `tmp/` at the repository root is gitignored and nothing else creates it, so
+# on a fresh clone both redirects below fail and the `sed`s run against files
+# that are not there. A redirection that fails does not end a non-interactive
+# shell, so an unchecked `mkdir` would land back in exactly that state.
+mkdir -p "$TEMP_PATH" || exit 1
 
-# Truncate unnecessary texts
-sed -i '' -e "/^Further documentation is available for these failures:/d" $TEMP_PATH/mdl.txt > /dev/null
-sed -i '' -e "/^ - /d" $TEMP_PATH/mdl.txt > /dev/null
-sed -i '' -e "/^Found /d" $TEMP_PATH/mado.txt > /dev/null
+# Before the guards, so that stopping at one of them leaves no pair behind. A
+# previous run's would otherwise sit there looking finished and be read as this
+# one's. That does cost a good pair when a precondition fails, which is the
+# trade taken deliberately: these two are regenerable by re-running, and being
+# misled by them is not recoverable in the same way.
+#
+# Everything below writes to working names and moves both into place at the
+# end, which covers the same ground for the steps after the guards.
+rm -f "$TEMP_PATH/mdl.txt" "$TEMP_PATH/mado.txt"
+
+# The working names, on every exit between here and the final rename, which
+# would otherwise leave some of them to sit until the next run.
+#
+# The second trap is not redundant: an `EXIT` trap runs when a signal is caught
+# but not when the shell dies from an uncaught one, and `dash` and `zsh` both
+# leave the debris on a `TERM`, a CI cancelling a job. Exiting from the
+# signal handler is what reaches the cleanup.
+trap 'rm -f "$TEMP_PATH/mdl.part" "$TEMP_PATH/mado.part" \
+  "$TEMP_PATH/mdl.done" "$TEMP_PATH/mado.done"
+  [ -f "$TEMP_PATH/mdl.txt" ] && [ -f "$TEMP_PATH/mado.txt" ] ||
+    rm -f "$TEMP_PATH/mdl.txt" "$TEMP_PATH/mado.txt"' EXIT
+trap 'exit 1' INT TERM HUP
+
+# Ahead of the build, all of these being cheap and none a precondition for it.
+# Each is separable from what the tools reported, which is deliberately not
+# checked: both exit non-zero when they find violations, the normal case here.
+#
+# `mdl` is a Ruby gem that nothing here installs, and an absent one leaves the
+# redirect's empty `mdl.txt` reading as mdl having found nothing. `cargo` fails
+# loudly rather than quietly, but a contributor without a Rust toolchain should
+# hear about it here rather than after the other guards have run.
+for tool in mdl cargo; do
+  if ! command -v "$tool" > /dev/null; then
+    echo "$tool is not installed" >&2
+    exit 1
+  fi
+done
+
+# The two configs themselves, which this script now names rather than leaves to
+# discovery. `mado --config` on a file that is not there exits 1 with nothing on
+# stdout, indistinguishable from finding violations, and `mdl` exits 3 the same
+# way; either leaves an empty file reading as that tool having found nothing.
+# `.mdlrc` is a symlink into `../benchmarks`, so this catches a broken one too.
+for config_file in "$MDL_CONFIG" "$MADO_CONFIG"; do
+  if [ ! -f "$config_file" ]; then
+    echo "$config_file does not exist" >&2
+    exit 1
+  fi
+done
+
+# `mado check` on a path that is not there exits 0, saying only "All checks
+# passed!" on stdout and putting the reason on stderr, and `mdl` prints nothing
+# at all, so this would otherwise compare two files with no findings in them.
+if [ ! -d "$DOC_PATH" ]; then
+  echo "$DOC_PATH does not exist; run setup.sh first" >&2
+  exit 1
+fi
+
+# And that `setup.sh` did its half of the job, not merely that it ran once.
+# Searched recursively, as `setup.sh` searches, so the two cannot disagree
+# about what the corpus holds if it ever stops being flat.
+style_files=$(find "$DOC_PATH" -name '*_style.rb') || exit 1
+documents=$(find "$DOC_PATH" -name '*.md') || exit 1
+
+# A corpus with nothing in it lints clean, which is the same "answer without
+# having run anything" as the cases above.
+if [ -z "$style_files" ] || [ -z "$documents" ]; then
+  echo "no fixtures in $DOC_PATH; run setup.sh" >&2
+  exit 1
+fi
+
+# What `setup.sh` leaves behind is the absence of a document beside any style
+# file, so that is what to look for. Not the `.bak` files: those are untracked,
+# and a `git restore` inside the clone brings the documents back while leaving
+# every one of them in place. Comparing those under one shared config is the
+# wrong answer rather than no answer.
+# Collected rather than piped into a loop. `$DOC_PATH` is absolute, so every
+# result carries the checkout's own path and a space in it would split the list
+# into pieces that exist nowhere; and an `exit` in the last stage of a pipeline
+# ends the whole script on the shells that run that stage in the current one,
+# taking the message below with it.
+leftover=$(
+  find "$DOC_PATH" -name '*_style.rb' ! -name 'default_test_style.rb' \
+    -exec sh -c 'for f; do
+      if [ -f "${f%_style.rb}.md" ]; then printf "%s\n" "$f"; fi
+    done' _ {} +
+) || exit 1
+
+if [ -n "$leftover" ]; then
+  echo "fixtures are not set aside in $DOC_PATH; run setup.sh" >&2
+  exit 1
+fi
+
+# `cargo run` finds its project through the working directory, so run from
+# anywhere else it exits 101 into an already-created, empty `mado.txt` that
+# compares as mado having found nothing.
+cd "$PROJECT_ROOT" || exit 1
+
+# A failed build is that same empty file, and `cargo run`'s status cannot be
+# told apart from mado's.
+cargo build || exit 1
+
+
+# Not gated on what they found, both returning 1 for violations, the normal
+# case; but anything above that is the tool failing, and the redirect has already
+# truncated the file it would have written to. mado buffers and writes at the
+# end, so a panic leaves an empty one that reads as having found nothing.
+mdl --config "$MDL_CONFIG" "$DOC_PATH" > "$TEMP_PATH/mdl.part"
+rc=$?
+if [ "$rc" -gt 1 ]; then
+  echo "mdl exited $rc" >&2
+  exit 1
+fi
+
+# And not merely that it exited politely: mdl says nothing at all when its
+# config names a rule this version does not implement, exiting 0 as it does so.
+# It also says nothing when the corpus is clean, which cannot be told apart
+# from here, and either way there is nothing to compare, so stopping is right
+# and the message names both.
+if [ ! -s "$TEMP_PATH/mdl.part" ]; then
+  echo "mdl reported nothing: a clean corpus, or a rule it does not know" >&2
+  exit 1
+fi
+
+# Named, rather than left to whichever `mado.toml` the working directory turns
+# up. The repository's own is mado's self-lint config and reports differently
+# from what `.mdlrc` asks of mdl: `allow-different-nesting = true` there
+# hides MD024 divergences this corpus exists to surface. `../benchmarks` holds
+# the counterpart: the same `.mdlrc` (this one is a symlink to it) beside the
+# `mado.toml` written to go with it. Not a perfect match either: its
+# `[lint.md007] indent = 4` is mdl's 3, which is most of what the two still
+# disagree about, but it is the pair, and #401 is where that is settled.
+#
+# `< /dev/null` because mado lints stdin instead of the paths given when stdin
+# is neither a terminal nor empty. An empty one falls through to the paths, so
+# this is about content: piped so much as a newline, mado would report on that
+# and call the corpus clean.
+#
+# `--` because `--config` means something to cargo too, and mado takes it
+# before the subcommand.
+cargo run -- --config "$MADO_CONFIG" \
+  check --output-format=mdl "$DOC_PATH" > "$TEMP_PATH/mado.part" < /dev/null
+rc=$?
+if [ "$rc" -gt 1 ]; then
+  echo "mado exited $rc" >&2
+  exit 1
+fi
+
+# A malformed config is the case this catches: mado exits 1 with nothing on
+# stdout, which is what finding violations looks like.
+if [ ! -s "$TEMP_PATH/mado.part" ]; then
+  echo "mado wrote nothing" >&2
+  exit 1
+fi
+
+# Truncate unnecessary texts.
+#
+# Reading one name and writing another rather than `sed -i ''`: the empty
+# suffix is BSD's spelling, and GNU sed reads it as another input file, so the
+# same line prints `can't read :` and exits non-zero having edited the file
+# correctly. This form works the same everywhere and can be checked.
+sed -e "/^Further documentation is available for these failures:/d" \
+  -e "/^ - /d" "$TEMP_PATH/mdl.part" > "$TEMP_PATH/mdl.done" || exit 1
+sed -e "/^Found /d" "$TEMP_PATH/mado.part" > "$TEMP_PATH/mado.done" || exit 1
+
+# Both, and only once both are ready. The trap asks whether the pair is there
+# rather than whether the run reached a flag, so there is no window in which a
+# signal can catch it: after the first rename only one exists and both go, and
+# after the second both exist and both stay.
+mv "$TEMP_PATH/mdl.done" "$TEMP_PATH/mdl.txt" || exit 1
+mv "$TEMP_PATH/mado.done" "$TEMP_PATH/mado.txt" || exit 1

--- a/scripts/benchmarks/comparison.sh
+++ b/scripts/benchmarks/comparison.sh
@@ -1,14 +1,150 @@
 #!/bin/sh
 
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
-PROJECT_ROOT=($SCRIPT_DIR/../..)
+# shellcheck disable=SC1007  # `CDPATH=` is the point, not a typo
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd) || exit 1
+PROJECT_ROOT=$SCRIPT_DIR/../..
 DATA_ROOT=$SCRIPT_DIR/data
+# Where cargo will have put the binary. `CARGO_TARGET_DIR` moves the root and
+# `CARGO_BUILD_TARGET` adds a triple below it; `build.target-dir` and
+# `build.target` in a cargo config do the same and cannot be seen from here.
+TARGET_DIR=${CARGO_TARGET_DIR:-$PROJECT_ROOT/target}
+if [ -n "$CARGO_BUILD_TARGET" ]; then
+  TARGET_DIR=$TARGET_DIR/$CARGO_BUILD_TARGET
+fi
 DOC_PATH=$DATA_ROOT/gitlab/doc
 
-cargo build --release
+# Named once, so the guards below, the smoke test and the commands hyperfine
+# runs cannot drift apart.
+MADO_BIN=$TARGET_DIR/release/mado
+MADO_CONFIG=$SCRIPT_DIR/mado.toml
+MDL_CONFIG=$SCRIPT_DIR/.mdlrc
+MARKDOWNLINT_BIN=$SCRIPT_DIR/node_modules/.bin/markdownlint
+MARKDOWNLINT_CLI2_BIN=$SCRIPT_DIR/node_modules/.bin/markdownlint-cli2
+MARKDOWNLINT_CONFIG=$SCRIPT_DIR/.markdownlint.jsonc
 
+# `cargo build` finds its project through the working directory, and hyperfine
+# runs with `--ignore-failure`, so from anywhere else this would build nothing
+# and then time whatever stale binary is on disk, or a `command not found` at
+# microsecond speed, and report either as a result.
+cd "$PROJECT_ROOT" || exit 1
+
+# Every command hyperfine is about to time, asked for before any of them runs.
+# A missing one is not an error to hyperfine: it times the shell failing to
+# start it, in microseconds, and prints that beside mado's real number. Nothing
+# installs `node_modules` here, so those two are absent on a fresh clone rather
+# than exceptionally.
+for tool in hyperfine mdl node cargo; do
+  if ! command -v "$tool" > /dev/null; then
+    echo "$tool is not installed" >&2
+    exit 1
+  fi
+done
+
+# `node` among them because both of these are `#!/usr/bin/env node` wrappers,
+# so `-x` says they can be started while they cannot run. A `node_modules`
+# restored from a cache rather than installed is where that shows up.
+#
+# `-x` rather than `command -v`, which is only exact for a name looked up on
+# `PATH`: given a path, dash reports an existing file as found whether or not
+# it can be run, so an unpacked-but-not-executable one would clear the check
+# and hyperfine would time "permission denied" instead.
+for tool in "$MARKDOWNLINT_BIN" "$MARKDOWNLINT_CLI2_BIN"; do
+  if [ ! -x "$tool" ]; then
+    echo "$tool is not executable; run: npm --prefix \"$SCRIPT_DIR\" ci" >&2
+    exit 1
+  fi
+done
+
+# What they are given, on the same reasoning: hyperfine cannot tell a tool that
+# refused to start from one that ran. `$DOC_PATH` comes from `setup.sh`, which
+# nothing here invokes.
+# Present but empty counts as absent here: none of `setup.sh`'s git commands is
+# checked, so a sparse-checkout that resolved to nothing leaves the directory
+# there, and hyperfine would time four tools linting no files.
+if [ ! -d "$DOC_PATH" ]; then
+  echo "$DOC_PATH does not exist; run setup.sh first" >&2
+  exit 1
+fi
+
+# Below that test, not above it: on a fresh clone `find` would otherwise fail
+# on the missing directory first and report it in its own words.
+#
+# `-quit` rather than `| head -n 1`, which would hide a `find` that failed
+# outright behind the same message as an empty corpus, and make GNU findutils
+# report a broken pipe on a corpus this size. It is a GNU and BSD extension,
+# which is the whole of what runs a script needing cargo, node and a Ruby gem.
+first_document=$(find "$DOC_PATH" -name '*.md' -print -quit) || exit 1
+
+if [ -z "$first_document" ]; then
+  echo "$DOC_PATH holds no documents; run setup.sh first" >&2
+  exit 1
+fi
+
+for config_file in "$MADO_CONFIG" "$MDL_CONFIG" "$MARKDOWNLINT_CONFIG"; do
+  if [ ! -f "$config_file" ]; then
+    echo "$config_file does not exist" >&2
+    exit 1
+  fi
+done
+
+# Unchecked, a compile error leaves the previous `target/release/mado` in place
+# for hyperfine to time and report as this tree's number.
+cargo build --release || exit 1
+
+# And that it landed where hyperfine will look: `CARGO_TARGET_DIR`, a
+# `build.target-dir` in the cargo config, or a configured target triple all put
+# it elsewhere, and a build that succeeded says nothing about that. Everything
+# else timed below is checked; the thing under test should be too.
+if [ ! -x "$MADO_BIN" ]; then
+  echo "no mado at $MADO_BIN" >&2
+  echo "a cargo config's build.target-dir or build.target moves it, and this" >&2
+  echo "reads only CARGO_TARGET_DIR and CARGO_BUILD_TARGET" >&2
+  exit 1
+fi
+
+# Started once each, because being present and executable is not the same as
+# working: a `node_modules` restored from a stale cache leaves the wrappers
+# runnable and `node` installed, and they still die on `MODULE_NOT_FOUND` in
+# milliseconds, which `--ignore-failure` would print as the fastest tool here.
+# `--version` is enough to make each resolve itself.
+#
+# It does not cover a config a tool starts up and then rejects; that is #400.
+for tool in "$MADO_BIN" mdl "$MARKDOWNLINT_BIN"; do
+  if ! "$tool" --version > /dev/null 2>&1; then
+    echo "$tool does not run" >&2
+    exit 1
+  fi
+done
+
+# `markdownlint-cli2` has no version flag; it reads every argument as a glob,
+# so `--version` would only pass by being treated as one. A pattern that
+# matches nothing is the same no-op, said on purpose. It reads its config
+# on the way, which the other three probes do not: `markdownlint` accepts a
+# broken one without complaint when nothing matches, so that half stays #400.
+if ! "$MARKDOWNLINT_CLI2_BIN" --config "$MARKDOWNLINT_CONFIG" \
+  'zz-no-such-file-*.md' > /dev/null 2>&1; then
+  echo "$MARKDOWNLINT_CLI2_BIN does not run" >&2
+  exit 1
+fi
+
+# Passed through the environment rather than pasted into the command strings.
+# hyperfine hands each string to a shell, so a path with a space in it has to
+# be quoted somehow, and quoting it here would only move the problem to
+# apostrophes: a checkout under `/Users/o'brien` would close the quote early.
+# Naming the values instead leaves the quoting to the shell that expands them.
+#
+# Without this the commands fail to start and `--ignore-failure` reports that
+# as a sub-millisecond timing beside the real numbers.
+export MADO_BIN MADO_CONFIG MDL_CONFIG DOC_PATH \
+  MARKDOWNLINT_BIN MARKDOWNLINT_CLI2_BIN MARKDOWNLINT_CONFIG
+
+# Named, because the command strings are now variable references and hyperfine
+# labels its results with them: without these the table says
+# `"$MADO_BIN" --config …` for every run, and two runs against different
+# binaries print identical labels.
 hyperfine --ignore-failure --warmup 10 \
-  "$PROJECT_ROOT/target/release/mado --config $SCRIPT_DIR/mado.toml check $DOC_PATH" \
-  "mdl --config $SCRIPT_DIR/.mdlrc $DOC_PATH" \
-  "$SCRIPT_DIR/node_modules/.bin/markdownlint --config $SCRIPT_DIR/.markdownlint.jsonc $DOC_PATH" \
-  "$SCRIPT_DIR/node_modules/.bin/markdownlint-cli2 --config $SCRIPT_DIR/.markdownlint.jsonc \"$DOC_PATH/**/*.md\""
+  -n mado '"$MADO_BIN" --config "$MADO_CONFIG" check "$DOC_PATH"' \
+  -n mdl 'mdl --config "$MDL_CONFIG" "$DOC_PATH"' \
+  -n markdownlint '"$MARKDOWNLINT_BIN" --config "$MARKDOWNLINT_CONFIG" "$DOC_PATH"' \
+  -n markdownlint-cli2 \
+  '"$MARKDOWNLINT_CLI2_BIN" --config "$MARKDOWNLINT_CONFIG" "$DOC_PATH/**/*.md"'


### PR DESCRIPTION
Three bugs that stop the development scripts from doing what they say. None is
user-visible, so there is no changelog entry.

## The fixture loop has never run

`scripts/acceptance/setup.sh` sets aside the fixtures that cannot be compared.
Upstream pairs some with an `X_style.rb`, and `test/test_rules.rb`
(`do_lint`, `do_fix_lint`) loads it to select the rules that fixture is checked
against **and to set their parameters**:

```ruby
# long_lines_100_style.rb, beside a document written to 100 columns
rule 'MD013', :line_length => 100
```

`test.sh` cannot reproduce that. It runs each tool once with a config of its
own — mdl under `scripts/acceptance/.mdlrc`, mado under whatever `mado.toml`
the working directory yields — and neither of those is the fixture's style, so
the document is read at whatever width *they* say. The fixtures with a style
file are exactly the parameter-sensitive ones (MD003, MD004, MD013, MD035,
MD046 and so on), which is why they are set aside rather than compared.

(Reviewing this turned up that those two configs do not match each other either
— mado is given `indent = 4` for MD007 where mdl uses its default of 3, among
others — which makes `test.sh` working-directory dependent and puts part of
#401's divergence down to the harness. Recorded there; not something this pull
request changes.)

The loop that does this did nothing, for two reasons that hid each other:

1. `find data/markdownlint/test/rule_tests` is relative, and the script has
   already `cd`ed into that clone, so it searched
   `.../markdownlint/data/markdownlint/test/rule_tests` and found nothing.
2. Fixing the path exposes `[ $style_file -eq "..." ]`, an integer comparison,
   which raises `Illegal number` on every iteration.

`default_test_style.rb` is skipped because it is the shared fallback
`test_rules.rb` uses for every fixture *without* a style of its own — which is
why it is the only style file with no `.md` beside it.

## A bash array in `#!/bin/sh`

`test.sh` and `comparison.sh` both had `PROJECT_ROOT=($SCRIPT_DIR/../..)`.
`dash -n` rejects them at line 4 with `Syntax error: "(" unexpected`. They ran
on macOS only because `/bin/sh` there is bash, where expanding an array without
a subscript yields its first element.

## Making the loop run

Most of the diff is what running it for the first time requires:

| state | result |
| --- | --- |
| document present | set aside |
| document gone, `.bak` present | nothing, exit 0 |
| document restored by `git restore`, `.bak` present | set aside again |
| neither present | named on stderr, exit 0 |
| nothing set aside at all | named on stderr, exit 1 |
| `mv` fails | the run fails, exit 1 |

Keyed on the document rather than on the `.bak`: this loop leaves the clone
permanently dirty, so `git restore` inside it is a natural thing to do, and it
brings the documents back while leaving the untracked `.bak` files alone.

The last row is not incidental hardening — a silent, successful exit having
done nothing is how this bug looked from outside for nine months. It counts
what was set aside rather than checking that `find` matched something, because
matching something is not the claim: a corpus holding only the fallback style
file matches and still sets nothing aside.

It claims nothing about *why* the corpus is wrong, so both `cd`s are checked as
well. Switching `find` to a clone-relative path makes arriving there
load-bearing in a way it was not before, and until now a failed clone let the
two git commands after it loose on mado's own repository. That closes the
clone-failed case; a `markdownlint/` that exists without being a repository
still passes `cd`, and that is #399.

## The line every path derives from

`SCRIPT_DIR=$(cd $(dirname $0); pwd)` is unquoted in each of these scripts, and
its `cd` is unguarded twice over. A checkout path containing a space
word-splits `$(dirname $0)`; and `$(dirname "$0")` is a *relative* operand when
the script is invoked by a relative path, so `cd` resolves it through `CDPATH`
and echoes where it landed — into the substitution:

```
$ cd /tmp/sp && CDPATH=. dash x/s.sh
[/tmp/sp/x
/tmp/sp/x]                      # the path twice, newline-separated
$ cd /tmp/sp && CDPATH=/tmp/decoy dash x/s.sh
[/tmp/decoy/x ...]              # the wrong tree
```

Now `SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd) || exit 1`. `setup.sh` reaches
its clone by absolute path for the same reason: `cd markdownlint` with `CDPATH`
set lands in an unrelated directory that happens to hold one, successfully, so
the guard above it never fires.

## `test.sh` could not run on a fresh clone

`tmp/` at the repository root is gitignored and nothing creates it, so both
redirects failed and the `sed`s ran against files that were not there. It works
in an existing checkout only because the directory happens to be there.

It now checks what it needs before producing anything, each of these being
separable from what the tools reported:

| | without it |
| --- | --- |
| `mkdir -p "$TEMP_PATH" \|\| exit 1` | a failed redirection does not end a non-interactive shell |
| `cd "$PROJECT_ROOT"` | `cargo run` exits 101 into an already-created empty `mado.txt` |
| `cargo build \|\| exit 1` | a failed build leaves the same empty file |
| `command -v mdl`, `command -v cargo` (`git` in `setup.sh`; `hyperfine`, `node`, `cargo` in `comparison.sh`) | the gem nothing here installs leaves `mdl.txt` reading as mdl finding nothing; `cargo` fails loudly, but a contributor without a toolchain should hear it here |
| `[ -d "$DOC_PATH" ]` | `mado check` on a missing path exits 0 saying "All checks passed!" |
| `< /dev/null` on the mado run | mado lints stdin instead of the given paths when stdin is neither a terminal nor empty, so piping a single newline into this script made it report on that and call the corpus clean — non-empty output, zero status, every guard satisfied. An empty stdin falls through to the paths, which is why `comparison.sh` needs no redirect |
| no document beside any style file | after a `git restore` in the clone, the set-aside documents are back and get compared under one shared config |
| `SCRIPT_DIR` non-empty | a failed `cd` there makes every derived path root-relative — `DOC_PATH` becomes `/data/markdownlint/test/rule_tests` |
| the corpus exists, then is not empty | nothing to lint produces two files that compare equal; the order matters, `find` otherwise failing on a missing directory in its own words before the message meant for it |
| each tool wrote something | mdl says nothing both when its config names a rule it lacks and when the corpus is clean; either way there is nothing to compare |
| both config files exist | `mado --config` on a missing file exits 1 with empty stdout, which is what violations look like; `mdl` exits 3 the same way. Named once, so the guard and the runs cannot drift apart |
| each benchmarked tool starts | `--version` on three of them and a no-match glob for `markdownlint-cli2`, which has no version flag; that one reads its config on the way, where `markdownlint` accepts a broken one without complaint when nothing matches (#400): present and executable is not the same as working, and a `node_modules` from a stale cache dies on `MODULE_NOT_FOUND` in milliseconds, which `--ignore-failure` prints as the fastest tool |

The set-aside check looks for the absence of a document, not for the `.bak`
files: those are untracked, so a `git restore` leaves all of them in place
while bringing the documents back. Same reasoning as `setup.sh`'s own loop, and
it searches recursively as that one does, so the two cannot disagree about the
corpus if upstream ever stops keeping it flat. It collects `find`'s output rather than
piping it into a loop. `$DOC_PATH` is absolute, so a space anywhere in the
checkout path split every result into pieces that exist nowhere and the guard
passed on a corpus it never looked at; and an `exit` in the last stage of a
pipeline ends the script outright on shells that run that stage in the current
one, taking the diagnostic with it. `setup.sh`'s loop is handed to `find -exec`
for the same reason, having had the opposite half of the problem: zsh does not
split an unquoted expansion at all, so `zsh scripts/acceptance/setup.sh` made
the whole list one iteration and set nothing aside. Both scripts read the
corpus the same way now, and all three scripts behave identically under dash,
bash and zsh — `test.sh` only after `status=$?` became `rc=$?`, `status` being
read-only in zsh, where assigning to it killed the script the moment mdl
returned and left an unfiltered `mdl.txt` with no `mado.txt` beside it:

```
$ DOC_PATH="/tmp/sp ace/rt"       # foo_style.rb and foo.md, not set aside
before: exit 0, silent            # tested /tmp/sp and ace/rt/foo.md
after:  exit 1, "fixtures are not set aside in /tmp/sp ace/rt"
```

The three cheap ones run before the build, so a contributor without the gem or
without a corpus is told so immediately rather than after it.


`test.sh` is quoted throughout, not only on line 3 — its `sed` operands split
too, and since `sed` is unchecked the script exited 0 having left `mado.txt`
unfiltered, a wrong answer rather than a missing one. (Their `> /dev/null` went
with them; `sed -i` prints nothing.) `comparison.sh` needed the same
treatment inside its command strings. An earlier revision claimed quoting could
not help there, since hyperfine hands each string to a shell that splits it
again — wrong, and the file disproved it: the `markdownlint-cli2` line already
protected its glob with quotes inside the string, which only works because that
shell honours them.

Quoting them in place is not the fix either, though — it moves the problem from
spaces to apostrophes, and `/Users/o'brien/src/mado` closes the quote early.
The paths go through the environment instead, so the shell that expands them
does the quoting — and each run gets a `-n` name, hyperfine otherwise labelling
its results table with the variable references rather than with what ran:

```
/Users/o'brien/…   quoted in place: fails to start   via environment: runs
/Users/sp ace/…    quoted in place: runs             via environment: runs
```

It does get the same
`cd` as `test.sh`, though, and the checks that go with it: `cargo build
--release` found its project through the working directory there too, and
`--ignore-failure` treats a command that could not start as a result rather
than an error, so it would have timed a stale binary or a `command not found`
at microsecond speed and printed either as this tree's number. It now asks for
`hyperfine`, `mdl`, `node` and both markdownlint commands up front — the
README's prerequisites name all three now — naming `npm ci` as
the remedy for the latter two, and testing those two with `-x` rather than
`command -v` — given a path rather than a name, dash reports an existing file
as found whether or not it can be run. Its corpus has to hold documents rather
than merely exist, none of `benchmarks/setup.sh`'s git commands being checked,
and mado's own binary has to be where cargo put it — a successful
`cargo build` says nothing about that. `CARGO_TARGET_DIR` and
`CARGO_BUILD_TARGET` are honoured for both the check and the command hyperfine
times; their cargo-config equivalents, which a script cannot see, are named in
the failure message instead of the binary being reported as "not built". `node` is on the list because both markdownlint
commands are `#!/usr/bin/env node` wrappers, which `-x` finds startable while
they cannot run.
Nothing installs
`node_modules`, so those two were absent on a fresh clone as the rule rather
than the exception — along with its corpus and its three config files, as
`test.sh` does.

## Neither output file is left half-written

The pair is removed before the guards run, so stopping at one of them leaves
nothing behind: a previous run's complete pair would otherwise sit there
looking finished and be read as this one's. That costs a good pair whenever a
precondition fails, which is the trade taken on purpose: the two files are
regenerable by re-running, and being misled by them is not. Past the guards, both outputs are
built under working names and moved into place only once both are ready, the
trap asking whether the pair is *there* rather than whether the run reached a
flag — so no signal has a window to catch: after the first rename only one
exists and both go, after the second both exist and both stay — which covers
the exits after the tools run — a mado failure used to leave a partial
`mado.txt` beside an unfiltered `mdl.txt`, the filtering happening last.

Verified both ways: tripping the corpus guard, and failing the mado
invocation, each leave the directory empty where the earlier arrangement left
last run's files in place. This matters more now that the README documents
`diff tmp/mdl.txt tmp/mado.txt` as a separate step.

## The clone is checked for being one

`cd "$CLONE_DIR"` proves the directory is there, not that it is the clone, and
git resolves `.git` upward — so a directory that exists without being a
repository sent `sparse-checkout set` and `git checkout` into **mado's own**
repository and emptied its working tree.

Asking git for the prefix — empty only when the working directory is a
repository's own top level — is the first proposal that survives every case the
earlier ones failed:

| | `cd` guard | `.git` test | `GIT_CEILING_DIRECTORIES` | `--show-prefix` |
| --- | --- | --- | --- | --- |
| directory exists, not a repository | passes | passes | rejects | rejects |
| directory holds a bare `.git` | passes | passes | rejects | rejects |
| directory in no repository at all | passes | passes | rejects | rejects |
| `GIT_DIR` exported to the outer repo | passes | passes | passes | rejects |
| a real clone | passes | passes | passes | passes |

The prefix rather than comparing `--show-toplevel` against `pwd -P`: those are
different spellings of the same directory under Git for Windows, where the
comparison would reject a perfectly good clone and re-cloning would never help.

Deferred through four reviews on the grounds that #399 should settle it once
for both scripts; landed here because this pull request is what made arriving
in the clone load-bearing, and the check is now settled rather than guessed.
`benchmarks/setup.sh` still needs it and stays with the issue.

## What is deliberately left unchecked

What the two linters *report*: both exit non-zero on violations, the normal
case here, so gating on that would abort the comparison this exists to produce.
Their statuses are still looked at — anything above 1 is the tool failing
rather than finding something — and each output has to be non-empty, since mado
prints "All checks passed!" when it genuinely finds none.

The `sed`s are no longer among them. They write through a temporary file rather
than `sed -i ''`, whose empty suffix GNU sed reads as another input file: the
same line exits non-zero having edited the file correctly, so the three of them
could not be checked, and a filter that genuinely failed left the trailers in
place under a successful exit. The closing `exit 0` went with them, having
existed only to paper over that status on Linux. That closes the `sed -i ''`
half of #398.

`setup.sh` says how many fixtures are set aside. The dots its loop prints are
the count, captured rather than shown, so a successful re-run's only output was
`git clone` reporting the directory already exists — success and failure looked
alike. It is phrased about the corpus rather than about the run, since the
count includes what an earlier run set aside and this one had nothing to do
for. (Sending the dots to stderr instead, as suggested, empties the capture and
makes the guard below fire every time; the count line is the version that
works.)

`test.sh` clears its working names from a trap rather than at the end. Every
exit between the first tool and the final rename left some of them in `tmp/`
until the next run cleaned up — the published names were always right, the
debris was not. It takes two traps, because an `EXIT` trap runs when a signal
is *caught* but not when the shell dies from an uncaught one:

| | dash | bash | zsh |
| --- | --- | --- | --- |
| `INT`, `EXIT` trap alone | cleaned | cleaned | cleaned |
| `TERM`, `EXIT` trap alone | **debris** | cleaned | **debris** |
| either, plus `trap 'exit 1' INT TERM HUP` | cleaned | cleaned | cleaned |

`TERM` is a CI cancelling a job, so the second trap is the one that matters.

## Raised in review and not changed

Moving the `rm -f` of the published pair below the preconditions, so that a
missing `mdl` does not cost a good pair. Raised twice, and it is a real trade
either way: below them, a precondition failure leaves the previous run's files
for the README's `diff` step to read as current. Kept above, because those two
are regenerable by re-running and being misled by them is not — written down in
the script so it stops being re-decided.

The trailing blank line in `tmp/mado.txt`, said to make `diff tmp/mdl.txt
tmp/mado.txt` permanently dirty. Both files end with exactly one blank line, so
they cancel: 132 differing lines either way, and 132 again with every blank
stripped from both.

## Scope

This reached 122 lines across four review rounds before being cut back. What
came out needs decisions rather than patches, and is tracked:

- **#399** — the same hazard in `benchmarks/setup.sh`, which this does not
  touch: its two `cd`s are unquoted and `git reset --hard <sha>` sits below
  them, so that file wants the whole treatment rather than one check. The
  acceptance side *is* fixed here — see below.
- **#400** — the ways these scripts produce an answer without having run
  anything.
- **#401** — the comparison this restores does not come out clean: 132
  differing lines (`diff | grep -c '^[<>]'`; the full `diff` output is 182,
  the rest being its own separators) over the 52 remaining fixtures. 43 of those are MD007, where
  `benchmarks/mado.toml` says `indent = 4` and mdl defaults to 3 — the one
  parameter in that file that does not match mdl, checked against
  `lib/mdl/rules.rb`. Not changed here, because that file is also what
  `comparison.sh` hands mado, so the value is not the acceptance harness's
  alone to pick.
- **#398** — the remaining `SC2086` quoting. The three instances that issue
  opened with are fixed here: the word-splitting loops go through `find -exec`,
  `sed -i ''` is gone, and hyperfine's command strings carry their own quotes.

The README gains named prerequisites for the benchmark — `hyperfine`, `mdl`,
`node`, `npm`, `cargo`, `git`, all of which its steps need and none of which it
listed — plus the `npm ci` those steps left out, and an Acceptance Testing
section — that flow was documented nowhere and
now fails hard without `mdl`: `node_modules` is
gitignored and nothing installed it, so the documented `setup.sh` then
`comparison.sh` flow could not work on a fresh clone. Developer docs, so no
changelog entry, same as the rest of this.

All four are the same point as #397: `shellcheck` finds none of them, because
they are facts about `git`, `hyperfine` and cargo rather than about shell
syntax.

Two things reviewers raised that are deliberately not here:

- The identical unchecked `cd` pair in `benchmarks/setup.sh`. This pull request
  guards the ones in `acceptance/setup.sh` because changing `find` to a
  clone-relative path made arriving there newly load-bearing; nothing in the
  benchmark script changed, and #399's actual fix replaces those `cd`s rather
  than guarding them. Noted on that issue so the omission is not read as the
  sibling being safe — it is the worse of the two. An earlier revision quoted
  its `SCRIPT_DIR` on its own; that made things worse, because `DATA_ROOT` then
  genuinely carried the space that the still-unquoted `cd $DATA_ROOT` below
  split on. The file wants quoting, both `cd`s guarded, and #399's treatment
  together or not at all, so it is back out of this diff.
- What `mdl` and `cargo run` *report* is still unchecked, deliberately: both
  exit non-zero when they find violations, which is the normal case here, so
  gating on their status would abort the comparison this script exists to
  produce. Whether they ran at all is checked; what they found is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWNoFSfDhBzXEX9UL68oqf









































