### PR TITLE
fix: report inline columns as written inside an escaped table cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ parsed and therefore what gets reported.
   no padding. A span whose delimiters sit on different lines is left unjudged
   rather than reported, since nothing recorded about it describes what was
   written against those delimiters (#391)
+- MD033, MD034, MD037, MD038 and MD039: report the column an inline was written
+  at when it sits in a table cell containing an escaped pipe. Each `\|` before
+  the inline moved the report one column to the left of the character it named
+  (#405)
 
 ## [0.3.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ parsed and therefore what gets reported.
   rather than reported, since nothing recorded about it describes what was
   written against those delimiters (#391)
 - MD033, MD034, MD037, MD038 and MD039: report the column an inline was written
-  at when it sits in a table cell containing an escaped pipe. Each `\|` before
-  the inline moved the report one column to the left of the character it named
-  (#405)
+  at when it sits in a table cell containing an escaped pipe, or in the text
+  above a table's header row. Each `\|` before the inline moved the report one
+  column to the left of the character it named (#405)
 
 ## [0.3.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,11 @@ parsed and therefore what gets reported.
   no padding. A span whose delimiters sit on different lines is left unjudged
   rather than reported, since nothing recorded about it describes what was
   written against those delimiters (#391)
-- MD033, MD034, MD037, MD038 and MD039: report the column an inline was written
-  at when it sits in a table cell containing an escaped pipe, or in the text
-  above a table's header row. Each `\|` before the inline moved the report one
-  column to the left of the character it named (#405)
+- MD033, MD034, MD037, MD038 and MD039: put back the columns an escaped pipe
+  cost the report. A `\|` written earlier in the same table cell, or earlier on
+  the same line above a table's header row, moved an inline's reported column
+  one to the left of the character it named, and one more for each further
+  escape (#405)
 
 ## [0.3.1] - 2026-07-22
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -15,9 +15,21 @@ pub struct Document<'a> {
     pub text: String,
     pub lines: Vec<String>,
 
-    /// Where each column comrak reports on a line was written, for the lines
-    /// where the two part company. See [`Document::written_position`].
-    written_columns: FxHashMap<usize, Vec<usize>>,
+    /// The regions comrak unescaped, by the line they were written on. See
+    /// [`Document::written_position`].
+    unescaped_regions: FxHashMap<usize, Vec<UnescapedRegion>>,
+}
+
+/// A run of one line's columns that comrak unescaped the pipes of before it
+/// parsed the inlines in it.
+#[derive(Debug, Clone)]
+struct UnescapedRegion {
+    /// The column the region begins at, which comrak reports and the line was
+    /// written with alike: nothing has been dropped yet where a region starts.
+    start: usize,
+
+    /// The columns comrak dropped, as written, in the order they appear.
+    dropped: Vec<usize>,
 }
 
 impl<'a> Document<'a> {
@@ -28,14 +40,14 @@ impl<'a> Document<'a> {
         options.extension.table = true;
         let ast = parse_document(arena, &text, &options);
         let lines: Vec<_> = text.lines().map(ToOwned::to_owned).collect();
-        let written_columns = Self::written_columns(ast, &lines, &text);
+        let unescaped_regions = Self::unescaped_regions(ast, &lines, &text);
 
         Ok(Self {
             path,
             ast,
             text,
             lines,
-            written_columns,
+            unescaped_regions,
         })
     }
 
@@ -68,65 +80,103 @@ impl<'a> Document<'a> {
         written
     }
 
+    /// The column as written, for one comrak reports on `line`.
+    ///
+    /// A column belongs to the last region that begins at or before it, and a
+    /// column past that region's content belongs to it all the same: the whole
+    /// of the region's shift applies there, which is what a column just past a
+    /// span at the end of a cell needs.
     fn written_column(&self, line: usize, column: usize) -> usize {
-        self.written_columns
-            .get(&line)
-            .and_then(|columns| columns.get(column))
-            .copied()
-            .unwrap_or(column)
+        let Some(regions) = self.unescaped_regions.get(&line) else {
+            return column;
+        };
+
+        let Some(region) = regions.iter().rev().find(|region| region.start <= column) else {
+            return column;
+        };
+
+        // Each column comrak dropped at or before where the column has reached
+        // is a byte it never reported, so the column moves one further right.
+        let mut written = column;
+        for &dropped in &region.dropped {
+            if dropped > written {
+                break;
+            }
+
+            written += 1;
+        }
+
+        written
     }
 
-    /// The column table [`Document::written_position`] reads, keyed by line.
+    /// The regions [`Document::written_position`] reads, keyed by line.
     ///
-    /// Only a line carrying a region that was written with a `\|` and unescaped
-    /// for it gets an entry; on every other line the two columns are equal, and
-    /// leaving those out keeps the table empty for the documents that have no
-    /// escape at all. Within an entry, index and value are the reported and the
-    /// written column, and an entry reaches as far as the last region it was
-    /// built from — a column past that is one nothing shifted, and reading past
-    /// the end is how [`Document::written_column`] answers for those.
-    fn written_columns(
+    /// Only a line that carries a region comrak dropped a byte from gets an
+    /// entry; on every other line the two columns are equal, and leaving those
+    /// out keeps this empty for the documents that have no escape at all. An
+    /// entry holds every region of its line in the order they were written, so
+    /// that a column can be answered for by the one it falls in rather than by
+    /// the one before it.
+    fn unescaped_regions(
         ast: &'a AstNode<'a>,
         lines: &[String],
         text: &str,
-    ) -> FxHashMap<usize, Vec<usize>> {
-        let mut written_columns = FxHashMap::default();
+    ) -> FxHashMap<usize, Vec<UnescapedRegion>> {
+        let mut unescaped_regions = FxHashMap::default();
 
         // Walking the tree costs more than the escape is common, and a document
         // written without one has no shifted column to correct.
         if !text.contains(r"\|") {
-            return written_columns;
+            return unescaped_regions;
         }
 
         for node in ast.descendants() {
             let position = node.data.borrow().sourcepos;
 
             match node.data.borrow().value {
-                // A cell's own `sourcepos` is built from the raw line rather
+                // A row is taken whole because its cells are unescaped one at a
+                // time: a cell after an escaped one is where the shift stops
+                // rather than carries on, and it can only say so by being here.
+                // The cells' own `sourcepos` is built from the raw line rather
                 // than from the unescaped content, so it is unshifted and gives
-                // the region to walk.
-                NodeValue::TableCell => Self::map_unescaped(
-                    &mut written_columns,
-                    lines,
-                    position.start.line,
-                    position.start.column,
-                    position.end.column,
-                ),
+                // each region's bounds.
+                NodeValue::TableRow(_) => {
+                    let cells: Vec<_> = node
+                        .children()
+                        .map(|cell| {
+                            let cell_position = cell.data.borrow().sourcepos;
+                            Self::unescaped_region(
+                                lines,
+                                cell_position.start.line,
+                                cell_position.start.column,
+                                cell_position.end.column,
+                            )
+                        })
+                        .collect();
+
+                    if cells.iter().any(|cell| !cell.dropped.is_empty()) {
+                        unescaped_regions.insert(position.start.line, cells);
+                    }
+                }
                 // The preface is unescaped as one string, but the inline parser
                 // measures each of its lines from that line's own offset, so
                 // each is shifted by the escapes written on it alone. A line of
                 // it is content and indentation and nothing else, and an escape
-                // cannot be in the indentation, so the whole of it is walked.
+                // cannot be in the indentation, so the whole of it is one
+                // region.
                 NodeValue::Paragraph if Self::is_table_preface(node) => {
                     for line in position.start.line..=position.end.line {
-                        Self::map_unescaped(&mut written_columns, lines, line, 1, usize::MAX);
+                        let region = Self::unescaped_region(lines, line, 1, usize::MAX);
+                        if !region.dropped.is_empty() {
+                            unescaped_regions.insert(line, vec![region]);
+                        }
                     }
                 }
                 _ => {}
             }
         }
 
-        written_columns
+        unescaped_regions
     }
 
     /// Whether this paragraph is the one comrak split off a table's header row.
@@ -147,80 +197,44 @@ impl<'a> Document<'a> {
             && next.data.borrow().sourcepos.start.line == node.data.borrow().sourcepos.end.line + 1
     }
 
-    /// Records where the columns of one unescaped region were written.
-    ///
-    /// The region is `line`'s bytes from `start` to `end`, both columns, with
-    /// `end` clamped to the line. A region comrak dropped nothing from is not
-    /// recorded: its columns are already the ones it was written with.
-    fn map_unescaped(
-        written_columns: &mut FxHashMap<usize, Vec<usize>>,
+    /// The region `line` holds from column `start` to column `end`, with `end`
+    /// clamped to the line.
+    fn unescaped_region(
         lines: &[String],
         line_number: usize,
         start: usize,
         end: usize,
-    ) {
+    ) -> UnescapedRegion {
         // A region's `sourcepos` names bytes of the line it was parsed from, so
         // the slice is there to take. One that somehow is not carries no escape
-        // either, and leaves with the regions written without one.
+        // either, and leaves as a region nothing was dropped from.
         let region = lines
             .get(line_number - 1)
             .and_then(|line| line.get(start - 1..end.min(line.len())))
             .unwrap_or_default();
 
-        let dropped = Self::dropped_columns(region, start);
-        if dropped.is_empty() {
-            return;
-        }
-
-        // Identity as far as this region reaches, for the columns before its
-        // first escape and for the regions on the line that had none.
-        let last = start + region.len() - 1;
-        let columns = written_columns.entry(line_number).or_default();
-        if columns.len() <= last {
-            let identity = columns.len()..=last;
-            columns.extend(identity);
-        }
-
-        let shift = dropped.len();
-        let mut dropped = dropped.into_iter().peekable();
-        let mut reported = start;
-        for written in start..=last {
-            // A dropped column is one comrak never reports, so it is passed
-            // over and every column after it in the region moves right by one.
-            if dropped.next_if_eq(&written).is_some() {
-                continue;
-            }
-
-            columns[reported] = written;
-            reported += 1;
-        }
-
-        // comrak reports one column fewer than the region was written with for
-        // each it dropped, so the columns at the region's end are left over.
-        // Those are where a rule's own arithmetic lands when it names the byte
-        // after the last one — an exclusive end — and past the region's content
-        // the whole of its shift applies.
-        for (offset, written) in columns[reported..=last].iter_mut().enumerate() {
-            *written = reported + offset + shift;
+        UnescapedRegion {
+            start,
+            dropped: Self::dropped_columns(region, start),
         }
     }
 
-    /// The columns of `cell`, which starts at column `start`, that comrak drops
-    /// before it parses the cell's inlines.
+    /// The columns of `region`, which starts at column `start`, that comrak
+    /// drops before it parses the inlines in it.
     ///
-    /// Those are the backslashes of the cell's `\|` escapes, and nothing else:
-    /// a table cell is unescaped for its pipes alone, and every other backslash
+    /// Those are the backslashes of the region's `\|` escapes, and nothing
+    /// else: it is unescaped for its pipes alone, and every other backslash
     /// reaches the inline parser, which records the columns it was written at.
     ///
     /// A backslash that is itself escaped does not start an escape, so the run
     /// is walked rather than the pairs matched: in `\\|` the second backslash
     /// is the first one's escape, and the pipe stands on its own. comrak leaves
     /// all three bytes where they were written, and so does this.
-    fn dropped_columns(cell: &str, start: usize) -> Vec<usize> {
+    fn dropped_columns(region: &str, start: usize) -> Vec<usize> {
         let mut dropped = vec![];
         let mut after_backslash = false;
 
-        for (offset, byte) in cell.bytes().enumerate() {
+        for (offset, byte) in region.bytes().enumerate() {
             if after_backslash {
                 if byte == b'|' {
                     dropped.push(start + offset - 1);
@@ -302,15 +316,16 @@ mod tests {
         let doc = Document::new(&arena, path, text)?;
 
         // `w` is at column 11, and comrak has it at 9 — one for each `\|`. The
-        // shift starts at the first escape, so the `x` before it and the `c` in
-        // the next cell, which was written without one, are where they say.
+        // shift starts at the first escape, so the row's opening delimiter, the
+        // `x` before that escape, and the `c` in the next cell, which was
+        // written without one, are all where they say.
         assert_eq!(
             doc.written_position(Sourcepos::from((3, 9, 3, 9))),
             Sourcepos::from((3, 11, 3, 11))
         );
         assert_eq!(
-            doc.written_position(Sourcepos::from((3, 3, 3, 3))),
-            Sourcepos::from((3, 3, 3, 3))
+            doc.written_position(Sourcepos::from((3, 1, 3, 3))),
+            Sourcepos::from((3, 1, 3, 3))
         );
         assert_eq!(
             doc.written_position(Sourcepos::from((3, 15, 3, 15))),
@@ -348,9 +363,10 @@ mod tests {
     }
 
     // A cell reports one column fewer than it was written with for each escape
-    // in it, so its last written columns are ones no inline starts at. A rule
-    // still names them when it counts an exclusive end off a span that runs to
-    // the cell's end, and the cell's whole shift applies to those.
+    // in it, so the columns at its end are ones comrak never reports from
+    // inside it. A region reaches to where the next one begins rather than to
+    // where its content stops, so those still answer with its shift instead of
+    // falling back on themselves.
     #[test]
     fn written_position_past_a_cell() -> Result<()> {
         let text = indoc! {r"

--- a/src/document.rs
+++ b/src/document.rs
@@ -72,10 +72,12 @@ impl<'a> Document<'a> {
     /// carries neither, or before the first region on a line that does, is
     /// returned unchanged.
     ///
-    /// The pipe is the only escape this knows about, and it is the only one
-    /// comrak resolves before it measures: a column that a `\<punctuation>`
-    /// escape put wrong was never shifted by comrak and cannot be found from
-    /// here. #406 covers those.
+    /// The pipe is the only escape this knows about, and only where it is
+    /// resolved ahead of the inline parser rather than by it — inside a cell,
+    /// or in that paragraph. Written anywhere else it is resolved like any
+    /// other escape, `\<punctuation>` and `\|` alike, and a column that leaves
+    /// wrong is one comrak never shifted and nothing here can find. #406
+    /// covers those.
     ///
     /// A column is put back on the line by the character comrak reports at it,
     /// so a caller whose own arithmetic named the byte *after* a span — an

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use comrak::nodes::{AstNode, NodeValue};
+use comrak::nodes::{AstNode, NodeValue, Sourcepos};
 use comrak::{Arena, Options, parse_document};
 use miette::IntoDiagnostic as _;
 use miette::Result;
@@ -13,6 +14,10 @@ pub struct Document<'a> {
     pub ast: &'a AstNode<'a>,
     pub text: String,
     pub lines: Vec<String>,
+
+    /// Where each column comrak reports on a line was written, for the lines
+    /// where the two part company. See [`Document::written_position`].
+    written_columns: HashMap<usize, Vec<usize>>,
 }
 
 impl<'a> Document<'a> {
@@ -23,12 +28,14 @@ impl<'a> Document<'a> {
         options.extension.table = true;
         let ast = parse_document(arena, &text, &options);
         let lines: Vec<_> = text.lines().map(ToOwned::to_owned).collect();
+        let written_columns = Self::written_columns(ast, &lines, &text);
 
         Ok(Self {
             path,
             ast,
             text,
             lines,
+            written_columns,
         })
     }
 
@@ -36,6 +43,139 @@ impl<'a> Document<'a> {
     pub fn open(arena: &'a Arena<'a>, path: &Path) -> Result<Self> {
         let text = fs::read_to_string(path).into_diagnostic()?;
         Self::new(arena, path.to_path_buf(), text)
+    }
+
+    /// The position as written, for one comrak measured against a table cell.
+    ///
+    /// comrak unescapes a table cell before it parses the cell's inlines, so a
+    /// column reported from inside one counts each `\|` the cell was written
+    /// with as the single byte it was unescaped to. Every inline after the
+    /// escape therefore lands one column to the left of where it was written,
+    /// and one more for each further escape. This puts those bytes back, so the
+    /// column names the character a reader sees at it.
+    ///
+    /// A position from anywhere else is returned unchanged, and so is one
+    /// outside the line it names — a rule that has done its own column
+    /// arithmetic can hand over either.
+    #[inline]
+    #[must_use]
+    pub fn written_position(&self, position: Sourcepos) -> Sourcepos {
+        let mut written = position;
+        written.start.column = self.written_column(position.start.line, position.start.column);
+        written.end.column = self.written_column(position.end.line, position.end.column);
+        written
+    }
+
+    fn written_column(&self, line: usize, column: usize) -> usize {
+        self.written_columns
+            .get(&line)
+            .and_then(|columns| columns.get(column))
+            .copied()
+            .unwrap_or(column)
+    }
+
+    /// The column table [`Document::written_position`] reads, keyed by line.
+    ///
+    /// Only a line carrying a table cell that was written with a `\|` gets an
+    /// entry; on every other line the two columns are equal, and leaving those
+    /// out keeps the table empty for the documents that have no escape at all.
+    /// Within an entry, index and value are the reported and the written
+    /// column, and the columns outside the affected cells map to themselves.
+    ///
+    /// A cell's own `sourcepos` is built from the raw line rather than from the
+    /// unescaped content, so it is unshifted and gives the region to walk.
+    fn written_columns(
+        ast: &'a AstNode<'a>,
+        lines: &[String],
+        text: &str,
+    ) -> HashMap<usize, Vec<usize>> {
+        let mut written_columns = HashMap::new();
+
+        // Walking the tree costs more than the escape is common, and a document
+        // written without one has no shifted column to correct.
+        if !text.contains(r"\|") {
+            return written_columns;
+        }
+
+        for node in ast.descendants() {
+            if !matches!(node.data.borrow().value, NodeValue::TableCell) {
+                continue;
+            }
+
+            let position = node.data.borrow().sourcepos;
+            let Some(line) = position
+                .start
+                .line
+                .checked_sub(1)
+                .and_then(|index| lines.get(index))
+            else {
+                continue;
+            };
+
+            let length = line.len();
+            let start = position.start.column;
+            let end = position.end.column.min(length);
+            let Some(cell) = start.checked_sub(1).and_then(|index| line.get(index..end)) else {
+                continue;
+            };
+
+            let dropped = Self::dropped_columns(cell, start);
+            if dropped.is_empty() {
+                continue;
+            }
+
+            let columns = written_columns
+                .entry(position.start.line)
+                .or_insert_with(|| (0..=length + 1).collect::<Vec<_>>());
+
+            let mut dropped = dropped.into_iter().peekable();
+            let mut reported = start;
+            for written in start..=end {
+                // A dropped column is one comrak never reports, so it is passed
+                // over and every column after it in the cell moves right by one.
+                if dropped.next_if_eq(&written).is_some() {
+                    continue;
+                }
+
+                if let Some(column) = columns.get_mut(reported) {
+                    *column = written;
+                }
+
+                reported += 1;
+            }
+        }
+
+        written_columns
+    }
+
+    /// The columns of `cell`, which starts at column `start`, that comrak drops
+    /// before it parses the cell's inlines.
+    ///
+    /// Those are the backslashes of the cell's `\|` escapes, and nothing else:
+    /// a table cell is unescaped for its pipes alone, and every other backslash
+    /// reaches the inline parser, which records the columns it was written at.
+    ///
+    /// A backslash that is itself escaped does not start an escape, so the run
+    /// is walked rather than the pairs matched: in `\\|` the second backslash
+    /// is the first one's escape, and the pipe stands on its own. comrak leaves
+    /// all three bytes where they were written, and so does this.
+    fn dropped_columns(cell: &str, start: usize) -> Vec<usize> {
+        let mut dropped = vec![];
+        let mut after_backslash = false;
+
+        for (offset, byte) in cell.bytes().enumerate() {
+            if after_backslash {
+                if byte == b'|' {
+                    dropped.push(start + offset - 1);
+                }
+
+                after_backslash = false;
+            } else if byte == b'\\' {
+                after_backslash = true;
+            }
+        }
+
+        dropped
     }
 
     #[inline]
@@ -89,6 +229,84 @@ mod tests {
         let path = Path::new("test.md").to_path_buf();
         let doc = Document::new(&arena, path, text)?;
         assert_eq!(doc.front_matter(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn written_position_in_table_cell() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\|y\|z w | c |
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+
+        // `w` is at column 11, and comrak has it at 9 — one for each `\|`. The
+        // shift starts at the first escape, so the `x` before it and the `c` in
+        // the next cell, which was written without one, are where they say.
+        assert_eq!(
+            doc.written_position(Sourcepos::from((3, 9, 3, 9))),
+            Sourcepos::from((3, 11, 3, 11))
+        );
+        assert_eq!(
+            doc.written_position(Sourcepos::from((3, 3, 3, 3))),
+            Sourcepos::from((3, 3, 3, 3))
+        );
+        assert_eq!(
+            doc.written_position(Sourcepos::from((3, 15, 3, 15))),
+            Sourcepos::from((3, 15, 3, 15))
+        );
+        Ok(())
+    }
+
+    // `\\` is an escaped backslash, so the pipe after it stands on its own and
+    // comrak drops nothing. Matching `\|` as a pair would find one across the
+    // two and shift every column after it that was never shifted.
+    #[test]
+    fn written_position_with_escaped_backslash() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\\|y w | c |
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        let position = Sourcepos::from((3, 8, 3, 8));
+        assert_eq!(doc.written_position(position), position);
+        Ok(())
+    }
+
+    #[test]
+    fn written_position_without_escaped_pipe() -> Result<()> {
+        let text = indoc! {"
+            | a | b |
+            | --- | --- |
+            | x | c |
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        let position = Sourcepos::from((3, 3, 3, 3));
+        assert_eq!(doc.written_position(position), position);
+        Ok(())
+    }
+
+    // An escape outside a table is `CommonMark`'s own, and comrak reports the
+    // columns of the line as written for it.
+    #[test]
+    fn written_position_outside_table() -> Result<()> {
+        let text = r"a \| b".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        let position = Sourcepos::from((1, 3, 1, 4));
+        assert_eq!(doc.written_position(position), position);
         Ok(())
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -68,9 +68,19 @@ impl<'a> Document<'a> {
     /// column names the character a reader sees at it.
     ///
     /// The paragraph comrak splits off a table's header row is unescaped the
-    /// same way, and is corrected the same way. A position from anywhere else
-    /// is returned unchanged, and so is one outside the region it names — a
-    /// rule that has done its own column arithmetic can hand over either.
+    /// same way, and is corrected the same way. A position on a line that
+    /// carries neither, or before the first region on a line that does, is
+    /// returned unchanged.
+    ///
+    /// The pipe is the only escape this knows about, and it is the only one
+    /// comrak resolves before it measures: a column that a `\<punctuation>`
+    /// escape put wrong was never shifted by comrak and cannot be found from
+    /// here. #406 covers those.
+    ///
+    /// A column is put back on the line by the character comrak reports at it,
+    /// so a caller whose own arithmetic named the byte *after* a span — an
+    /// exclusive end — has to hand over the span's last byte and step past the
+    /// column that comes back, rather than hand over the byte after it.
     #[inline]
     #[must_use]
     pub fn written_position(&self, position: Sourcepos) -> Sourcepos {
@@ -82,10 +92,11 @@ impl<'a> Document<'a> {
 
     /// The column as written, for one comrak reports on `line`.
     ///
-    /// A column belongs to the last region that begins at or before it, and a
-    /// column past that region's content belongs to it all the same: the whole
-    /// of the region's shift applies there, which is what a column just past a
-    /// span at the end of a cell needs.
+    /// A column belongs to the last region that begins at or before it. A
+    /// region reaches to where the next one begins rather than to where its
+    /// content stops, so the columns between the two carry its shift as well —
+    /// comrak reports none of them, and answering with the shift keeps a column
+    /// at the end of a cell next to the one before it instead of jumping back.
     fn written_column(&self, line: usize, column: usize) -> usize {
         let Some(regions) = self.unescaped_regions.get(&line) else {
             return column;

--- a/src/document.rs
+++ b/src/document.rs
@@ -80,7 +80,9 @@ impl<'a> Document<'a> {
     /// entry; on every other line the two columns are equal, and leaving those
     /// out keeps the table empty for the documents that have no escape at all.
     /// Within an entry, index and value are the reported and the written
-    /// column, and the columns outside the affected cells map to themselves.
+    /// column, and an entry reaches as far as the last cell it was built from —
+    /// a column past its end is one nothing shifted, and reading past the end
+    /// is how [`Document::written_column`] answers for those.
     ///
     /// A cell's own `sourcepos` is built from the raw line rather than from the
     /// unescaped content, so it is unshifted and gives the region to walk.
@@ -103,30 +105,30 @@ impl<'a> Document<'a> {
             }
 
             let position = node.data.borrow().sourcepos;
-            let Some(line) = position
-                .start
-                .line
-                .checked_sub(1)
-                .and_then(|index| lines.get(index))
-            else {
-                continue;
-            };
-
-            let length = line.len();
             let start = position.start.column;
-            let end = position.end.column.min(length);
-            let Some(cell) = start.checked_sub(1).and_then(|index| line.get(index..end)) else {
-                continue;
-            };
+
+            // A cell's `sourcepos` names bytes of the line it was parsed from,
+            // so the slice is there to take. One that somehow is not carries no
+            // escape either, and leaves with the cells that were written
+            // without one.
+            let cell = lines
+                .get(position.start.line - 1)
+                .and_then(|line| line.get(start - 1..position.end.column.min(line.len())))
+                .unwrap_or_default();
 
             let dropped = Self::dropped_columns(cell, start);
             if dropped.is_empty() {
                 continue;
             }
 
-            let columns = written_columns
-                .entry(position.start.line)
-                .or_insert_with(|| (0..=length + 1).collect::<Vec<_>>());
+            // Identity as far as this cell reaches, for the columns before its
+            // first escape and for the cells on the line that had none.
+            let end = start + cell.len() - 1;
+            let columns = written_columns.entry(position.start.line).or_default();
+            if columns.len() <= end {
+                let identity = columns.len()..=end;
+                columns.extend(identity);
+            }
 
             let mut dropped = dropped.into_iter().peekable();
             let mut reported = start;
@@ -137,10 +139,7 @@ impl<'a> Document<'a> {
                     continue;
                 }
 
-                if let Some(column) = columns.get_mut(reported) {
-                    *column = written;
-                }
-
+                columns[reported] = written;
                 reported += 1;
             }
         }
@@ -258,6 +257,34 @@ mod tests {
         assert_eq!(
             doc.written_position(Sourcepos::from((3, 15, 3, 15))),
             Sourcepos::from((3, 15, 3, 15))
+        );
+        Ok(())
+    }
+
+    // Each cell is unescaped on its own, so the shift restarts at every one and
+    // the table has to reach past the first to carry the second.
+    #[test]
+    fn written_position_in_two_table_cells() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\|y w | c\|d v |
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+
+        // `w` is at column 8 and `v` at column 17, each one to the right of
+        // where comrak has it — the second because of its own cell's escape,
+        // not because the first cell's is still being counted.
+        assert_eq!(
+            doc.written_position(Sourcepos::from((3, 7, 3, 7))),
+            Sourcepos::from((3, 8, 3, 8))
+        );
+        assert_eq!(
+            doc.written_position(Sourcepos::from((3, 16, 3, 16))),
+            Sourcepos::from((3, 17, 3, 17))
         );
         Ok(())
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -6,6 +5,7 @@ use comrak::nodes::{AstNode, NodeValue, Sourcepos};
 use comrak::{Arena, Options, parse_document};
 use miette::IntoDiagnostic as _;
 use miette::Result;
+use rustc_hash::FxHashMap;
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -17,7 +17,7 @@ pub struct Document<'a> {
 
     /// Where each column comrak reports on a line was written, for the lines
     /// where the two part company. See [`Document::written_position`].
-    written_columns: HashMap<usize, Vec<usize>>,
+    written_columns: FxHashMap<usize, Vec<usize>>,
 }
 
 impl<'a> Document<'a> {
@@ -45,7 +45,8 @@ impl<'a> Document<'a> {
         Self::new(arena, path.to_path_buf(), text)
     }
 
-    /// The position as written, for one comrak measured against a table cell.
+    /// The position as written, for one comrak measured against a region it
+    /// unescaped the pipes of.
     ///
     /// comrak unescapes a table cell before it parses the cell's inlines, so a
     /// column reported from inside one counts each `\|` the cell was written
@@ -54,9 +55,10 @@ impl<'a> Document<'a> {
     /// and one more for each further escape. This puts those bytes back, so the
     /// column names the character a reader sees at it.
     ///
-    /// A position from anywhere else is returned unchanged, and so is one
-    /// outside the line it names — a rule that has done its own column
-    /// arithmetic can hand over either.
+    /// The paragraph comrak splits off a table's header row is unescaped the
+    /// same way, and is corrected the same way. A position from anywhere else
+    /// is returned unchanged, and so is one outside the region it names — a
+    /// rule that has done its own column arithmetic can hand over either.
     #[inline]
     #[must_use]
     pub fn written_position(&self, position: Sourcepos) -> Sourcepos {
@@ -76,22 +78,19 @@ impl<'a> Document<'a> {
 
     /// The column table [`Document::written_position`] reads, keyed by line.
     ///
-    /// Only a line carrying a table cell that was written with a `\|` gets an
-    /// entry; on every other line the two columns are equal, and leaving those
-    /// out keeps the table empty for the documents that have no escape at all.
-    /// Within an entry, index and value are the reported and the written
-    /// column, and an entry reaches as far as the last cell it was built from —
-    /// a column past its end is one nothing shifted, and reading past the end
-    /// is how [`Document::written_column`] answers for those.
-    ///
-    /// A cell's own `sourcepos` is built from the raw line rather than from the
-    /// unescaped content, so it is unshifted and gives the region to walk.
+    /// Only a line carrying a region that was written with a `\|` and unescaped
+    /// for it gets an entry; on every other line the two columns are equal, and
+    /// leaving those out keeps the table empty for the documents that have no
+    /// escape at all. Within an entry, index and value are the reported and the
+    /// written column, and an entry reaches as far as the last region it was
+    /// built from — a column past that is one nothing shifted, and reading past
+    /// the end is how [`Document::written_column`] answers for those.
     fn written_columns(
         ast: &'a AstNode<'a>,
         lines: &[String],
         text: &str,
-    ) -> HashMap<usize, Vec<usize>> {
-        let mut written_columns = HashMap::new();
+    ) -> FxHashMap<usize, Vec<usize>> {
+        let mut written_columns = FxHashMap::default();
 
         // Walking the tree costs more than the escape is common, and a document
         // written without one has no shifted column to correct.
@@ -100,51 +99,110 @@ impl<'a> Document<'a> {
         }
 
         for node in ast.descendants() {
-            if !matches!(node.data.borrow().value, NodeValue::TableCell) {
-                continue;
-            }
-
             let position = node.data.borrow().sourcepos;
-            let start = position.start.column;
 
-            // A cell's `sourcepos` names bytes of the line it was parsed from,
-            // so the slice is there to take. One that somehow is not carries no
-            // escape either, and leaves with the cells that were written
-            // without one.
-            let cell = lines
-                .get(position.start.line - 1)
-                .and_then(|line| line.get(start - 1..position.end.column.min(line.len())))
-                .unwrap_or_default();
-
-            let dropped = Self::dropped_columns(cell, start);
-            if dropped.is_empty() {
-                continue;
-            }
-
-            // Identity as far as this cell reaches, for the columns before its
-            // first escape and for the cells on the line that had none.
-            let end = start + cell.len() - 1;
-            let columns = written_columns.entry(position.start.line).or_default();
-            if columns.len() <= end {
-                let identity = columns.len()..=end;
-                columns.extend(identity);
-            }
-
-            let mut dropped = dropped.into_iter().peekable();
-            let mut reported = start;
-            for written in start..=end {
-                // A dropped column is one comrak never reports, so it is passed
-                // over and every column after it in the cell moves right by one.
-                if dropped.next_if_eq(&written).is_some() {
-                    continue;
+            match node.data.borrow().value {
+                // A cell's own `sourcepos` is built from the raw line rather
+                // than from the unescaped content, so it is unshifted and gives
+                // the region to walk.
+                NodeValue::TableCell => Self::map_unescaped(
+                    &mut written_columns,
+                    lines,
+                    position.start.line,
+                    position.start.column,
+                    position.end.column,
+                ),
+                // The preface is unescaped as one string, but the inline parser
+                // measures each of its lines from that line's own offset, so
+                // each is shifted by the escapes written on it alone. A line of
+                // it is content and indentation and nothing else, and an escape
+                // cannot be in the indentation, so the whole of it is walked.
+                NodeValue::Paragraph if Self::is_table_preface(node) => {
+                    for line in position.start.line..=position.end.line {
+                        Self::map_unescaped(&mut written_columns, lines, line, 1, usize::MAX);
+                    }
                 }
-
-                columns[reported] = written;
-                reported += 1;
+                _ => {}
             }
         }
 
         written_columns
+    }
+
+    /// Whether this paragraph is the one comrak split off a table's header row.
+    ///
+    /// A table interrupts the paragraph its header row was written in, and what
+    /// came before that row is moved into a paragraph of its own — with its
+    /// pipes unescaped on the way, the same as a cell's. Nothing else leaves a
+    /// paragraph on the line directly above a table: a table can only begin by
+    /// converting an open paragraph, so without a blank line between them the
+    /// two came from one block and this is that split, and with one there is a
+    /// line between them that this does not match.
+    fn is_table_preface(node: &'a AstNode<'a>) -> bool {
+        let Some(next) = node.next_sibling() else {
+            return false;
+        };
+
+        matches!(next.data.borrow().value, NodeValue::Table(_))
+            && next.data.borrow().sourcepos.start.line == node.data.borrow().sourcepos.end.line + 1
+    }
+
+    /// Records where the columns of one unescaped region were written.
+    ///
+    /// The region is `line`'s bytes from `start` to `end`, both columns, with
+    /// `end` clamped to the line. A region comrak dropped nothing from is not
+    /// recorded: its columns are already the ones it was written with.
+    fn map_unescaped(
+        written_columns: &mut FxHashMap<usize, Vec<usize>>,
+        lines: &[String],
+        line_number: usize,
+        start: usize,
+        end: usize,
+    ) {
+        // A region's `sourcepos` names bytes of the line it was parsed from, so
+        // the slice is there to take. One that somehow is not carries no escape
+        // either, and leaves with the regions written without one.
+        let region = lines
+            .get(line_number - 1)
+            .and_then(|line| line.get(start - 1..end.min(line.len())))
+            .unwrap_or_default();
+
+        let dropped = Self::dropped_columns(region, start);
+        if dropped.is_empty() {
+            return;
+        }
+
+        // Identity as far as this region reaches, for the columns before its
+        // first escape and for the regions on the line that had none.
+        let last = start + region.len() - 1;
+        let columns = written_columns.entry(line_number).or_default();
+        if columns.len() <= last {
+            let identity = columns.len()..=last;
+            columns.extend(identity);
+        }
+
+        let shift = dropped.len();
+        let mut dropped = dropped.into_iter().peekable();
+        let mut reported = start;
+        for written in start..=last {
+            // A dropped column is one comrak never reports, so it is passed
+            // over and every column after it in the region moves right by one.
+            if dropped.next_if_eq(&written).is_some() {
+                continue;
+            }
+
+            columns[reported] = written;
+            reported += 1;
+        }
+
+        // comrak reports one column fewer than the region was written with for
+        // each it dropped, so the columns at the region's end are left over.
+        // Those are where a rule's own arithmetic lands when it names the byte
+        // after the last one — an exclusive end — and past the region's content
+        // the whole of its shift applies.
+        for (offset, written) in columns[reported..=last].iter_mut().enumerate() {
+            *written = reported + offset + shift;
+        }
     }
 
     /// The columns of `cell`, which starts at column `start`, that comrak drops
@@ -286,6 +344,81 @@ mod tests {
             doc.written_position(Sourcepos::from((3, 16, 3, 16))),
             Sourcepos::from((3, 17, 3, 17))
         );
+        Ok(())
+    }
+
+    // A cell reports one column fewer than it was written with for each escape
+    // in it, so its last written columns are ones no inline starts at. A rule
+    // still names them when it counts an exclusive end off a span that runs to
+    // the cell's end, and the cell's whole shift applies to those.
+    #[test]
+    fn written_position_past_a_cell() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            |x\|y| c |
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+
+        // `y` is the cell's last character, at column 5, and column 6 is the
+        // delimiter an exclusive end off it names.
+        assert_eq!(
+            doc.written_position(Sourcepos::from((3, 4, 3, 5))),
+            Sourcepos::from((3, 5, 3, 6))
+        );
+        Ok(())
+    }
+
+    // comrak also unescapes the paragraph it splits off a table's header row,
+    // measuring each of its lines from that line's own offset, so a line of it
+    // is shifted by the escapes written on it alone.
+    #[test]
+    fn written_position_in_a_table_header_preface() -> Result<()> {
+        let text = indoc! {r"
+            foo x\|y bar
+            baz a\|b\|c qux
+            | a | b |
+            | --- | --- |
+            | c | d |
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+
+        // `bar` is at column 10 on its line and `qux` at column 13 on the next,
+        // one and two to the right of where comrak has them.
+        assert_eq!(
+            doc.written_position(Sourcepos::from((1, 9, 1, 11))),
+            Sourcepos::from((1, 10, 1, 12))
+        );
+        assert_eq!(
+            doc.written_position(Sourcepos::from((2, 11, 2, 13))),
+            Sourcepos::from((2, 13, 2, 15))
+        );
+        Ok(())
+    }
+
+    // A blank line between the two leaves an ordinary paragraph, whose escape
+    // is `CommonMark`'s own and whose columns comrak already reports as written.
+    #[test]
+    fn written_position_in_a_paragraph_above_a_table() -> Result<()> {
+        let text = indoc! {r"
+            foo x\|y bar
+
+            | a | b |
+            | --- | --- |
+            | c | d |
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        let position = Sourcepos::from((1, 10, 1, 12));
+        assert_eq!(doc.written_position(position), position);
         Ok(())
     }
 

--- a/src/rule/md033.rs
+++ b/src/rule/md033.rs
@@ -82,7 +82,7 @@ impl RuleLike for MD033 {
         let mut violations = vec![];
 
         for node in doc.ast.descendants() {
-            let position = node.data.borrow().sourcepos;
+            let position = doc.written_position(node.data.borrow().sourcepos);
 
             match &node.data.borrow().value {
                 NodeValue::HtmlInline(html) => {
@@ -232,6 +232,31 @@ mod tests {
         let rule = MD033::default();
         let actual = rule.check(&doc)?;
         let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // comrak unescapes a table cell before parsing its inlines, so the columns
+    // it reports from inside one are short a byte for every `\|` written before
+    // them. The `<br>` here is at column 8, not the 7 comrak has it at.
+    #[test]
+    fn check_errors_with_escaped_pipe_in_table() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\|y <br> | c |
+            | x\|y\|z <br> | c |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD033::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((3, 8, 3, 11))),
+            rule.to_violation(path, Sourcepos::from((4, 11, 4, 14))),
+        ];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md033.rs
+++ b/src/rule/md033.rs
@@ -82,10 +82,9 @@ impl RuleLike for MD033 {
         let mut violations = vec![];
 
         for node in doc.ast.descendants() {
-            let position = doc.written_position(node.data.borrow().sourcepos);
-
             match &node.data.borrow().value {
                 NodeValue::HtmlInline(html) => {
+                    let position = doc.written_position(node.data.borrow().sourcepos);
                     self.check_html(html, &doc.path, &position, &mut violations);
                 }
                 NodeValue::HtmlBlock(html) => {
@@ -95,6 +94,7 @@ impl RuleLike for MD033 {
                         continue;
                     }
 
+                    let position = doc.written_position(node.data.borrow().sourcepos);
                     self.check_html(&html.literal, &doc.path, &position, &mut violations);
                 }
                 _ => {}

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -52,7 +52,8 @@ impl RuleLike for MD034 {
                     position.end = position.start.column_add(link.end() as isize);
                     position.start = position.start.column_add(link.start() as isize);
 
-                    let violation = self.to_violation(doc.path.clone(), position);
+                    let violation =
+                        self.to_violation(doc.path.clone(), doc.written_position(position));
                     violations.push(violation);
                 }
             }
@@ -67,6 +68,7 @@ mod tests {
     use std::path::Path;
 
     use comrak::{Arena, nodes::Sourcepos};
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -120,6 +122,32 @@ mod tests {
         let rule = MD034::default();
         let actual = rule.check(&doc)?;
         let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // comrak unescapes a table cell before parsing its inlines, so the columns
+    // it reports from inside one are short a byte for every `\|` written before
+    // them. The rule adds its own offsets on top of a start that has already
+    // been shifted, and both are put back together.
+    #[test]
+    fn check_errors_with_escaped_pipe_in_table() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\|y http://www.example.com/ | c |
+            | x\|y\|z http://www.example.com/ | c |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((3, 8, 3, 31))),
+            rule.to_violation(path, Sourcepos::from((4, 11, 4, 34))),
+        ];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -49,11 +49,19 @@ impl RuleLike for MD034 {
 
                     // NOTE: link.start and link.end start from 0
                     let mut position = node.data.borrow().sourcepos;
-                    position.end = position.start.column_add(link.end() as isize);
+                    // The URL's last byte rather than the one after it, which
+                    // is the column reported. A column is put back on the line
+                    // by the character comrak reports at it, and the byte after
+                    // the URL is not the URL's: a `\|` written there would be
+                    // unescaped, and the end would follow it past the URL.
+                    position.end = position.start.column_add(link.end() as isize - 1);
                     position.start = position.start.column_add(link.start() as isize);
 
-                    let violation =
-                        self.to_violation(doc.path.clone(), doc.written_position(position));
+                    // Back to the byte after the URL, in the line's own columns.
+                    position = doc.written_position(position);
+                    position.end = position.end.column_add(1);
+
+                    let violation = self.to_violation(doc.path.clone(), position);
                     violations.push(violation);
                 }
             }
@@ -168,6 +176,27 @@ mod tests {
         let rule = MD034::default();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((3, 7, 3, 30)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // The column the rule names is the byte after the URL, and here that byte
+    // is the backslash of an escape comrak unescaped. Reading it as the URL's
+    // own would carry the end past the escape along with it.
+    #[test]
+    fn check_errors_with_escaped_pipe_after_url_in_table_cell() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x http://www.example.com/\|y |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 5, 3, 28)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -151,4 +151,24 @@ mod tests {
         assert_eq!(actual, expected);
         Ok(())
     }
+
+    // The rule names the byte after the URL's last, and a URL that runs to the
+    // end of its cell puts that past the columns comrak reports for the cell.
+    #[test]
+    fn check_errors_with_escaped_pipe_at_end_of_table_cell() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            |x\|y http://www.example.com/| c |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 7, 3, 30)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
 }

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -48,6 +48,10 @@ impl RuleLike for MD034 {
                     }
 
                     // NOTE: link.start and link.end start from 0
+                    //
+                    // These index `text`, where a backslash escape has already
+                    // been resolved, so they only name columns while it and the
+                    // line are the same length. #406 covers the rest.
                     let mut position = node.data.borrow().sourcepos;
                     // The URL's last byte rather than the one after it, which
                     // is the column reported. A column is put back on the line

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -60,7 +60,7 @@ impl RuleLike for MD037 {
                     position.start = position.start.column_add(m.start() as isize);
                 }
 
-                let violation = self.to_violation(doc.path.clone(), position);
+                let violation = self.to_violation(doc.path.clone(), doc.written_position(position));
                 violations.push(violation);
             }
         }
@@ -230,6 +230,32 @@ mod tests {
         let rule = MD037::new();
         let actual = rule.check(&doc)?;
         let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // comrak unescapes a table cell before parsing its inlines, so the columns
+    // it reports from inside one are short a byte for every `\|` written before
+    // them. The rule adds its own offsets on top of a start that has already
+    // been shifted, and both are put back together.
+    #[test]
+    fn check_errors_with_escaped_pipe_in_table() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\|y ** b ** | c |
+            | x\|y\|z ** b ** | c |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((3, 8, 3, 14))),
+            rule.to_violation(path, Sourcepos::from((4, 11, 4, 17))),
+        ];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -48,6 +48,10 @@ impl RuleLike for MD037 {
             if let NodeValue::Text(text) = &node.data.borrow().value
                 && let Some(m) = RE.find(text)
             {
+                // The match indexes `text`, where a backslash escape has already
+                // been resolved, so its offsets only name columns while that and
+                // the line are the same length — and an escaped marker reaches
+                // the regex as a bare one. #406 covers both.
                 let mut position = node.data.borrow().sourcepos;
 
                 if m.as_str().starts_with(' ') {

--- a/src/rule/md038.rs
+++ b/src/rule/md038.rs
@@ -493,4 +493,25 @@ mod tests {
         assert_eq!(actual, expected);
         Ok(())
     }
+
+    // comrak unescapes the paragraph it splits off a table's header row too, so
+    // a span written above a table is shifted like one written in it.
+    #[test]
+    fn check_errors_with_escaped_pipe_in_table_header_preface() -> Result<()> {
+        let text = indoc! {r"
+            text x\|y `` some text `` here
+            | a | b |
+            | --- | --- |
+            | c | d |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD038::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 11, 1, 25)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
 }

--- a/src/rule/md038.rs
+++ b/src/rule/md038.rs
@@ -55,6 +55,9 @@ impl MD038 {
     /// inlines, so inside one every `\|` earlier in the cell shifts the columns
     /// of everything after it by a byte. A width survives that — both ends shift
     /// together — where a slice of `doc.lines` would read the wrong text.
+    /// [`Document::written_position`] undoes the shift, but only for the report:
+    /// the columns handed here still describe the unescaped content, which is
+    /// the string `literal` came from and so the one to measure against.
     ///
     /// `None` means the columns do not describe a span at all, and the caller
     /// then skips it: a position we cannot measure is not evidence of a
@@ -140,7 +143,10 @@ impl RuleLike for MD038 {
                 };
 
                 if Self::is_padded(&content) {
-                    let violation = self.to_violation(doc.path.clone(), position);
+                    // `content` is measured against the columns comrak reports;
+                    // only the report is put back on the line as written.
+                    let violation =
+                        self.to_violation(doc.path.clone(), doc.written_position(position));
                     violations.push(violation);
                 }
             }
@@ -361,12 +367,10 @@ mod tests {
 
     // comrak unescapes a table cell before parsing its inlines, so `sourcepos`
     // no longer indexes the line the cell was written on. Widths survive that;
-    // both spans here are measured, not sliced.
-    //
-    // NOTE: the column asserted here is one to the left of the backtick it names
-    // — one for the single `\|` before it — and is what mado reports today
-    // rather than what it should. The shift is in the position comrak records,
-    // not in this rule, and reaches every inline it forwards; #403 tracks it.
+    // both spans here are measured, not sliced. The report does not survive it,
+    // and `Document::written_position` is what puts it back: the backtick the
+    // column below names is at column 8, one to the right of where comrak has
+    // it because of the single `\|` before it.
     #[test]
     fn check_errors_with_escaped_pipe_in_table() -> Result<()> {
         let text = indoc! {r"
@@ -381,7 +385,28 @@ mod tests {
         let doc = Document::new(&arena, path.clone(), text)?;
         let rule = MD038::new();
         let actual = rule.check(&doc)?;
-        let expected = vec![rule.to_violation(path, Sourcepos::from((4, 7, 4, 21)))];
+        let expected = vec![rule.to_violation(path, Sourcepos::from((4, 8, 4, 22)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // Two escapes shift the span by two, and one written inside the span shifts
+    // its end one further than its start. The width the rule measures is taken
+    // before any of that is undone, so it still describes the unescaped content.
+    #[test]
+    fn check_errors_with_escaped_pipe_inside_code_span_in_table() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\|y\|z `` a\|b `` | c |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD038::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 11, 3, 20)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md039.rs
+++ b/src/rule/md039.rs
@@ -41,7 +41,8 @@ impl RuleLike for MD039 {
                     && text.trim_start() != text
                 {
                     let position = text_node.data.borrow().sourcepos;
-                    let violation = self.to_violation(doc.path.clone(), position);
+                    let violation =
+                        self.to_violation(doc.path.clone(), doc.written_position(position));
                     violations.push(violation);
                     continue;
                 }
@@ -51,7 +52,8 @@ impl RuleLike for MD039 {
                     && text.trim_end() != text
                 {
                     let position = text_node.data.borrow().sourcepos;
-                    let violation = self.to_violation(doc.path.clone(), position);
+                    let violation =
+                        self.to_violation(doc.path.clone(), doc.written_position(position));
                     violations.push(violation);
                 }
             }
@@ -170,6 +172,31 @@ mod tests {
         let rule = MD039::new();
         let actual = rule.check(&doc)?;
         let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // comrak unescapes a table cell before parsing its inlines, so the columns
+    // it reports from inside one are short a byte for every `\|` written before
+    // them. The rule reports the link's text, which starts at column 9 here.
+    #[test]
+    fn check_errors_with_escaped_pipe_in_table() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\|y [ t ](http://www.example.com/) | c |
+            | x\|y\|z [ t ](http://www.example.com/) | c |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD039::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((3, 9, 3, 11))),
+            rule.to_violation(path, Sourcepos::from((4, 12, 4, 14))),
+        ];
         assert_eq!(actual, expected);
         Ok(())
     }


### PR DESCRIPTION
Closes #403.

## The defect

comrak unescapes a table cell before it parses the cell's inlines, so every `\|`
written earlier in the cell drops a byte from the string the inline parser
measures `sourcepos` against. Every inline after the escape is recorded one
column to the left of where it was written, and one more for each further
escape. The rules forwarded that unchanged, so the caret landed on the wrong
character.

```markdown
| a | b |
| --- | --- |
| x\|y `` pad `` | c |
| x\|y [ t ](http://e.com) | c |
| x\|y ** b ** | c |
| x\|y <br> | c |
| x\|y http://e.com | c |
```

The inline starts at column 8 on every row. Before, mado reported column 7 for
MD038, MD037, MD033 and MD034, and column 8 for MD039 — which #403 read as MD039
being unaffected. It is not: MD039 reports the link's *text*, which is at column
9, so it was shifted by one like the rest and only looked right against the
issue's yardstick. All five now report the column the character was written at.

`\|` inside the inline shifts its end one further than its start, and both are
put back independently.

## The fix

`Document` records, for each line where the two columns part company, which
column comrak's column was written at, and `written_position` maps one to the
other. The table is built from the cells' own `sourcepos`, which comrak takes
from the raw line and so does not shift, and a document with no `\|` in it
builds nothing.

comrak unescapes one other region the same way — the paragraph it splits off a
table's header row (`table.rs:299`) — so text written directly above a table
carried the shift too. That paragraph is the one ending on the line directly
above a table it is a sibling of: a table can only begin by converting an open
paragraph, so without a blank line between them the two came from one block, and
with one there is a line between them. It is corrected the same way, per line.

A column is put back on the line by the character comrak reports at it, so a
column naming the byte *after* a span answers for whatever is there. MD034's end
is one of those: with a `\|` directly after a bare URL, the end followed the
escape past the URL it was meant to bound. MD034 maps the URL's last byte and
steps one past that instead, which is the same column it always was outside a
table.

A line is stored as the regions comrak unescaped — each a start column and the
columns dropped from it — so the memory is the escapes rather than the length of
the line. A column is answered for by the last region beginning at or before it,
and a region reaches to where the next begins rather than to where its content
stops, so a column at a region's end still carries its shift. A row's cells are
recorded together, which is how a cell after an escaped one says the shift stops
there.

MD033, MD034, MD037, MD038 and MD039 report through it:

- MD034 and MD037 add their own byte offsets into the unescaped text on top of a
  start that has already been shifted. Mapping the position they arrive at
  covers both, because that position is in the same coordinates comrak reported.
- MD038 keeps measuring its span against the columns comrak reports — those are
  the ones that describe `literal` — and maps only the report. Its existing test
  asserted the shifted column and named this issue; it now asserts the written
  one.

`\\|` is an escaped backslash rather than an escaped pipe, and comrak drops
nothing for it, so the escapes are found by walking the backslash run rather
than by matching the pair. Matching pairs shifted a column that was never
shifted, which is what the `written_position_with_escaped_backslash` test pins.

## Verification

- `cargo test --all-features --workspace`: 370 tests pass, including new
  table-cell tests in each of the five rules and eight for `written_position`.
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` and
  `cargo fmt --all --check` are clean.
- Ran the built binary over `scripts/acceptance/data/markdownlint/test/rule_tests`
  and over this repository's own Markdown, before and after: byte-identical
  output, so nothing outside an escaped table cell moved.
- Checked by hand that a table inside a blockquote or a list item, a header row,
  an escape written *after* the inline, and multibyte cell content all report the
  column as written.

## Where the correction stops

The pipe is the only escape this reaches, and only where it is resolved ahead of
the inline parser rather than by it — inside a table cell, or in the paragraph
split off a header row. Written anywhere else, `\|` is resolved like any other
escape, and so is every `\<punctuation>` everywhere: the columns MD034 and MD037
count off a text node come from a literal `CommonMark` had already resolved the
escape in, and comrak never shifted the column they add to, so
`written_position` has nothing to find.

```markdown
x \. y http://www.example.com/ z    reports 1:7 for a URL at 1:8
see x\|y http://www.example.com/     reports 1:9 for a URL at 1:10
```

That is a separate defect, present on `main` and unchanged here; it is filed as
#406, and `written_position`, MD034, MD037 and the changelog entry say where the
guarantee stops.

## Left open

#403 also asks whether the fix belongs upstream in comrak. This one is in mado,
where the reported position is assembled; it does not change what comrak
records, so an upstream fix later would make `written_position` a no-op rather
than conflict with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV




