### PR TITLE
fix: measure MD034 and MD037 against the line, not the literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ parsed and therefore what gets reported.
   the same line above a table's header row, moved an inline's reported column
   one to the left of the character it named, and one more for each further
   escape (#405)
+- MD034 and MD037: measure the line a text node was written on rather than the
+  string `CommonMark` resolved its escapes out of. A `\.` written earlier in
+  the node moved the reported column one to the left of the character it named,
+  and one more for each further escape. MD037 also read an escaped `*` or `_`
+  as an emphasis marker, and reported a line whose only emphasis was the one
+  the author escaped to keep; MD034 now leaves a URL alone when its scheme is
+  escaped, which is how a URL is written so that it is not autolinked (#407)
 
 ## [0.3.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,16 +41,16 @@ parsed and therefore what gets reported.
   the same line above a table's header row, moved an inline's reported column
   one to the left of the character it named, and one more for each further
   escape (#405)
-- MD034 and MD037: measure the line a text node was written on rather than the
-  string `CommonMark` resolved its escapes out of. A `\.` written earlier in
-  the node moved the reported column one to the left of the character it named,
-  and one more for each further escape (#407)
+- MD034 and MD037: report the column an inline was written at, rather than one
+  counted off a string `CommonMark` had already resolved the escapes out of. A
+  `\.` written earlier in the same text node moved the reported column one to
+  the left of the character it named, and one more for each further escape
+  (#407)
 - MD037: an escaped `*` or `_` is no longer read as an emphasis marker, so a
   line whose only emphasis is the one its author escaped to keep is left alone,
   and a line that has emphasis besides is reported at it (#407)
-- MD034: a URL is left alone when an escape is written into its scheme or its
-  host, neither of which GFM autolinks (#407)
-- MD037: report the marker after a tab rather than the tab itself (#407)
+- MD037: report the marker after a tab, or after any other whitespace, rather
+  than the whitespace itself (#407)
 
 ## [0.3.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,12 @@ parsed and therefore what gets reported.
 - MD034 and MD037: measure the line a text node was written on rather than the
   string `CommonMark` resolved its escapes out of. A `\.` written earlier in
   the node moved the reported column one to the left of the character it named,
-  and one more for each further escape. MD037 also read an escaped `*` or `_`
-  as an emphasis marker, and reported a line whose only emphasis was the one
-  the author escaped to keep; MD034 now leaves a URL alone when its scheme is
-  escaped, which is how a URL is written so that it is not autolinked (#407)
+  and one more for each further escape (#407)
+- MD037: an escaped `*` or `_` is no longer read as an emphasis marker, so a
+  line whose only emphasis is the one its author escaped to keep is left alone,
+  and a line that has emphasis besides is reported at it (#407)
+- MD034: a URL whose scheme is escaped is left alone, that being how a URL is
+  written so that it is not autolinked (#407)
 
 ## [0.3.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,9 @@ parsed and therefore what gets reported.
 - MD037: an escaped `*` or `_` is no longer read as an emphasis marker, so a
   line whose only emphasis is the one its author escaped to keep is left alone,
   and a line that has emphasis besides is reported at it (#407)
-- MD034: a URL whose scheme is escaped is left alone, that being how a URL is
-  written so that it is not autolinked (#407)
+- MD034: a URL is left alone when an escape is written into its scheme or its
+  host, neither of which GFM autolinks (#407)
+- MD037: report the marker after a tab rather than the tab itself (#407)
 
 ## [0.3.1] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ parsed and therefore what gets reported.
   one to the left of the character it named, and one more for each further
   escape (#405)
 - MD034 and MD037: report the column an inline was written at, rather than one
-  counted off a string `CommonMark` had already resolved the escapes out of. A
+  counted off a string CommonMark had already resolved the escapes out of. A
   `\.` written earlier in the same text node moved the reported column one to
   the left of the character it named, and one more for each further escape
   (#407)

--- a/src/document.rs
+++ b/src/document.rs
@@ -117,8 +117,8 @@ impl<'a> Document<'a> {
     /// what this does are the two halves of one report: the position of the
     /// node, and the offsets counted off inside it.
     ///
-    /// Where the line is not the literal's source, [`Document::line_text`] says
-    /// so and the literal answers for itself.
+    /// Where the line is not the literal's source, `line_text` says so and the
+    /// literal answers for itself.
     #[inline]
     #[must_use]
     pub fn written_text<'t>(&'t self, position: Sourcepos, literal: &'t str) -> (&'t str, usize) {
@@ -144,9 +144,9 @@ impl<'a> Document<'a> {
     /// comes back as one: the run is walked rather than the pairs matched, the
     /// same as everywhere else here.
     ///
-    /// Where the line is not the literal's source, [`Document::line_text`] says
-    /// so and the literal answers for itself — with its escapes already
-    /// resolved, and nothing on it to mask.
+    /// Where the line is not the literal's source, `line_text` says so and the
+    /// literal answers for itself — with its escapes already resolved, and
+    /// nothing on it to mask.
     #[inline]
     #[must_use]
     pub fn written_text_without_escapes<'t>(

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,3 +1,6 @@
+extern crate alloc;
+
+use alloc::borrow::Cow;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -98,11 +101,15 @@ impl<'a> Document<'a> {
     /// against a string `CommonMark` has already resolved the escapes in: `\.`
     /// is two bytes on the line and one there, so every offset past it names a
     /// column to the left of the one it was written at, and one more for each
-    /// further escape. An escaped marker fares worse than shifted — it reaches
-    /// the literal as a bare one, where a rule looking for markers finds it and
-    /// reports what the author escaped to keep. The line carries neither: it is
-    /// what was written and what the report points at, so a rule measuring
-    /// against it names the character a reader sees at the column.
+    /// further escape. The line carries what was written and is what the report
+    /// points at, so a rule measuring against it names the character a reader
+    /// sees at the column.
+    ///
+    /// The escapes are on the line, backslash and all. That is what a rule
+    /// looking for a bare URL wants — GFM autolinks `http://example.com/\|y`
+    /// whole and leaves `http\://example.com` alone — and not what a rule
+    /// looking for a marker wants, which is
+    /// [`Document::written_text_without_escapes`].
     ///
     /// The columns are put back on the line by [`Document::written_position`]
     /// first, because a position from inside a table cell is measured against
@@ -110,53 +117,123 @@ impl<'a> Document<'a> {
     /// what this does are the two halves of one report: the position of the
     /// node, and the offsets counted off inside it.
     ///
-    /// The line is answered with only where it reads back as the source the
-    /// literal was built from, which is checked rather than assumed. Two things
-    /// are known to fail it. comrak measures the inlines after one that spans
-    /// two lines — a link with its destination on the line below — from a line
-    /// and column that are both a line behind, and the slice then holds text
-    /// the node was never built from; against the literal that is a wrong
-    /// column, and against the line it would be a violation reported out of
-    /// text the document does not have there. A character reference is resolved
-    /// into the literal the way an escape is, and naming the character `&amp;`
-    /// stands for takes the whole HTML5 table, so a node holding one does not
-    /// read back either.
-    ///
-    /// Both then answer with the literal, at the column comrak reported for the
-    /// node — the pair the rules measured before this, wrong by the escapes in
-    /// it and no more wrong than it was.
+    /// Where the line is not the literal's source, [`Document::line_text`] says
+    /// so and the literal answers for itself.
     #[inline]
     #[must_use]
     pub fn written_text<'t>(&'t self, position: Sourcepos, literal: &'t str) -> (&'t str, usize) {
-        let written = self.written_position(position);
-        let fallback = (literal, written.start.column);
+        self.line_text(position, literal)
+            .unwrap_or_else(|| (literal, self.written_position(position).start.column))
+    }
 
-        if position.start.line != position.end.line {
-            return fallback;
+    /// The text `position` describes with the escapes in it masked out, and the
+    /// column it starts at.
+    ///
+    /// An escaped marker is not a marker, and against the literal it cannot be
+    /// told from one: `CommonMark` resolves `\*` before the literal is built,
+    /// so a rule searching for emphasis reads the marker the author escaped to
+    /// keep. Searching the line instead is not enough on its own — a marker is
+    /// escaped by the byte *before* it, and only some of the places a search
+    /// can find one have something before them to look at — so the escapes are
+    /// taken out of the search rather than guarded against inside it.
+    ///
+    /// Each is replaced by as many bytes as it was written with, so every
+    /// column the search reports is still the column the byte is at, and by a
+    /// letter, which a search for markers and the whitespace around them can
+    /// only read as text. `\\*` is an escaped backslash and then a marker, and
+    /// comes back as one: the run is walked rather than the pairs matched, the
+    /// same as everywhere else here.
+    ///
+    /// Where the line is not the literal's source, [`Document::line_text`] says
+    /// so and the literal answers for itself — with its escapes already
+    /// resolved, and nothing on it to mask.
+    #[inline]
+    #[must_use]
+    pub fn written_text_without_escapes<'t>(
+        &'t self,
+        position: Sourcepos,
+        literal: &'t str,
+    ) -> (Cow<'t, str>, usize) {
+        match self.line_text(position, literal) {
+            Some((text, column)) => (Self::without_escapes(text), column),
+            None => (
+                Cow::Borrowed(literal),
+                self.written_position(position).start.column,
+            ),
         }
+    }
+
+    /// The line `position` was written on, sliced to the columns it covers, and
+    /// the column that slice starts at.
+    ///
+    /// `None` means the line is not the source `literal` was built from, which
+    /// is checked rather than assumed. Two things are known to fail it. comrak
+    /// measures the inlines after one that spans two lines — a link with its
+    /// destination on the line below — from a line and a column that are both a
+    /// line behind, and the slice then holds text the node was never built
+    /// from; against the literal that is a wrong column, and against the line
+    /// it would be a violation reported out of text the document does not have
+    /// there. A character reference is resolved into the literal the way an
+    /// escape is, and naming the character `&amp;` stands for takes the whole
+    /// HTML5 table, so a node holding one does not read back either.
+    ///
+    /// A position naming two lines, or columns its line does not have, has no
+    /// slice to answer with at all.
+    ///
+    /// A caller that answers with the literal instead is measuring what the
+    /// rules measured before any of this: offsets counted off a string the
+    /// escapes are already out of, added to the column comrak reported. The one
+    /// difference is that the column is put back on the line once, for the node,
+    /// rather than once for each column reported out of it, so a `\|` written
+    /// between the start of the node and the offset is a column that stays
+    /// missing. Both are wrong about that offset either way, and neither is a
+    /// line this can read.
+    fn line_text<'t>(&'t self, position: Sourcepos, literal: &str) -> Option<(&'t str, usize)> {
+        if position.start.line != position.end.line {
+            return None;
+        }
+
+        let written = self.written_position(position);
 
         // A line and a column are counted from one, and an index from zero, so
         // a position that starts at either's zero indexes nothing at all.
-        let (Some(index), Some(start)) = (
-            written.start.line.checked_sub(1),
-            written.start.column.checked_sub(1),
-        ) else {
-            return fallback;
-        };
-
-        let Some(text) = self
+        let index = written.start.line.checked_sub(1)?;
+        let start = written.start.column.checked_sub(1)?;
+        let text = self
             .lines
             .get(index)
-            .and_then(|line| line.get(start..written.end.column))
-        else {
-            return fallback;
-        };
+            .and_then(|line| line.get(start..written.end.column))?;
 
-        if Self::is_source_of(text, literal) {
-            return (text, written.start.column);
+        Self::is_source_of(text, literal).then_some((text, written.start.column))
+    }
+
+    /// `written` with the escapes in it masked out, a byte for a byte.
+    ///
+    /// The byte the escape guards goes with the backslash: a marker is what
+    /// there is to hide, and it is the guarded byte that is one.
+    fn without_escapes(written: &str) -> Cow<'_, str> {
+        // Nothing to take out, and nothing to allocate for. Most text is this.
+        if !written.contains('\\') {
+            return Cow::Borrowed(written);
         }
 
-        fallback
+        let mut masked = String::with_capacity(written.len());
+        let mut chars = written.chars().peekable();
+
+        while let Some(char) = chars.next() {
+            match chars.peek() {
+                Some(&next) if char == '\\' && next.is_ascii_punctuation() => {
+                    chars.next();
+
+                    // Two bytes for the two the escape was written with, so an
+                    // offset past this one is still the column it was at.
+                    masked.push_str("xx");
+                }
+                _ => masked.push(char),
+            }
+        }
+
+        Cow::Owned(masked)
     }
 
     /// Whether `CommonMark` built `literal` out of `written`.
@@ -171,6 +248,15 @@ impl<'a> Document<'a> {
     /// not need saying so: `\\|` is walked as `\\` and then `|`, which is the
     /// pair `CommonMark` resolves it to.
     fn is_source_of(written: &str, literal: &str) -> bool {
+        // Resolving an escape takes a byte off, and nothing `CommonMark` does
+        // to a text node puts one back, so two of the same length had no escape
+        // between them and have to be the same bytes. That is nearly every node
+        // in a document, and comparing the two whole is cheaper than walking
+        // them a byte at a time.
+        if written.len() == literal.len() {
+            return written == literal;
+        }
+
         let mut literal = literal.bytes();
         let mut written = written.bytes().peekable();
 
@@ -691,6 +777,54 @@ mod tests {
         assert_eq!(
             doc.written_text(Sourcepos::from((3, 1, 3, 4)), "will be used."),
             ("will be used.", 1)
+        );
+        Ok(())
+    }
+
+    // The escapes are masked a byte for a byte, so a marker the author escaped
+    // is not one the search can find and every column past it is still where it
+    // was. `\\*` is an escaped backslash and then a marker, and the marker
+    // comes back.
+    #[test]
+    fn written_text_without_escapes_of_a_line() -> Result<()> {
+        let text = r"x \* y \\* z".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 12)), r"x * y \* z"),
+            (Cow::Owned("x xx y xx* z".to_owned()), 1)
+        );
+        Ok(())
+    }
+
+    // A line with no escape on it is masked into nothing, and is answered with
+    // as it stands.
+    #[test]
+    fn written_text_without_escapes_of_a_line_without_one() -> Result<()> {
+        let text = "x ** b ** y".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 11)), "x ** b ** y"),
+            (Cow::Borrowed("x ** b ** y"), 1)
+        );
+        Ok(())
+    }
+
+    // The literal has its escapes resolved already, and a backslash still in it
+    // was written as an escaped one — `\*` there is a backslash and a marker,
+    // and masking it would take a marker the document has out of the search.
+    #[test]
+    fn written_text_without_escapes_of_a_literal() -> Result<()> {
+        let text = r"a &amp; b \\* c".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 15)), r"a & b \* c"),
+            (Cow::Borrowed(r"a & b \* c"), 1)
         );
         Ok(())
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -95,35 +95,69 @@ impl<'a> Document<'a> {
         written
     }
 
-    /// The text `position` describes, and the column it starts at.
+    /// The column the byte at `offset` of a text node's `literal` was written
+    /// at.
     ///
-    /// A rule that counts an offset off a text node's `literal` is measuring
-    /// against a string `CommonMark` has already resolved the escapes in: `\.`
-    /// is two bytes on the line and one there, so every offset past it names a
-    /// column to the left of the one it was written at, and one more for each
-    /// further escape. The line carries what was written and is what the report
-    /// points at, so a rule measuring against it names the character a reader
-    /// sees at the column.
+    /// A rule that counts an offset off a literal is counting on a string
+    /// `CommonMark` has already resolved the escapes in: `\.` is two bytes on
+    /// the line and one there, so an offset past one names a column to the left
+    /// of the one it was written at, and one more for each further escape.
+    /// Adding an offset to a column is what put the report to the left of the
+    /// character it named; the offset is walked along the line here instead,
+    /// where the escapes still are, and the column comes out of the walk.
     ///
-    /// The escapes are on the line, backslash and all. That is what a rule
-    /// looking for a bare URL wants — GFM autolinks `http://example.com/\|y`
-    /// whole and leaves `http\://example.com` alone — and not what a rule
-    /// looking for a marker wants, which is
-    /// [`Document::written_text_without_escapes`].
+    /// [`Document::written_position`] is where the walk starts, because a
+    /// position from inside a table cell is measured against the unescaped cell
+    /// rather than against the line. What that corrects and what this does are
+    /// the two halves of one report: the position of the node, and the offsets
+    /// counted off inside it.
     ///
-    /// The columns are put back on the line by [`Document::written_position`]
-    /// first, because a position from inside a table cell is measured against
-    /// the unescaped cell rather than against the line. What that corrects and
-    /// what this does are the two halves of one report: the position of the
-    /// node, and the offsets counted off inside it.
+    /// An offset past the end of the literal answers with the column after the
+    /// node, which is where a caller naming the byte after a span lands.
     ///
-    /// Where the line is not the literal's source, `line_text` says so and the
-    /// literal answers for itself.
+    /// Where the line is not the literal's source, `line_text` says so, and the
+    /// offset is added to the column comrak reported and that column put back
+    /// on the line — which is what the rules did before any of this, and is
+    /// wrong by whatever escapes the offset passed.
     #[inline]
     #[must_use]
-    pub fn written_text<'t>(&'t self, position: Sourcepos, literal: &'t str) -> (&'t str, usize) {
-        self.line_text(position, literal)
-            .unwrap_or_else(|| (literal, self.written_position(position).start.column))
+    pub fn written_column_of(&self, position: Sourcepos, literal: &str, offset: usize) -> usize {
+        match self.line_text(position, literal) {
+            Some((text, column)) => column + Self::written_offset(text, offset),
+            None => self.written_column(position.start.line, position.start.column + offset),
+        }
+    }
+
+    /// The offset into `written` of the byte its literal has at `offset`.
+    ///
+    /// The two run together a character at a time, and part company only at an
+    /// escape: its backslash is a byte of the line that the literal does not
+    /// have, and the byte it guards stands there for the pair.
+    fn written_offset(written: &str, offset: usize) -> usize {
+        let mut literal_offset = 0;
+        let mut chars = written.char_indices().peekable();
+
+        while let Some((index, char)) = chars.next() {
+            if literal_offset >= offset {
+                return index;
+            }
+
+            // An escape is two bytes of the line and one of the literal, and
+            // the one is the byte it guards, which is always punctuation and so
+            // always a single byte.
+            if char == '\\'
+                && chars
+                    .peek()
+                    .is_some_and(|&(_, next)| next.is_ascii_punctuation())
+            {
+                chars.next();
+                literal_offset += 1;
+            } else {
+                literal_offset += char.len_utf8();
+            }
+        }
+
+        written.len()
     }
 
     /// The text `position` describes with the escapes in it masked out, and the
@@ -686,27 +720,29 @@ mod tests {
         Ok(())
     }
 
-    // The text is taken from the line, so an escape the literal no longer has
-    // is in it and the column it is read from is the one it was written at.
+    // The offset is walked along the line, where the escapes still are, so the
+    // column comes out one to the right of the literal's own for each one the
+    // walk passed. An offset that lands on an escape answers with the backslash
+    // it begins at, which is where the character was written.
     #[test]
-    fn written_text_of_a_line() -> Result<()> {
-        let text = "x \\. y ** b ** z".to_owned();
+    fn written_column_of_a_line() -> Result<()> {
+        let text = r"x \. y z".to_owned();
         let arena = Arena::new();
         let path = Path::new("test.md").to_path_buf();
         let doc = Document::new(&arena, path, text)?;
-        assert_eq!(
-            doc.written_text(Sourcepos::from((1, 3, 1, 7)), ". y "),
-            (r"\. y ", 3)
-        );
+        let position = Sourcepos::from((1, 1, 1, 8));
+        assert_eq!(doc.written_column_of(position, "x . y z", 0), 1);
+        assert_eq!(doc.written_column_of(position, "x . y z", 2), 3);
+        assert_eq!(doc.written_column_of(position, "x . y z", 6), 8);
         Ok(())
     }
 
-    // comrak measures a position from inside a table cell against the
-    // unescaped cell, so the columns are put back on the line before the text
-    // is read from it — off by one here, where the column comrak reports for
-    // the `y` lands on the `|` of the escape before it.
+    // comrak measures a position from inside a table cell against the unescaped
+    // cell, so the columns are put back on the line before the walk starts —
+    // and the walk takes it from there, the cell's `\|` being an escape like
+    // any other on the line.
     #[test]
-    fn written_text_in_a_table_cell() -> Result<()> {
+    fn written_column_of_a_table_cell() -> Result<()> {
         let text = indoc! {r"
             | a | b |
             | --- | --- |
@@ -716,37 +752,57 @@ mod tests {
         let arena = Arena::new();
         let path = Path::new("test.md").to_path_buf();
         let doc = Document::new(&arena, path, text)?;
-        assert_eq!(
-            doc.written_text(Sourcepos::from((3, 5, 3, 7)), "y w"),
-            ("y w", 6)
-        );
+        let position = Sourcepos::from((3, 3, 3, 7));
+        assert_eq!(doc.written_column_of(position, "x|y w", 0), 3);
+        assert_eq!(doc.written_column_of(position, "x|y w", 1), 4);
+        assert_eq!(doc.written_column_of(position, "x|y w", 4), 8);
+
+        // The byte after the node, which is where a caller naming the byte
+        // after a span lands.
+        assert_eq!(doc.written_column_of(position, "x|y w", 5), 9);
         Ok(())
     }
 
-    // A position that names two lines describes no slice of either, and one
-    // reaching past the end of its line describes none of it. Neither is a line
-    // to measure against, so the literal answers for itself.
+    // `\\|` is an escaped backslash and then a pipe, and the walk takes the
+    // run as `CommonMark` resolves it: two bytes for the one, and the pipe on
+    // its own.
     #[test]
-    fn written_text_of_no_line() -> Result<()> {
+    fn written_column_of_an_escaped_backslash() -> Result<()> {
+        let text = r"a \\| b".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        let position = Sourcepos::from((1, 1, 1, 7));
+        assert_eq!(doc.written_column_of(position, r"a \| b", 3), 5);
+        assert_eq!(doc.written_column_of(position, r"a \| b", 5), 7);
+        Ok(())
+    }
+
+    // A position that names two lines describes no slice of either, one
+    // reaching past the end of its line describes none of it, and one starting
+    // at a line or a column of zero indexes nothing at all. None of them is a
+    // line to walk, so the offset is added to the column comrak reported.
+    #[test]
+    fn written_column_of_no_line() -> Result<()> {
         let text = "x y\nz w".to_owned();
         let arena = Arena::new();
         let path = Path::new("test.md").to_path_buf();
         let doc = Document::new(&arena, path, text)?;
         assert_eq!(
-            doc.written_text(Sourcepos::from((1, 1, 2, 3)), "x y z w"),
-            ("x y z w", 1)
+            doc.written_column_of(Sourcepos::from((1, 1, 2, 3)), "x y z w", 2),
+            3
         );
         assert_eq!(
-            doc.written_text(Sourcepos::from((1, 1, 1, 4)), "x y"),
-            ("x y", 1)
+            doc.written_column_of(Sourcepos::from((1, 1, 1, 4)), "x y", 2),
+            3
         );
         assert_eq!(
-            doc.written_text(Sourcepos::from((3, 1, 3, 1)), "v"),
-            ("v", 1)
+            doc.written_column_of(Sourcepos::from((3, 1, 3, 1)), "v", 0),
+            1
         );
         assert_eq!(
-            doc.written_text(Sourcepos::from((0, 0, 0, 0)), "x y"),
-            ("x y", 0)
+            doc.written_column_of(Sourcepos::from((0, 0, 0, 0)), "x y", 1),
+            1
         );
         Ok(())
     }
@@ -755,9 +811,9 @@ mod tests {
     // from: comrak measures the inlines after one that spans two lines from a
     // line behind, and the slice is then some other text of the document
     // entirely. Reading it back as the literal's source is what tells the two
-    // apart, and the literal answers for itself where it is not.
+    // apart, and the column comrak reported answers where it is not.
     #[test]
-    fn written_text_of_a_line_that_is_not_the_source() -> Result<()> {
+    fn written_column_of_a_line_that_is_not_the_source() -> Result<()> {
         let text = indoc! {"
             a [b](
             https://www.example.com/) c
@@ -768,15 +824,25 @@ mod tests {
         let path = Path::new("test.md").to_path_buf();
         let doc = Document::new(&arena, path, text)?;
         assert_eq!(
-            doc.written_text(Sourcepos::from((2, 1, 2, 13)), "will be used."),
-            ("will be used.", 1)
+            doc.written_column_of(Sourcepos::from((2, 1, 2, 13)), "will be used.", 5),
+            6
         );
+        Ok(())
+    }
 
-        // And the slice being a piece of what the literal holds is not the
-        // literal's source either.
+    // A character reference is resolved into the literal the way an escape is,
+    // and is not one this can put back, so the line does not read back as the
+    // source and the column comrak reported answers — which is what the rules
+    // counted off before any of this, and is short by the reference.
+    #[test]
+    fn written_column_of_a_character_reference() -> Result<()> {
+        let text = "a &amp; b".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
         assert_eq!(
-            doc.written_text(Sourcepos::from((3, 1, 3, 4)), "will be used."),
-            ("will be used.", 1)
+            doc.written_column_of(Sourcepos::from((1, 1, 1, 9)), "a & b", 4),
+            5
         );
         Ok(())
     }
@@ -834,37 +900,6 @@ mod tests {
         // Borrowed, and the literal's own: nothing was masked out of it.
         assert!(matches!(actual.0, Cow::Borrowed(_)));
         assert_eq!(actual, (Cow::Borrowed(r"a & b \* c"), 1));
-        Ok(())
-    }
-
-    // A character reference is resolved into the literal the way an escape is,
-    // and is not one this can put back, so the line does not read back as the
-    // source and the literal answers for itself.
-    #[test]
-    fn written_text_of_a_character_reference() -> Result<()> {
-        let text = "a &amp; b".to_owned();
-        let arena = Arena::new();
-        let path = Path::new("test.md").to_path_buf();
-        let doc = Document::new(&arena, path, text)?;
-        assert_eq!(
-            doc.written_text(Sourcepos::from((1, 1, 1, 9)), "a & b"),
-            ("a & b", 1)
-        );
-        Ok(())
-    }
-
-    // `\\|` is an escaped backslash and a pipe, which `CommonMark` resolves to
-    // the two bytes it walks as one escape and one byte of its own.
-    #[test]
-    fn written_text_with_escaped_backslash() -> Result<()> {
-        let text = r"a \\| b".to_owned();
-        let arena = Arena::new();
-        let path = Path::new("test.md").to_path_buf();
-        let doc = Document::new(&arena, path, text)?;
-        assert_eq!(
-            doc.written_text(Sourcepos::from((1, 1, 1, 7)), r"a \| b"),
-            (r"a \\| b", 1)
-        );
         Ok(())
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -92,6 +92,107 @@ impl<'a> Document<'a> {
         written
     }
 
+    /// The text `position` describes, and the column it starts at.
+    ///
+    /// A rule that counts an offset off a text node's `literal` is measuring
+    /// against a string `CommonMark` has already resolved the escapes in: `\.`
+    /// is two bytes on the line and one there, so every offset past it names a
+    /// column to the left of the one it was written at, and one more for each
+    /// further escape. An escaped marker fares worse than shifted — it reaches
+    /// the literal as a bare one, where a rule looking for markers finds it and
+    /// reports what the author escaped to keep. The line carries neither: it is
+    /// what was written and what the report points at, so a rule measuring
+    /// against it names the character a reader sees at the column.
+    ///
+    /// The columns are put back on the line by [`Document::written_position`]
+    /// first, because a position from inside a table cell is measured against
+    /// the unescaped cell rather than against the line. What that corrects and
+    /// what this does are the two halves of one report: the position of the
+    /// node, and the offsets counted off inside it.
+    ///
+    /// The line is answered with only where it reads back as the source the
+    /// literal was built from, which is checked rather than assumed. Two things
+    /// are known to fail it. comrak measures the inlines after one that spans
+    /// two lines — a link with its destination on the line below — from a line
+    /// and column that are both a line behind, and the slice then holds text
+    /// the node was never built from; against the literal that is a wrong
+    /// column, and against the line it would be a violation reported out of
+    /// text the document does not have there. A character reference is resolved
+    /// into the literal the way an escape is, and naming the character `&amp;`
+    /// stands for takes the whole HTML5 table, so a node holding one does not
+    /// read back either.
+    ///
+    /// Both then answer with the literal, at the column comrak reported for the
+    /// node — the pair the rules measured before this, wrong by the escapes in
+    /// it and no more wrong than it was.
+    #[inline]
+    #[must_use]
+    pub fn written_text<'t>(&'t self, position: Sourcepos, literal: &'t str) -> (&'t str, usize) {
+        let written = self.written_position(position);
+        let fallback = (literal, written.start.column);
+
+        if position.start.line != position.end.line {
+            return fallback;
+        }
+
+        // A line and a column are counted from one, and an index from zero, so
+        // a position that starts at either's zero indexes nothing at all.
+        let (Some(index), Some(start)) = (
+            written.start.line.checked_sub(1),
+            written.start.column.checked_sub(1),
+        ) else {
+            return fallback;
+        };
+
+        let Some(text) = self
+            .lines
+            .get(index)
+            .and_then(|line| line.get(start..written.end.column))
+        else {
+            return fallback;
+        };
+
+        if Self::is_source_of(text, literal) {
+            return (text, written.start.column);
+        }
+
+        fallback
+    }
+
+    /// Whether `CommonMark` built `literal` out of `written`.
+    ///
+    /// The escapes are the difference between the two that this knows about:
+    /// the backslash of a `\<punctuation>` is not in the literal, and the byte
+    /// it guards stands there for the pair. Everything else has to be equal,
+    /// byte for byte and to the same length, so text from some other part of
+    /// the document is not taken for this node's.
+    ///
+    /// A backslash that is itself escaped does not start an escape, and does
+    /// not need saying so: `\\|` is walked as `\\` and then `|`, which is the
+    /// pair `CommonMark` resolves it to.
+    fn is_source_of(written: &str, literal: &str) -> bool {
+        let mut literal = literal.bytes();
+        let mut written = written.bytes().peekable();
+
+        while let Some(byte) = written.next() {
+            // The backslash of an escape is not in the literal, where the byte
+            // it guards stands for the pair.
+            let byte = match written.peek() {
+                Some(&next) if byte == b'\\' && next.is_ascii_punctuation() => {
+                    written.next();
+                    next
+                }
+                _ => byte,
+            };
+
+            if literal.next() != Some(byte) {
+                return false;
+            }
+        }
+
+        literal.next().is_none()
+    }
+
     /// The column as written, for one comrak reports on `line`.
     ///
     /// A column belongs to the last region that begins at or before it. A
@@ -496,6 +597,132 @@ mod tests {
         let doc = Document::new(&arena, path, text)?;
         let position = Sourcepos::from((1, 3, 1, 4));
         assert_eq!(doc.written_position(position), position);
+        Ok(())
+    }
+
+    // The text is taken from the line, so an escape the literal no longer has
+    // is in it and the column it is read from is the one it was written at.
+    #[test]
+    fn written_text_of_a_line() -> Result<()> {
+        let text = "x \\. y ** b ** z".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text(Sourcepos::from((1, 3, 1, 7)), ". y "),
+            (r"\. y ", 3)
+        );
+        Ok(())
+    }
+
+    // comrak measures a position from inside a table cell against the
+    // unescaped cell, so the columns are put back on the line before the text
+    // is read from it — off by one here, where the column comrak reports for
+    // the `y` lands on the `|` of the escape before it.
+    #[test]
+    fn written_text_in_a_table_cell() -> Result<()> {
+        let text = indoc! {r"
+            | a | b |
+            | --- | --- |
+            | x\|y w | c |
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text(Sourcepos::from((3, 5, 3, 7)), "y w"),
+            ("y w", 6)
+        );
+        Ok(())
+    }
+
+    // A position that names two lines describes no slice of either, and one
+    // reaching past the end of its line describes none of it. Neither is a line
+    // to measure against, so the literal answers for itself.
+    #[test]
+    fn written_text_of_no_line() -> Result<()> {
+        let text = "x y\nz w".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text(Sourcepos::from((1, 1, 2, 3)), "x y z w"),
+            ("x y z w", 1)
+        );
+        assert_eq!(
+            doc.written_text(Sourcepos::from((1, 1, 1, 4)), "x y"),
+            ("x y", 1)
+        );
+        assert_eq!(
+            doc.written_text(Sourcepos::from((3, 1, 3, 1)), "v"),
+            ("v", 1)
+        );
+        assert_eq!(
+            doc.written_text(Sourcepos::from((0, 0, 0, 0)), "x y"),
+            ("x y", 0)
+        );
+        Ok(())
+    }
+
+    // The line a position names is not always the one the literal was built
+    // from: comrak measures the inlines after one that spans two lines from a
+    // line behind, and the slice is then some other text of the document
+    // entirely. Reading it back as the literal's source is what tells the two
+    // apart, and the literal answers for itself where it is not.
+    #[test]
+    fn written_text_of_a_line_that_is_not_the_source() -> Result<()> {
+        let text = indoc! {"
+            a [b](
+            https://www.example.com/) c
+            will be used.
+        "}
+        .to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text(Sourcepos::from((2, 1, 2, 13)), "will be used."),
+            ("will be used.", 1)
+        );
+
+        // And the slice being a piece of what the literal holds is not the
+        // literal's source either.
+        assert_eq!(
+            doc.written_text(Sourcepos::from((3, 1, 3, 4)), "will be used."),
+            ("will be used.", 1)
+        );
+        Ok(())
+    }
+
+    // A character reference is resolved into the literal the way an escape is,
+    // and is not one this can put back, so the line does not read back as the
+    // source and the literal answers for itself.
+    #[test]
+    fn written_text_of_a_character_reference() -> Result<()> {
+        let text = "a &amp; b".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text(Sourcepos::from((1, 1, 1, 9)), "a & b"),
+            ("a & b", 1)
+        );
+        Ok(())
+    }
+
+    // `\\|` is an escaped backslash and a pipe, which `CommonMark` resolves to
+    // the two bytes it walks as one escape and one byte of its own.
+    #[test]
+    fn written_text_with_escaped_backslash() -> Result<()> {
+        let text = r"a \\| b".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+        assert_eq!(
+            doc.written_text(Sourcepos::from((1, 1, 1, 7)), r"a \| b"),
+            (r"a \\| b", 1)
+        );
         Ok(())
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -791,10 +791,13 @@ mod tests {
         let arena = Arena::new();
         let path = Path::new("test.md").to_path_buf();
         let doc = Document::new(&arena, path, text)?;
-        assert_eq!(
-            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 12)), r"x * y \* z"),
-            (Cow::Owned("x xx y xx* z".to_owned()), 1)
-        );
+        let actual =
+            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 12)), r"x * y \* z");
+
+        // `Cow` compares what it holds and not which of the two it is, so the
+        // masking is asked for by name as well as by what it produced.
+        assert!(matches!(actual.0, Cow::Owned(_)));
+        assert_eq!(actual, (Cow::Owned("x xx y xx* z".to_owned()), 1));
         Ok(())
     }
 
@@ -806,10 +809,13 @@ mod tests {
         let arena = Arena::new();
         let path = Path::new("test.md").to_path_buf();
         let doc = Document::new(&arena, path, text)?;
-        assert_eq!(
-            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 11)), "x ** b ** y"),
-            (Cow::Borrowed("x ** b ** y"), 1)
-        );
+        let actual =
+            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 11)), "x ** b ** y");
+
+        // Borrowed, so the line was answered with as it stands rather than
+        // copied to take nothing out of.
+        assert!(matches!(actual.0, Cow::Borrowed(_)));
+        assert_eq!(actual, (Cow::Borrowed("x ** b ** y"), 1));
         Ok(())
     }
 
@@ -822,10 +828,12 @@ mod tests {
         let arena = Arena::new();
         let path = Path::new("test.md").to_path_buf();
         let doc = Document::new(&arena, path, text)?;
-        assert_eq!(
-            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 15)), r"a & b \* c"),
-            (Cow::Borrowed(r"a & b \* c"), 1)
-        );
+        let actual =
+            doc.written_text_without_escapes(Sourcepos::from((1, 1, 1, 15)), r"a & b \* c");
+
+        // Borrowed, and the literal's own: nothing was masked out of it.
+        assert!(matches!(actual.0, Cow::Borrowed(_)));
+        assert_eq!(actual, (Cow::Borrowed(r"a & b \* c"), 1));
         Ok(())
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -235,13 +235,23 @@ impl<'a> Document<'a> {
         // A line and a column are counted from one, and an index from zero, so
         // a position that starts at either's zero indexes nothing at all.
         let index = written.start.line.checked_sub(1)?;
-        let start = written.start.column.checked_sub(1)?;
-        let text = self
-            .lines
-            .get(index)
-            .and_then(|line| line.get(start..written.end.column))?;
+        let mut start = written.start.column.checked_sub(1)?;
+        let line = self.lines.get(index)?;
 
-        Self::is_source_of(text, literal).then_some((text, written.start.column))
+        // comrak measures a node from the byte its literal begins with, and a
+        // byte written escaped is a column further along than the escape that
+        // wrote it. The backslash is the node's own — nothing else can end on
+        // one, an inline ending in a backtick, a bracket, a marker or a `>` —
+        // and without it the slice is the literal's twin rather than its
+        // source: the escapes in the rest of it are read one byte early, and
+        // the escape at the start is not there to be read at all.
+        if start > 0 && line.as_bytes().get(start - 1) == Some(&b'\\') {
+            start -= 1;
+        }
+
+        let text = line.get(start..written.end.column)?;
+
+        Self::is_source_of(text, literal).then_some((text, start + 1))
     }
 
     /// `written` with the escapes in it masked out, a byte for a byte.
@@ -778,6 +788,27 @@ mod tests {
         let position = Sourcepos::from((1, 1, 1, 7));
         assert_eq!(doc.written_column_of(position, r"a \| b", 3), 5);
         assert_eq!(doc.written_column_of(position, r"a \| b", 5), 7);
+        Ok(())
+    }
+
+    // comrak measures a node from the byte its literal begins with, and a byte
+    // written escaped is a column further along than the escape that wrote it.
+    // Without the backslash the slice is the literal's twin rather than its
+    // source — here it is that byte for byte — and the escapes in the rest of
+    // it are read a byte early.
+    #[test]
+    fn written_column_of_a_line_beginning_with_an_escape() -> Result<()> {
+        let text = r"\\.x y".to_owned();
+        let arena = Arena::new();
+        let path = Path::new("test.md").to_path_buf();
+        let doc = Document::new(&arena, path, text)?;
+
+        // comrak reports 1:2 for a node beginning at the escaped backslash,
+        // which is written at columns 1 and 2.
+        let position = Sourcepos::from((1, 2, 1, 6));
+        assert_eq!(doc.written_column_of(position, r"\.x y", 0), 1);
+        assert_eq!(doc.written_column_of(position, r"\.x y", 1), 3);
+        assert_eq!(doc.written_column_of(position, r"\.x y", 4), 6);
         Ok(())
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -216,12 +216,15 @@ impl<'a> Document<'a> {
     ///
     /// A caller that answers with the literal instead is measuring what the
     /// rules measured before any of this: offsets counted off a string the
-    /// escapes are already out of, added to the column comrak reported. The one
-    /// difference is that the column is put back on the line once, for the node,
-    /// rather than once for each column reported out of it, so a `\|` written
-    /// between the start of the node and the offset is a column that stays
-    /// missing. Both are wrong about that offset either way, and neither is a
-    /// line this can read.
+    /// escapes are already out of, added to the column comrak reported.
+    /// [`Document::written_column_of`] answers with exactly that, one column at
+    /// a time, so a caller of it falls back to what it always did. A caller
+    /// taking the column of the text and adding its offsets to it — which is
+    /// what a caller searching the line has to do — gets that column put back on
+    /// the line once, for the node, rather than once for each column reported
+    /// out of it, so a `\|` written between the start of the node and the offset
+    /// is a column that stays missing. Both are wrong about that offset either
+    /// way, and neither is a line this can read.
     fn line_text<'t>(&'t self, position: Sourcepos, literal: &str) -> Option<(&'t str, usize)> {
         if position.start.line != position.end.line {
             return None;

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -31,43 +31,42 @@ impl RuleLike for MD034 {
         &Self::METADATA
     }
 
-    // TODO: Use safe casting
     #[inline]
-    #[allow(clippy::cast_possible_wrap)]
     fn check(&self, doc: &Document) -> Result<Vec<Violation>> {
         let mut violations = vec![];
         let finder = LinkFinder::new();
 
         for node in doc.ast.descendants() {
-            if let NodeValue::Text(text) = &node.data.borrow().value {
-                for link in finder.links(text) {
-                    if let Some(parent) = node.parent()
-                        && let NodeValue::Link(_) = parent.data.borrow().value
-                    {
-                        continue;
-                    }
+            let data = node.data.borrow();
+            let NodeValue::Text(literal) = &data.value else {
+                continue;
+            };
 
-                    // NOTE: link.start and link.end start from 0
-                    //
-                    // These index `text`, where a backslash escape has already
-                    // been resolved, so they only name columns while it and the
-                    // line are the same length. #406 covers the rest.
-                    let mut position = node.data.borrow().sourcepos;
-                    // The URL's last byte rather than the one after it, which
-                    // is the column reported. A column is put back on the line
-                    // by the character comrak reports at it, and the byte after
-                    // the URL is not the URL's: a `\|` written there would be
-                    // unescaped, and the end would follow it past the URL.
-                    position.end = position.start.column_add(link.end() as isize - 1);
-                    position.start = position.start.column_add(link.start() as isize);
+            // A URL inside a link is already linked.
+            if let Some(parent) = node.parent()
+                && let NodeValue::Link(_) = parent.data.borrow().value
+            {
+                continue;
+            }
 
-                    // Back to the byte after the URL, in the line's own columns.
-                    position = doc.written_position(position);
-                    position.end = position.end.column_add(1);
+            // The line the node was written on rather than its literal, whose
+            // offsets stop naming columns as soon as an escape is resolved out
+            // of it. A URL written with an escape in it is bounded where the
+            // line bounds it, backslash and all, which is where GFM bounds the
+            // link it autolinks out of one.
+            let (text, column) = doc.written_text(data.sourcepos, literal);
 
-                    let violation = self.to_violation(doc.path.clone(), position);
-                    violations.push(violation);
-                }
+            for link in finder.links(text) {
+                // NOTE: link.start and link.end start from 0, and count off
+                //       `column`, which is where the text starts on the line.
+                let mut position = data.sourcepos;
+                position.start.column = column + link.start();
+
+                // The byte after the URL's last, which is the column reported.
+                position.end.column = column + link.end();
+
+                let violation = self.to_violation(doc.path.clone(), position);
+                violations.push(violation);
             }
         }
 
@@ -184,9 +183,10 @@ mod tests {
         Ok(())
     }
 
-    // The column the rule names is the byte after the URL, and here that byte
-    // is the backslash of an escape comrak unescaped. Reading it as the URL's
-    // own would carry the end past the escape along with it.
+    // A backslash directly after a URL is a byte of the line like any other,
+    // and the URL scanner reads it as the URL's own — which is what GFM does
+    // with it too, autolinking `http://www.example.com/\` here. The column
+    // reported is the byte after that.
     #[test]
     fn check_errors_with_escaped_pipe_after_url_in_table_cell() -> Result<()> {
         let text = indoc! {r"
@@ -200,7 +200,64 @@ mod tests {
         let doc = Document::new(&arena, path.clone(), text)?;
         let rule = MD034::default();
         let actual = rule.check(&doc)?;
-        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 5, 3, 28)))];
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 5, 3, 29)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // A backslash escape is resolved before the text node's literal is built,
+    // so the literal is a byte shorter than the line for each one and the URL's
+    // offset in it names a column to the left of where it was written. The line
+    // is measured instead, and the escape keeps its two columns.
+    #[test]
+    fn check_errors_with_escaped_punctuation() -> Result<()> {
+        let text = indoc! {r"
+            x \. y http://www.example.com/ z
+            x \. y\. z http://www.example.com/ w
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((1, 8, 1, 31))),
+            rule.to_violation(path, Sourcepos::from((2, 12, 2, 35))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // Outside a table cell and the paragraph comrak splits off a header row,
+    // `\|` is resolved by the inline parser like any other escape, so it costs
+    // the literal a byte there rather than shifting the columns comrak reports.
+    #[test]
+    fn check_errors_with_escaped_pipe_outside_table() -> Result<()> {
+        let text = "see x\\|y http://www.example.com/".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 10, 1, 33)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // An escape in the scheme is how a URL is written so that it is not
+    // autolinked, and GFM leaves this one alone. The literal has the escape
+    // resolved out of it and reads as a bare URL, so measuring against it
+    // reported a URL the author had already stopped from becoming one.
+    #[test]
+    fn check_no_errors_with_escaped_scheme() -> Result<()> {
+        let text = "For more information, see http\\://www.example.com/.".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -23,37 +23,6 @@ impl MD034 {
     pub const fn new() -> Self {
         Self {}
     }
-
-    /// Whether the scan that found `url` stopped at an escape rather than at
-    /// the end of a URL, leaving a piece of text that is no URL at all.
-    ///
-    /// A backslash written into a URL's path is the URL's own, to a scanner
-    /// here and to GFM alike, and the scan runs on through it. One written into
-    /// the authority is a byte no authority can hold, so the scan stops there
-    /// and hands back what came before it — `http://ex` out of
-    /// `http://ex\_ample.com/` — which a scanner that asks no more of an
-    /// authority than a scheme and a name reads as a URL of its own. GFM
-    /// autolinks nothing there, the authority being what the escape spoiled, so
-    /// neither does this.
-    ///
-    /// The literal says which of the two happened: it holds the authority with
-    /// the escape resolved, so a scan of it finds the URL that was written or
-    /// finds nothing where there is none. A scan that stopped at an escape
-    /// never took one, so what it did take is a prefix of whatever stands there
-    /// in the literal.
-    fn is_cut_short(finder: &LinkFinder, url: &str, rest: &str, literal: &str) -> bool {
-        Self::starts_with_escape(rest)
-            && !finder
-                .links(literal)
-                .any(|link| link.as_str().starts_with(url))
-    }
-
-    /// Whether `text` begins with a `\<punctuation>` escape.
-    fn starts_with_escape(text: &str) -> bool {
-        let mut chars = text.chars();
-
-        chars.next() == Some('\\') && chars.next().is_some_and(|char| char.is_ascii_punctuation())
-    }
 }
 
 impl RuleLike for MD034 {
@@ -80,32 +49,28 @@ impl RuleLike for MD034 {
                 continue;
             }
 
-            // The line the node was written on rather than its literal, whose
-            // offsets stop naming columns as soon as an escape is resolved out
-            // of it. The backslash of an escape is on the line and belongs
-            // there: GFM reads one written into a URL as the URL's own rather
-            // than as an escape, and a URL whose scheme carries one it does not
-            // autolink at all.
-            let (text, column) = doc.written_text(data.sourcepos, literal);
-
-            for link in finder.links(text) {
-                if Self::is_cut_short(&finder, link.as_str(), &text[link.end()..], literal) {
-                    continue;
-                }
-
-                // NOTE: link.start and link.end start from 0, and count off
-                //       `column`, which is where the text starts on the line.
+            // The literal rather than the line, because what a bare URL is is a
+            // question about the text a reader is given: a scan of the line
+            // stops at a backslash written into an authority, which no
+            // authority can hold, and hands back the piece before it as a URL
+            // of its own. `CommonMark` has resolved the escape by the time the
+            // literal is built, and the authority there is the one a reader
+            // sees. What the literal cannot say is where any of it was written,
+            // and that is what `written_column_of` is for.
+            for link in finder.links(literal) {
+                // NOTE: link.start and link.end start from 0
                 let mut position = data.sourcepos;
-
-                // The offsets are counted off one line, so the span is that
-                // line's. comrak ends a text node on another only where the
-                // position is one `written_text` cannot read the line for, and
-                // the offsets are the start line's there too.
                 position.end.line = position.start.line;
-                position.start.column = column + link.start();
+                position.start.column =
+                    doc.written_column_of(data.sourcepos, literal, link.start());
 
-                // The byte after the URL's last, which is the column reported.
-                position.end.column = column + link.end();
+                // The URL's last byte rather than the one after it, stepped
+                // past once it is on the line: a column is answered for by the
+                // byte the literal has at it, and the byte after the URL is not
+                // the URL's. A `\|` written there would be one the walk stops
+                // at, and the end would follow it past the URL.
+                position.end.column =
+                    doc.written_column_of(data.sourcepos, literal, link.end() - 1) + 1;
 
                 let violation = self.to_violation(doc.path.clone(), position);
                 violations.push(violation);
@@ -225,11 +190,10 @@ mod tests {
         Ok(())
     }
 
-    // A backslash directly after a URL is a byte of the line like any other,
-    // and the URL scanner reads it as the URL's own rather than stopping at it.
-    // The column reported is the byte after the last one that scanner took,
-    // which is its own boundary and not GFM's: GFM unescapes the cell first and
-    // autolinks on through the `|y`.
+    // The column the rule names is the byte after the URL, and here that byte
+    // is the backslash of an escape. A column is answered for by the byte the
+    // literal has at it, and the byte after the URL is not the URL's: the walk
+    // stops at that escape, and the end would follow it past the URL.
     #[test]
     fn check_errors_with_escaped_pipe_after_url_in_table_cell() -> Result<()> {
         let text = indoc! {r"
@@ -243,7 +207,7 @@ mod tests {
         let doc = Document::new(&arena, path.clone(), text)?;
         let rule = MD034::default();
         let actual = rule.check(&doc)?;
-        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 5, 3, 29)))];
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 5, 3, 28)))];
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -288,28 +252,12 @@ mod tests {
         Ok(())
     }
 
-    // An escape in the scheme is how a URL is written so that it is not
-    // autolinked, and GFM leaves this one alone. The literal has the escape
-    // resolved out of it and reads as a bare URL, so measuring against it
-    // reported a URL the author had already stopped from becoming one.
-    #[test]
-    fn check_no_errors_with_escaped_scheme() -> Result<()> {
-        let text = "For more information, see http\\://www.example.com/.".to_owned();
-        let path = Path::new("test.md").to_path_buf();
-        let arena = Arena::new();
-        let doc = Document::new(&arena, path, text)?;
-        let rule = MD034::default();
-        let actual = rule.check(&doc)?;
-        let expected = vec![];
-        assert_eq!(actual, expected);
-        Ok(())
-    }
-
-    // A scan of the line stops inside the authority at a backslash, and what it
-    // hands back — `http://ex` here — is a URL to a scanner that asks no more of
-    // an authority than a scheme and a name. GFM autolinks nothing on this line,
-    // the authority being what the escape spoiled, and the literal says so: with
-    // the escape resolved there is no URL in it to be a prefix of.
+    // An escape resolved out of an authority can leave one no URL is written
+    // with — an underscore in either of the last two labels is not a domain to
+    // GFM, and is not one here — and the literal is where that can be seen. A
+    // scan of the line stops at the backslash instead, no authority being able
+    // to hold one, and hands back the `http://ex` before it as a URL of its
+    // own.
     #[test]
     fn check_no_errors_with_escaped_authority() -> Result<()> {
         let text = "see http://my\\_site.com/ now".to_owned();
@@ -323,24 +271,40 @@ mod tests {
         Ok(())
     }
 
-    // The scan stops at the same escape here, and this time the literal does
-    // hold the URL the line was written with, so the piece the scan took is a
-    // prefix of it and the URL beside it is nobody's prefix.
+    // And the piece a scan of the line hands back is a prefix of any URL that
+    // shares it, so a second URL on the line is enough to make one of these
+    // look like a URL that was written.
     #[test]
     fn check_errors_with_escaped_authority_beside_a_url() -> Result<()> {
-        let text = "http://ex\\_ample.com/ and http://good.com".to_owned();
+        let text = "see http://ex\\_ample.com/ and http://ex.com now".to_owned();
         let path = Path::new("test.md").to_path_buf();
         let arena = Arena::new();
         let doc = Document::new(&arena, path.clone(), text)?;
         let rule = MD034::default();
         let actual = rule.check(&doc)?;
-        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 27, 1, 42)))];
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 31, 1, 44)))];
         assert_eq!(actual, expected);
         Ok(())
     }
 
-    // A backslash written into the path is the URL's own, and the scan runs on
-    // through it as GFM does, so nothing here was cut short.
+    // An escape resolved out of an authority that leaves a domain leaves a URL,
+    // and GFM autolinks this one whole. The rule reports the whole of it: the
+    // literal holds it whole, and the walk puts each end back on the line.
+    #[test]
+    fn check_errors_with_escaped_authority_that_resolves() -> Result<()> {
+        let text = "see http://ex\\-ample.com/ now".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 5, 1, 26)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // An escape written into the path is resolved out of the literal like any
+    // other, and the walk puts its two columns back.
     #[test]
     fn check_errors_with_escaped_path() -> Result<()> {
         let text = "see http://www.example.com/foo\\_bar now".to_owned();

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -23,6 +23,37 @@ impl MD034 {
     pub const fn new() -> Self {
         Self {}
     }
+
+    /// Whether the scan that found `url` stopped at an escape rather than at
+    /// the end of a URL, leaving a piece of text that is no URL at all.
+    ///
+    /// A backslash written into a URL's path is the URL's own, to a scanner
+    /// here and to GFM alike, and the scan runs on through it. One written into
+    /// the authority is a byte no authority can hold, so the scan stops there
+    /// and hands back what came before it — `http://ex` out of
+    /// `http://ex\_ample.com/` — which a scanner that asks no more of an
+    /// authority than a scheme and a name reads as a URL of its own. GFM
+    /// autolinks nothing there, the authority being what the escape spoiled, so
+    /// neither does this.
+    ///
+    /// The literal says which of the two happened: it holds the authority with
+    /// the escape resolved, so a scan of it finds the URL that was written or
+    /// finds nothing where there is none. A scan that stopped at an escape
+    /// never took one, so what it did take is a prefix of whatever stands there
+    /// in the literal.
+    fn is_cut_short(finder: &LinkFinder, url: &str, rest: &str, literal: &str) -> bool {
+        Self::starts_with_escape(rest)
+            && !finder
+                .links(literal)
+                .any(|link| link.as_str().starts_with(url))
+    }
+
+    /// Whether `text` begins with a `\<punctuation>` escape.
+    fn starts_with_escape(text: &str) -> bool {
+        let mut chars = text.chars();
+
+        chars.next() == Some('\\') && chars.next().is_some_and(|char| char.is_ascii_punctuation())
+    }
 }
 
 impl RuleLike for MD034 {
@@ -58,6 +89,10 @@ impl RuleLike for MD034 {
             let (text, column) = doc.written_text(data.sourcepos, literal);
 
             for link in finder.links(text) {
+                if Self::is_cut_short(&finder, link.as_str(), &text[link.end()..], literal) {
+                    continue;
+                }
+
                 // NOTE: link.start and link.end start from 0, and count off
                 //       `column`, which is where the text starts on the line.
                 let mut position = data.sourcepos;
@@ -266,6 +301,55 @@ mod tests {
         let rule = MD034::default();
         let actual = rule.check(&doc)?;
         let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // A scan of the line stops inside the authority at a backslash, and what it
+    // hands back — `http://ex` here — is a URL to a scanner that asks no more of
+    // an authority than a scheme and a name. GFM autolinks nothing on this line,
+    // the authority being what the escape spoiled, and the literal says so: with
+    // the escape resolved there is no URL in it to be a prefix of.
+    #[test]
+    fn check_no_errors_with_escaped_authority() -> Result<()> {
+        let text = "see http://my\\_site.com/ now".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // The scan stops at the same escape here, and this time the literal does
+    // hold the URL the line was written with, so the piece the scan took is a
+    // prefix of it and the URL beside it is nobody's prefix.
+    #[test]
+    fn check_errors_with_escaped_authority_beside_a_url() -> Result<()> {
+        let text = "http://ex\\_ample.com/ and http://good.com".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 27, 1, 42)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // A backslash written into the path is the URL's own, and the scan runs on
+    // through it as GFM does, so nothing here was cut short.
+    #[test]
+    fn check_errors_with_escaped_path() -> Result<()> {
+        let text = "see http://www.example.com/foo\\_bar now".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 5, 1, 36)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -51,15 +51,22 @@ impl RuleLike for MD034 {
 
             // The line the node was written on rather than its literal, whose
             // offsets stop naming columns as soon as an escape is resolved out
-            // of it. A URL written with an escape in it is bounded where the
-            // line bounds it, backslash and all, which is where GFM bounds the
-            // link it autolinks out of one.
+            // of it. The backslash of an escape is on the line and belongs
+            // there: GFM reads one written into a URL as the URL's own rather
+            // than as an escape, and a URL whose scheme carries one it does not
+            // autolink at all.
             let (text, column) = doc.written_text(data.sourcepos, literal);
 
             for link in finder.links(text) {
                 // NOTE: link.start and link.end start from 0, and count off
                 //       `column`, which is where the text starts on the line.
                 let mut position = data.sourcepos;
+
+                // The offsets are counted off one line, so the span is that
+                // line's. comrak ends a text node on another only where the
+                // position is one `written_text` cannot read the line for, and
+                // the offsets are the start line's there too.
+                position.end.line = position.start.line;
                 position.start.column = column + link.start();
 
                 // The byte after the URL's last, which is the column reported.
@@ -184,9 +191,10 @@ mod tests {
     }
 
     // A backslash directly after a URL is a byte of the line like any other,
-    // and the URL scanner reads it as the URL's own — which is what GFM does
-    // with it too, autolinking `http://www.example.com/\` here. The column
-    // reported is the byte after that.
+    // and the URL scanner reads it as the URL's own rather than stopping at it.
+    // The column reported is the byte after the last one that scanner took,
+    // which is its own boundary and not GFM's: GFM unescapes the cell first and
+    // autolinks on through the `|y`.
     #[test]
     fn check_errors_with_escaped_pipe_after_url_in_table_cell() -> Result<()> {
         let text = indoc! {r"

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -64,13 +64,15 @@ impl RuleLike for MD034 {
                 position.start.column =
                     doc.written_column_of(data.sourcepos, literal, link.start());
 
-                // The URL's last byte rather than the one after it, stepped
-                // past once it is on the line: a column is answered for by the
-                // byte the literal has at it, and the byte after the URL is not
-                // the URL's. A `\|` written there would be one the walk stops
-                // at, and the end would follow it past the URL.
-                position.end.column =
-                    doc.written_column_of(data.sourcepos, literal, link.end() - 1) + 1;
+                // The byte after the URL's last, which is the column reported,
+                // and asked for as that rather than as the last byte's column
+                // stepped past. A step of one is the width of that byte, which
+                // is one only where it is a single byte written as itself: `é`
+                // is two, and a byte written as `\_` is at the column of the
+                // backslash and two wide. An offset past the end of the literal
+                // is the column after the node, which is where a URL that runs
+                // to the end of its text belongs.
+                position.end.column = doc.written_column_of(data.sourcepos, literal, link.end());
 
                 let violation = self.to_violation(doc.path.clone(), position);
                 violations.push(violation);
@@ -299,6 +301,36 @@ mod tests {
         let rule = MD034::default();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((1, 5, 1, 26)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // The byte after the URL is asked for as that: a URL ending at an escape
+    // ends at the byte the escape guards, which is at the column of its
+    // backslash and two columns wide, and one ending at a multibyte character
+    // is that character's width along.
+    #[test]
+    fn check_errors_with_escape_at_end_of_url() -> Result<()> {
+        let text = "see http://www.example.com/foo\\_ now".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 5, 1, 33)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_with_multibyte_at_end_of_url() -> Result<()> {
+        let text = "see http://www.example.com/f\u{e9}\u{e9} now".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 5, 1, 33)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md034.rs
+++ b/src/rule/md034.rs
@@ -335,6 +335,23 @@ mod tests {
         Ok(())
     }
 
+    // comrak measures a node from the byte its literal begins with, and here
+    // that byte was written as `\\`, which is a column earlier than comrak
+    // reports. The slice is taken from the backslash, or the escapes after it
+    // are read a byte early and the URL lands a column to the right.
+    #[test]
+    fn check_errors_with_escape_at_start_of_node() -> Result<()> {
+        let text = "\\\\.x http://www.example.com/ y".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD034::default();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 6, 1, 29)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
     // An escape written into the path is resolved out of the literal like any
     // other, and the walk puts its two columns back.
     #[test]

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -73,12 +73,19 @@ impl RuleLike for MD037 {
             // The alternatives that begin at a start marker begin at the
             // whitespace before it, and the ones that begin at an end marker
             // begin at the marker, so what the match begins with says which
-            // matched. Asked about a space alone, a tab written before a marker
-            // answered for the end-marker arithmetic and put the report on the
-            // tab rather than on the marker after it.
-            if m.as_str().starts_with(char::is_whitespace) {
+            // matched. `\s` is any whitespace and not the space alone, so it is
+            // asked about as such — a tab answered for the end-marker
+            // arithmetic and put the report on the tab rather than on the
+            // marker — and the marker is that character's width along, which is
+            // two bytes for a no-break space and three for an ideographic one.
+            if let Some(space) = m
+                .as_str()
+                .chars()
+                .next()
+                .filter(|char| char.is_whitespace())
+            {
                 // When a start marker matches
-                position.start.column = column + m.start() + 1;
+                position.start.column = column + m.start() + space.len_utf8();
                 position.end.column = column + m.end() - 1;
             } else {
                 // When an end marker matches
@@ -388,6 +395,23 @@ mod tests {
         let rule = MD037::new();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((1, 3, 1, 9)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // `\s` is whatever is whitespace and not what is one byte of it, so the
+    // marker is that character's width along rather than one: a no-break space
+    // is two bytes, and a column one past its first is inside it and not a
+    // column of the line at all.
+    #[test]
+    fn check_errors_with_multibyte_space_before_marker() -> Result<()> {
+        let text = "x\u{a0}** b ** y".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 4, 1, 10)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -61,6 +61,12 @@ impl RuleLike for MD037 {
 
             let mut position = data.sourcepos;
 
+            // The offsets are counted off one line, so the span is that line's.
+            // comrak ends a text node on another only where the position is one
+            // `written_text_without_escapes` cannot read the line for, and the
+            // offsets are the start line's there too.
+            position.end.line = position.start.line;
+
             // NOTE: m.start and m.end start from 0, and count off `column`,
             //       which is where the text starts on the line.
             if m.as_str().starts_with(' ') {

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -69,7 +69,14 @@ impl RuleLike for MD037 {
 
             // NOTE: m.start and m.end start from 0, and count off `column`,
             //       which is where the text starts on the line.
-            if m.as_str().starts_with(' ') {
+            //
+            // The alternatives that begin at a start marker begin at the
+            // whitespace before it, and the ones that begin at an end marker
+            // begin at the marker, so what the match begins with says which
+            // matched. Asked about a space alone, a tab written before a marker
+            // answered for the end-marker arithmetic and put the report on the
+            // tab rather than on the marker after it.
+            if m.as_str().starts_with(char::is_whitespace) {
                 // When a start marker matches
                 position.start.column = column + m.start() + 1;
                 position.end.column = column + m.end() - 1;
@@ -366,6 +373,21 @@ mod tests {
         let rule = MD037::new();
         let actual = rule.check(&doc)?;
         let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // The regex anchors a start marker to `\s`, which is a tab as much as a
+    // space, and the report belongs on the marker either way.
+    #[test]
+    fn check_errors_with_tab_before_marker() -> Result<()> {
+        let text = "x\t** b ** y".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 3, 1, 9)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -48,15 +48,14 @@ impl RuleLike for MD037 {
                 continue;
             };
 
-            // The line the node was written on rather than its literal. A
-            // marker `CommonMark` resolved an escape off reaches the literal as
-            // a bare one and reads as emphasis, and the offsets of a match stop
-            // naming columns as soon as one has been. The line has the
-            // backslash the author wrote, so the regex passes over the marker it
-            // guards and the offsets it does match are columns already.
-            let (text, column) = doc.written_text(data.sourcepos, literal);
+            // The line the node was written on rather than its literal, whose
+            // offsets stop naming columns as soon as an escape is resolved out
+            // of it, and with the escapes on that line masked out: a marker the
+            // author escaped is not one, and this regex looks for markers in
+            // places that have nothing before them for it to check.
+            let (text, column) = doc.written_text_without_escapes(data.sourcepos, literal);
 
-            let Some(m) = RE.find(text) else {
+            let Some(m) = RE.find(&text) else {
                 continue;
             };
 
@@ -336,9 +335,25 @@ mod tests {
     // Emphasis an author escaped is text, and a pair of escaped markers is not
     // emphasis with spaces inside it. Against the literal both escapes were
     // gone and the pair read as a violation the document does not have.
+    //
+    // The escapes are masked out of the search rather than guarded against
+    // inside it, because the regex looks for a marker in four places that have
+    // nothing before them to check: the closing marker of each start-marker
+    // alternative, and the opening marker of each end-marker one. A backslash
+    // left on the line is also a byte for `.+` to match, so the search reaches
+    // further along the line than the literal ever let it.
     #[test]
     fn check_no_errors_with_escaped_markers() -> Result<()> {
-        let text = "x \\* y \\* z".to_owned();
+        let text = indoc! {r"
+            x \* y \* z
+
+            a b \_ * \*
+
+            a \* b * c
+
+            a * b \*
+        "}
+        .to_owned();
         let path = Path::new("test.md").to_path_buf();
         let arena = Arena::new();
         let doc = Document::new(&arena, path, text)?;

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -33,9 +33,7 @@ impl RuleLike for MD037 {
         &Self::METADATA
     }
 
-    // TODO: Use safe casting
     #[inline]
-    #[allow(clippy::cast_possible_wrap)]
     fn check(&self, doc: &Document) -> Result<Vec<Violation>> {
         static RE: LazyLock<Regex> = LazyLock::new(|| {
             #[allow(clippy::unwrap_used)]
@@ -45,28 +43,39 @@ impl RuleLike for MD037 {
         let mut violations = vec![];
 
         for node in doc.ast.descendants() {
-            if let NodeValue::Text(text) = &node.data.borrow().value
-                && let Some(m) = RE.find(text)
-            {
-                // The match indexes `text`, where a backslash escape has already
-                // been resolved, so its offsets only name columns while that and
-                // the line are the same length — and an escaped marker reaches
-                // the regex as a bare one. #406 covers both.
-                let mut position = node.data.borrow().sourcepos;
+            let data = node.data.borrow();
+            let NodeValue::Text(literal) = &data.value else {
+                continue;
+            };
 
-                if m.as_str().starts_with(' ') {
-                    // When a start marker matches
-                    position.end = position.start.column_add(m.end() as isize - 1);
-                    position.start = position.start.column_add(m.start() as isize + 1);
-                } else {
-                    // When an end marker matches
-                    position.end = position.start.column_add(m.end() as isize - 2);
-                    position.start = position.start.column_add(m.start() as isize);
-                }
+            // The line the node was written on rather than its literal. A
+            // marker `CommonMark` resolved an escape off reaches the literal as
+            // a bare one and reads as emphasis, and the offsets of a match stop
+            // naming columns as soon as one has been. The line has the
+            // backslash the author wrote, so the regex passes over the marker it
+            // guards and the offsets it does match are columns already.
+            let (text, column) = doc.written_text(data.sourcepos, literal);
 
-                let violation = self.to_violation(doc.path.clone(), doc.written_position(position));
-                violations.push(violation);
+            let Some(m) = RE.find(text) else {
+                continue;
+            };
+
+            let mut position = data.sourcepos;
+
+            // NOTE: m.start and m.end start from 0, and count off `column`,
+            //       which is where the text starts on the line.
+            if m.as_str().starts_with(' ') {
+                // When a start marker matches
+                position.start.column = column + m.start() + 1;
+                position.end.column = column + m.end() - 1;
+            } else {
+                // When an end marker matches
+                position.start.column = column + m.start();
+                position.end.column = column + m.end() - 2;
             }
+
+            let violation = self.to_violation(doc.path.clone(), position);
+            violations.push(violation);
         }
 
         Ok(violations)
@@ -260,6 +269,82 @@ mod tests {
             rule.to_violation(path.clone(), Sourcepos::from((3, 8, 3, 14))),
             rule.to_violation(path, Sourcepos::from((4, 11, 4, 17))),
         ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // A backslash escape is resolved before the text node's literal is built,
+    // so the literal is a byte shorter than the line for each one and the
+    // marker's offset in it names a column to the left of where it was written.
+    // The line is measured instead, and the escape keeps its two columns.
+    #[test]
+    fn check_errors_with_escaped_punctuation() -> Result<()> {
+        let text = indoc! {r"
+            x \. y ** b ** z
+
+            | a | b |
+            | --- | --- |
+            | x \. y ** b ** | c |
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((1, 8, 1, 14))),
+            rule.to_violation(path, Sourcepos::from((5, 10, 5, 16))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // Outside a table cell and the paragraph comrak splits off a header row,
+    // `\|` is resolved by the inline parser like any other escape, so it costs
+    // the literal a byte there rather than shifting the columns comrak reports.
+    #[test]
+    fn check_errors_with_escaped_pipe_outside_table() -> Result<()> {
+        let text = "see x\\|y\\|z ** b ** w".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 13, 1, 19)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // An escaped marker reaches the literal as a bare one, so a match could
+    // begin at a marker that is not one and name a column that holds neither of
+    // the markers on the line. The line keeps the backslash that guards it, and
+    // the match begins at the emphasis that is really there.
+    #[test]
+    fn check_errors_with_escaped_marker() -> Result<()> {
+        let text = "x \\* y ** b ** z".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 8, 1, 14)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // Emphasis an author escaped is text, and a pair of escaped markers is not
+    // emphasis with spaces inside it. Against the literal both escapes were
+    // gone and the pair read as a violation the document does not have.
+    #[test]
+    fn check_no_errors_with_escaped_markers() -> Result<()> {
+        let text = "x \\* y \\* z".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -70,28 +70,20 @@ impl RuleLike for MD037 {
             // NOTE: m.start and m.end start from 0, and count off `column`,
             //       which is where the text starts on the line.
             //
-            // The alternatives that begin at a start marker begin at the
-            // whitespace before it, and the ones that begin at an end marker
-            // begin at the marker, so what the match begins with says which
-            // matched. `\s` is any whitespace and not the space alone, so it is
-            // asked about as such — a tab answered for the end-marker
-            // arithmetic and put the report on the tab rather than on the
-            // marker — and the marker is that character's width along, which is
-            // two bytes for a no-break space and three for an ideographic one.
-            if let Some(space) = m
-                .as_str()
-                .chars()
-                .next()
-                .filter(|char| char.is_whitespace())
-            {
-                // When a start marker matches
-                position.start.column = column + m.start() + space.len_utf8();
-                position.end.column = column + m.end() - 1;
-            } else {
-                // When an end marker matches
-                position.start.column = column + m.start();
-                position.end.column = column + m.end() - 2;
-            }
+            // Every alternative is anchored by the whitespace on one side of
+            // the emphasis — before a start marker, after an end one — and what
+            // is reported is the emphasis. The anchor comes off whichever end
+            // carries it, and off by however wide it is: `\s` is any whitespace
+            // and not the space alone, so it is a tab, or the two bytes of a
+            // no-break space, or the three of an ideographic one. Trimming both
+            // ends is one way of saying that, the alternative that anchors an
+            // end has nothing to trim off the other.
+            let matched = m.as_str();
+            let start = m.start() + matched.len() - matched.trim_start().len();
+            let end = m.end() - (matched.len() - matched.trim_end().len());
+
+            position.start.column = column + start;
+            position.end.column = column + end - 1;
 
             let violation = self.to_violation(doc.path.clone(), position);
             violations.push(violation);
@@ -400,9 +392,23 @@ mod tests {
     }
 
     // `\s` is whatever is whitespace and not what is one byte of it, so the
-    // marker is that character's width along rather than one: a no-break space
-    // is two bytes, and a column one past its first is inside it and not a
-    // column of the line at all.
+    // anchor comes off by its own width rather than by one: a no-break space is
+    // two bytes, and a column one inside it is not a column of the line at all.
+    // This is the end marker's anchor, which is trimmed off the end.
+    #[test]
+    fn check_errors_with_multibyte_space_after_marker() -> Result<()> {
+        let text = "x** b **\u{a0}y".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 2, 1, 8)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // And this is the start marker's, which is trimmed off the start.
     #[test]
     fn check_errors_with_multibyte_space_before_marker() -> Result<()> {
         let text = "x\u{a0}** b ** y".to_owned();

--- a/src/rule/md037.rs
+++ b/src/rule/md037.rs
@@ -376,6 +376,47 @@ mod tests {
         Ok(())
     }
 
+    // comrak measures a node from the byte its literal begins with, so a node
+    // beginning with an escape is reported from the byte the escape wrote and
+    // not from the backslash. Taking the slice from the backslash is what keeps
+    // the escapes after it from being read a byte early — and here it is what
+    // keeps a real marker from being masked as an escaped one, the `\\` of `\\\\`
+    // having been read as the escape of the `*` after it.
+    #[test]
+    fn check_errors_with_escape_at_start_of_node() -> Result<()> {
+        let text = r"\\* a * b".to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 3, 1, 7)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // And a node beginning at an escaped marker is reported from the marker, so
+    // the backslash that escaped it is outside the columns comrak gives and the
+    // mask cannot see it there either. `* a * b` is one unpaired marker and an
+    // escaped one, which is no emphasis at all.
+    #[test]
+    fn check_no_errors_with_escaped_marker_at_start_of_node() -> Result<()> {
+        let text = indoc! {r"
+            `c`\* a * b
+
+            **z**\* a * b
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD037::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
     // The regex anchors a start marker to `\s`, which is a tab as much as a
     // space, and the report belongs on the marker either way.
     #[test]


### PR DESCRIPTION
Closes #406.

## The defect

`CommonMark` resolves a backslash escape before a text node's `literal` is
built, so `\.` is two bytes on the line and one there. MD034 and MD037 counted
their offsets off that literal and added them to the node's start column, which
comrak records against the line. Every offset past an escape named a column one
to the left of the character it was written at, and one more for each further
escape.

```markdown
x \. y http://www.example.com/ z        reported 1:7  for a URL at 1:8
x \. y\. z http://www.example.com/ w    reported 2:10 for a URL at 2:12
see x\|y http://www.example.com/        reported 1:9  for a URL at 1:10
| x \. y ** b ** | c |                  reported 6:9  for a marker at 6:10
```

MD037 fared worse than shifted: an escaped `*` or `_` reaches the literal as a
bare one, so `x \* y ** b ** z` was reported at 1:3 — the escaped marker, which
is neither of the two markers the line has.

The pipe is not #403's everywhere either. Outside a table cell and the paragraph
comrak splits off a header row, `\|` is resolved by the inline parser like any
other escape, so it lands here rather than there and `written_position` has
nothing recorded for it.

## The fix

The two rules want different things, because their defects are different.

**MD034 keeps scanning the literal**, which is what `main` scans and what
`CommonMark` renders: what a bare URL *is* is a question about the text a reader
is given. Only its columns were wrong, so only its columns change.
`Document::written_column_of` walks an offset of the literal along the line — the
two run together a character at a time and part company only at an escape, whose
backslash is a byte of the line the literal does not have — and answers with the
column it lands on.

**MD037 searches the line**, because no arithmetic on a column can undo an
escape the literal has already resolved: a marker the author escaped to keep is
a bare one there. It searches `written_text_without_escapes`, the line with each
escape masked out a byte for a byte, so the escaped markers are invisible to the
search and every column it reports is still the column the byte is at. Searching
the line alone would not do it — only the opening marker of `\s\*\s.+\*` and the
three like it is anchored to whitespace, which a backslash cannot be, so an
escaped marker still matched at their closing marker and at the opening marker of
the four that end `\s\*\s`, and the backslash left on the line is a byte for `.+`
besides. Masking is also what gets `\\*` right, that being an escaped backslash
and then a marker: the run is walked, so the marker comes back.

#405's correction runs first for both, since a position from inside a table cell
is measured against the unescaped cell rather than against the line. What it
corrects and what this does are the two halves of one report: the position of
the node, and the offsets counted off inside it.

## Where the line begins

comrak measures a node from the byte its literal begins with, and a byte
written escaped is a column further along than the escape that wrote it:
`\\.x http://ex.com/ y` is one node reported from 1:2, and the `\\` that put the
literal's first byte there begins at 1:1. The slice is taken from the escape,
not from the column comrak gives, or what is left is the literal's twin rather
than its source and every escape after it is read a byte early. The backslash
before a node can only be the node's own: nothing else ends on one, an inline
ending in a backtick, a bracket, a marker or a `>`.

It is also what lets the mask do its whole job. A node beginning at an escaped
marker is reported from the marker — `` `c`\* a * b `` is one node from 1:5 — so
without the extra column the backslash is not in the slice to be masked, and the
escaped marker is reported on a line whose only other marker is unpaired.

## The line is checked, not assumed

The line is used only where it reads back as the source the literal was built
from. Two things fail that, and both then fall back to what the rules did before
any of this — the offset added to comrak's column, and that column put back on
the line.

- comrak measures the inlines after one that spans two lines — a link with its
  destination on the line below — from a line and a column that are both a line
  behind. The slice then holds text from some other part of the document. The
  gitlab benchmark corpus has one, at `doc/user/group/insights/index.md:33`.
- A character reference is resolved into the literal the way an escape is, and
  naming the character `&amp;` stands for takes the whole HTML5 table. 15 of the
  190,074 text nodes in the gitlab corpus hold one.

## What else changes

- MD037 no longer reports a line whose only emphasis is the one its author
  escaped to keep, and reports the marker rather than the escaped one on a line
  that has both.
- MD037 trims the anchoring whitespace off whichever end of the match carries
  it, and off by that character's own width. The regex anchors on `\s`, which is
  a tab as much as a space and is two bytes for a no-break space and three for
  an ideographic one; a tab put the report on the tab instead of the marker
  after it, and a wider space put an end column inside the character.
- MD034's span ends one column further right wherever an escape was written
  inside the URL, the end being a column now walked to the line like the start.
  No output format reads a violation's end, so this is not visible.

## Where this stops

`http\://www.example.com/` is still reported, as on `main`, and GFM does not
autolink it. Which of the two strings a rule scans is the wrong lever for that —
scanning the line, which #407 did at first, hands back the `http://ex` of
`http://ex\_ample.com/` as a URL of its own, a false positive of its own and a
worse one — and the answer is GFM's own rules about what an authority may hold.
That is filed as #408, along with `http://localhost/x`, which is the same defect
with no escape in it.

The fallbacks above take the literal, so an escape in a node holding a character
reference is still counted off the literal, and a position comrak measured from a
line behind is still reported a line behind. The character reference is a
`CommonMark` transformation this could learn the same way it learned the escape;
it is not in this PR.

MD037's fallback is a column put back on the line once, for the node, rather
than once for each column reported out of it — a caller that searches the line
has to add its offsets to the column it was given — so a `\|` written between the
node's start and the match is a column that stays missing where `main` put it
back. `| x\|y &amp;amp; z ** b ** w |` reports one column left of where `main` does,
both being wrong about it, and it takes a table cell holding an escaped pipe and
a character reference and spaced emphasis to reach. MD034 has no such gap:
`written_column_of` puts each column back on its own, which is what `main` did
column by column. This is deliberate, and `line_text` says so.

## Verification

- `cargo test --all-features --workspace`: 378 tests pass, including the columns
  #406 names, MD034 cases for an escape written into an authority, a path, the
  end of the URL and after it, and a multibyte character at the end, MD037 cases
  that pin the escaped markers out of its search and a tab and a no-break space
  on either side of a marker, cases in both rules for a node that begins with an
  escape, and twelve for `written_column_of` and `written_text_without_escapes`.
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`,
  `cargo fmt --all --check` and `cargo doc` under `-D warnings` are clean.
- `cargo llvm-cov`: `src/document.rs`, MD034 and MD037 keep 100% line coverage.
- Ran the built binary over the acceptance corpus, the gitlab benchmark corpus
  and this repository's own Markdown, before and after: byte-identical output,
  so nothing outside an escape moved.
- `mado check` on the gitlab corpus, release build, 20 interleaved runs each:
  75ms median against `main`'s 74ms. MD034 reaches the line only where it found
  a URL; MD037 reads it per text node, and two texts of the same length had no
  escape resolved between them and so have to be the same bytes, which is nearly
  every node and is compared whole rather than walked.
- Every violation's span is one line's: the rules set `end.line` with
  `end.column` rather than leaving whatever line comrak ended the node on, which
  the old arithmetic carried over for them.
- The three tests for the masking assert which `Cow` arm it took as well as what
  it produced. `Cow` compares its contents and not its variant, so deleting the
  `contains('\\')` fast path left them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV
