### PR TITLE
ci: run cargo test with --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           toolchain: "1.91.1"
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --locked --all-features --workspace
         env:
           CLICOLOR_FORCE: true
           TZ: 'Asia/Tokyo'

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ fmt:
     taplo format
 
 test:
-    CLICOLOR_FORCE=true cargo test --all-features --workspace
+    CLICOLOR_FORCE=true cargo test --locked --all-features --workspace
 
 lint:
     cargo clippy --all-targets --all-features --workspace -- -D warnings


### PR DESCRIPTION
One of the three things #394 asks for. What happened to the second is below,
because it is the more useful half of this pull request.

## `cargo test --locked`

In CI and in `just test`. Without it a stale `Cargo.lock` first shows up in CD's
matrix, which builds `--locked --release`, rather than on the pull request that
staled it. `scripts/release/check-versions.sh` compares the lockfile's `mado`
version against `Cargo.toml`, so it catches a forgotten bump and nothing else.

## Dropped: pointing `Test Action` at a release whose assets are up

#394 says a run can land between CD creating a release and its last asset
finishing upload, and 404. It cannot, and this pull request originally carried
about forty lines defending against it.

CD publishes through `houseabsolute/actions-rust-release/publish`, whose
`create-release.py` issues a single `gh release create <tag> … <files>`. `gh`
given assets does not create-then-upload:

> When using the `create` command to attach assets to a release, separate API
> calls are made to create the release as a draft, upload the assets, and then
> publish the release.
> — `gh release create --help`

and `create-release.py` says the same in `build_command`, calling it "the
sequence GitHub documents for repos that have immutable releases turned on". So
a published release never lacks the assets it was created with, and while the
upload is running the release is a draft — which `gh release view` does not
return. The step that was already there was safe.

The step that replaced it was not free, either: an API call per release walked,
a hard failure on any runner that is not Linux, a second copy of the asset-name
mapping that `action/entrypoint.sh` owns, and a swap of `gh release view`'s "the
release GitHub marks Latest" for `gh release list`'s newest-by-creation-date,
under which a patch to an older series published after a newer one becomes what
the action is tested against. It also checked asset *names*, which appear as
soon as an upload starts — `--json assets --jq '.assets[] | {name, state}'`
shows `state` on each — so even in the one case that could reach it (a release
created by hand, with files dragged in afterwards) it would have answered yes
while the archive was still in flight.

None of that is worth carrying for a race that does not exist. `ci-action.yml`
is unchanged here.

## Verification

- `cargo metadata --locked` succeeds against the tracked lockfile, so `--locked`
  gates rather than breaks.
- `just test`: 378 tests pass under `--locked`. `just lint` is clean.
- `actionlint` is clean on every workflow.

No changelog entry: CI is not something a user of `mado` can observe, which is
what `CONTRIBUTING.md` asks the entry to describe.

## What is left of #394

Both other items. The default `version` is still never exercised — the workflow
always passes one, so `VERSION="${INPUT_VERSION:-$DEFAULT_VERSION}"`, the line
every caller of `akiomik/mado@vx.y.z` takes, is never run — and covering it
needs to know where the action installs, which is being decided in #393. The
asset race is being written up in the issue as not a defect, with the evidence
above, so that it is not built a second time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV
