### PR TITLE
ci: run the rest of the cargo jobs with --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Clippy check
-        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features --workspace -- -D warnings
 
   docs:
     name: Docs
@@ -95,7 +95,7 @@ jobs:
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --no-deps --document-private-items --all-features --workspace
+        run: cargo doc --locked --no-deps --document-private-items --all-features --workspace
 
   coverage:
     name: Code Coverage
@@ -115,7 +115,7 @@ jobs:
           tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --locked --all-features --workspace --lcov --output-path lcov.info
         env:
           CLICOLOR_FORCE: true
           TZ: 'Asia/Tokyo'

--- a/justfile
+++ b/justfile
@@ -13,11 +13,11 @@ test:
     CLICOLOR_FORCE=true cargo test --locked --all-features --workspace
 
 lint:
-    cargo clippy --all-targets --all-features --workspace -- -D warnings
+    cargo clippy --locked --all-targets --all-features --workspace -- -D warnings
     taplo lint
 
 cov:
-    CLICOLOR_FORCE=true cargo llvm-cov --open
+    CLICOLOR_FORCE=true cargo llvm-cov --locked --open
 
 [linux]
 flamegraph target="scripts/benchmarks/data/gitlab":


### PR DESCRIPTION
Follows #410, which put `--locked` on `cargo test` because that is the job whose
absence #394 named. The rest of the cargo jobs resolve dependencies too.

Left as they were, they quietly regenerate the lockfile they were handed:
`Test Suite` goes red on a stale `Cargo.lock` while `Clippy`, `Docs` and
`Code Coverage` pass beside it, each having written a different answer to what
the tree says. Whatever a job builds, it builds what the lockfile names.

- `.github/workflows/ci.yml`: `cargo clippy`, `cargo doc`, `cargo llvm-cov`.
- `justfile`: `just lint` and `just cov`, `just test` having gone in #410.

## Left alone

- `cargo fmt` — takes no lockfile and resolves nothing.
- `just flamegraph` and `just fuzz` — `cargo fuzz` builds out of `fuzz/`, which
  carries a manifest and a lockfile of its own, and neither recipe is a gate. A
  contributor profiling a change is not the person a stale lockfile has to stop.

## Verification

Each of the five commands run with the flag against the tracked lockfile:

- `cargo clippy --locked --all-targets --all-features --workspace -- -D warnings`: clean.
- `cargo doc --locked --no-deps --document-private-items --all-features --workspace`
  under `RUSTDOCFLAGS=-D warnings`: clean.
- `cargo llvm-cov --locked --all-features --workspace`: 99.73% line coverage, the
  same as without it.
- `just test`: 378 tests pass. `just lint`: clean.
- `actionlint` is clean on every workflow.

No changelog entry: CI is not something a user of `mado` can observe, which is
what `CONTRIBUTING.md` asks the entry to describe.

Refs #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV
