### PR TITLE
ci: build the development scripts' mado with --locked

### DIFF
--- a/scripts/acceptance/test.sh
+++ b/scripts/acceptance/test.sh
@@ -121,7 +121,11 @@ cd "$PROJECT_ROOT" || exit 1
 
 # A failed build is that same empty file, and `cargo run`'s status cannot be
 # told apart from mado's.
-cargo build || exit 1
+#
+# `--locked` because this measures the tree as it stands: a build that resolves
+# a newer dependency measures something else, and writes the answer into the
+# `Cargo.lock` the tree tracks on its way past.
+cargo build --locked || exit 1
 
 
 # Not gated on what they found, both returning 1 for violations, the normal
@@ -161,7 +165,7 @@ fi
 #
 # `--` because `--config` means something to cargo too, and mado takes it
 # before the subcommand.
-cargo run -- --config "$MADO_CONFIG" \
+cargo run --locked -- --config "$MADO_CONFIG" \
   check --output-format=mdl "$DOC_PATH" > "$TEMP_PATH/mado.part" < /dev/null
 rc=$?
 if [ "$rc" -gt 1 ]; then

--- a/scripts/benchmarks/comparison.sh
+++ b/scripts/benchmarks/comparison.sh
@@ -89,7 +89,11 @@ done
 
 # Unchecked, a compile error leaves the previous `target/release/mado` in place
 # for hyperfine to time and report as this tree's number.
-cargo build --release || exit 1
+#
+# `--locked` because a benchmark is a number about this tree: a build that
+# resolves a newer dependency times something else, and writes the answer into
+# the `Cargo.lock` the tree tracks on its way past.
+cargo build --locked --release || exit 1
 
 # And that it landed where hyperfine will look: `CARGO_TARGET_DIR`, a
 # `build.target-dir` in the cargo config, or a configured target triple all put


### PR DESCRIPTION
Finishes what #410 and #411 did for CI, on the side a contributor runs.

`scripts/acceptance/test.sh` builds and runs mado to compare it against mdl, and
`scripts/benchmarks/comparison.sh` builds it to time. Both did so unlocked, so
either one can rewrite the tracked `Cargo.lock` under someone who only meant to
measure something.

The measurement is the better reason. Both scripts answer a question about this
tree — what mado reports, and how long it takes — and a build that resolves a
newer dependency answers it about a different one.

```
scripts/acceptance/test.sh:124        cargo build              -> cargo build --locked
scripts/acceptance/test.sh:168        cargo run --             -> cargo run --locked --
scripts/benchmarks/comparison.sh:92   cargo build --release    -> cargo build --locked --release
```

## Left alone

`just flamegraph` and `just fuzz`, which are the two invocations this leaves.
Neither can be given the flag:

- `cargo flamegraph` has no `--locked`, `--frozen` or `--offline` of its own and
  no passthrough to cargo's; its trailing arguments go to the binary being
  profiled.
- `cargo fuzz run` has none of the three either; its trailing arguments go to
  libFuzzer. It resolves and can rewrite `fuzz/Cargo.lock`, which is tracked, so
  it is the same failure this pull request closes rather than a different one.

Both need something other than a flag — `CARGO_NET_OFFLINE` around the recipe,
or a `cargo build --locked` ahead of it — and that is not a `--locked` change.

## Verification

- Each command run as the scripts now spell it: `cargo build --locked`,
  `cargo run --locked -- --config … check …` and `cargo build --locked --release`
  all succeed against the tracked lockfile. The middle one matters most, the
  flag having to sit before the `--` that hands the rest to mado.
- `sh -n` and `dash -n` pass on both scripts.
- `shellcheck` reports what it reported before the change: the four SC2016 in
  `comparison.sh` that #398 covers, and nothing new.

No changelog entry: the development scripts are not something a user of `mado`
can observe, which is what `CONTRIBUTING.md` asks the entry to describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV
