### PR TITLE
chore: bump version to v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ parsed and therefore what gets reported.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-09-07
+
 ### Added
 
 - The GitHub Action takes a `version` input, so a workflow can run a mado
@@ -168,7 +170,8 @@ parsed and therefore what gets reported.
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[Unreleased]: https://github.com/akiomik/mado/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/akiomik/mado/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/akiomik/mado/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/akiomik/mado/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/akiomik/mado/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/akiomik/mado/compare/v0.2.1...v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "mado"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mado"
 description = "A fast Markdown linter."
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 repository = "https://github.com/akiomik/mado"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ Mado is compatible with GitHub Actions.
 
 ```yaml
 # Basic usage (runs `mado check .`)
-- uses: akiomik/mado@v0.3.1
+- uses: akiomik/mado@v0.3.2
 
 # Custom usage (runs `mado` with specified arguments)
-- uses: akiomik/mado@v0.3.1
+- uses: akiomik/mado@v0.3.2
   with:
     args: '--config path/to/mado.toml check path/to/*.md'
 ```

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -4,7 +4,7 @@ COMMAND="mado"
 # The release published alongside this version of the action. The `version`
 # input overrides it, because a version bump names its release before the tag
 # that creates it exists.
-DEFAULT_VERSION="v0.3.1"
+DEFAULT_VERSION="v0.3.2"
 VERSION="${INPUT_VERSION:-$DEFAULT_VERSION}"
 # This ends up in a path and a URL, and a workflow can wire the input to
 # anything, so accept only something shaped like one of our tags.


### PR DESCRIPTION
Release preparation for v0.3.2 — steps 1 and 2 of the release procedure in
`CONTRIBUTING.md`.

## Changes

- `CHANGELOG.md`: close `## [Unreleased]` as `## [0.3.2] - 2026-09-07`, add a
  fresh empty `## [Unreleased]` above it, and update the link definitions.
- Bump the version in the files the tagged commit has to be right about:
  `version` in `Cargo.toml` and `Cargo.lock`, `DEFAULT_VERSION` in
  `action/entrypoint.sh`, and the `akiomik/mado@vx.y.z` pins in `README.md`.

`flake.nix` and the manifests under `pkg/` still name v0.3.1. Their `just`
recipes download the assets of the release being packaged, so they cannot run
before CD has published the tag; refreshing them is the follow-up pull request
of step 4.

## Release contents

`0.3.2` collects one addition — the GitHub Action's `version` input — and
fixes to MD004, MD005, MD007, MD029, MD030, MD033, MD034, MD037, MD038 and
MD039, plus the Action's arm64 asset name. See the changelog section for the
full list; CD publishes it as the release notes.

## Next steps

Once this is merged, tag the merged commit `v0.3.2` and push the tag to start
CD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV