### PR TITLE
chore: bump packages to v0.3.2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,17 +25,17 @@
         packages = {
           mado = pkgs.stdenv.mkDerivation rec {
             pname = "mado";
-            version = "0.3.1";
+            version = "0.3.2";
 
             src = pkgs.fetchzip {
               stripRoot = false;
               url = "https://github.com/akiomik/mado/releases/download/v${version}/mado-${os}-${arch}.tar.gz";
               sha256 =
                 {
-                  x86_64-linux = "1nwmvgl3dy89n543mip9y9rdrw70rrakz196706lnvphy87q2r79";
-                  aarch64-linux = "0phxxgfz7ddvlxjry2216k2sjfsbv7ma9v6w9h57f1aa8gxk7q15";
-                  x86_64-darwin = "0f0mfv152xfq4cg41bf9fnzpjgbxbn1m0aflm7kzph4yh38msl3c";
-                  aarch64-darwin = "0dfdg2d8znnvzwvf1qrkk0iv9jndc8ksqyi81vdzkzlifqjy2p0i";
+                  x86_64-linux = "01pr100kq24638hil6vm6s6dmjv26ljbaibbzg3jik85vpagh3mb";
+                  aarch64-linux = "0wbanyvgs744mb6wp1jcyhz9bpr1f9f9k6ai7izs8q5cn8sq7z6z";
+                  x86_64-darwin = "1rq4axj2pxzw39bc6njfx7hpmy1gg89igj96f4znwjj7nfd5mxjs";
+                  aarch64-darwin = "0wrinjdh5jy9a0nk0f2y8faflwdlrvz930vc1xwsyjivy4j27sgl";
                 }
                 .${system} or (throw "unsupported system ${system}");
             };

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
-prev_version := "0.3.0"
-version := "0.3.1"
+prev_version := "0.3.1"
+version := "0.3.2"
 tempdir := `mktemp -d`
 
 default: fmt test lint

--- a/pkg/homebrew/mado.rb
+++ b/pkg/homebrew/mado.rb
@@ -3,30 +3,30 @@
 class Mado < Formula
   desc "Fast Markdown linter written in Rust"
   homepage "https://github.com/akiomik/mado"
-  version "0.3.1"
+  version "0.3.2"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
       url "https://github.com/akiomik/mado/releases/download/v#{version}/mado-macOS-arm64.tar.gz"
-      sha256 "8043af62e1d2f726b34cb34c9f66fe74f9bc1750666351872318fb680f20cde6"
+      sha256 "d3164d15cce56433353873e82973c79b6353a63f0f77cc26befd9924c1e1d7cf"
     end
 
     on_intel do
       url "https://github.com/akiomik/mado/releases/download/v#{version}/mado-macOS-x86_64.tar.gz"
-      sha256 "c7d0cc6665ca9d6535219a790222913a6d92d7a170aa4e7665cec4c2a1427646"
+      sha256 "672960fd9d563d2c00991ebdadd21d148d50e0cc84aa195849ec78511f9b2610"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/akiomik/mado/releases/download/v#{version}/mado-Linux-gnu-arm64.tar.gz"
-      sha256 "cb7df9feff1c117eeedc7b33267d853980192b7cffceb723794f74d54cde1522"
+      sha256 "64111976745e939df3d9f18d9912a6b0a0c62aabf571ea1c5eb31ffd111be46a"
     end
 
     on_intel do
       url "https://github.com/akiomik/mado/releases/download/v#{version}/mado-Linux-gnu-x86_64.tar.gz"
-      sha256 "403f72360876d42301b79f879344ba27bf320ca885069db2c697cd21acaf1f4d"
+      sha256 "3d4993a8c175485a8574706c243cbaeb2a7b4788a9f0deee5eac79a883107726"
     end
   end
 

--- a/pkg/scoop/mado.json
+++ b/pkg/scoop/mado.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A fast Markdown linter written in Rust",
   "homepage": "https://github.com/akiomik/mado",
   "license": "Apache-2.0",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/akiomik/mado/releases/download/v0.3.1/mado-Windows-msvc-x86_64.zip",
-      "hash": "be65d19751bfe6702307f11c08ea6ade92da1d9a034bde85aefc979e2f0a700e"
+      "url": "https://github.com/akiomik/mado/releases/download/v0.3.2/mado-Windows-msvc-x86_64.zip",
+      "hash": "4d04095cccaad58319ad1094575797dc92d7488413f18099768865e4c47fb8e7"
     }
   },
   "bin": "mado.exe",

--- a/pkg/winget/mado.yml
+++ b/pkg/winget/mado.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.9.0.schema.json
 
 PackageIdentifier: AkiomiKamakura.Mado
-PackageVersion: 0.3.1
+PackageVersion: 0.3.2
 PackageLocale: en-US
 PackageName: Mado
 ShortDescription: A fast Markdown linter written in Rust.
@@ -19,7 +19,7 @@ UpgradeBehavior: install
 ReleaseDate: 2025-01-17
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/akiomik/mado/releases/download/v0.3.1/mado-Windows-msvc-x86_64.zip
-    InstallerSha256: be65d19751bfe6702307f11c08ea6ade92da1d9a034bde85aefc979e2f0a700e
+    InstallerUrl: https://github.com/akiomik/mado/releases/download/v0.3.2/mado-Windows-msvc-x86_64.zip
+    InstallerSha256: 4d04095cccaad58319ad1094575797dc92d7488413f18099768865e4c47fb8e7
 ManifestType: singleton
 ManifestVersion: 1.9.0


### PR DESCRIPTION
Step 4 of the release procedure in `CONTRIBUTING.md`, for the
[v0.3.2](https://github.com/akiomik/mado/releases/tag/v0.3.2) release CD has
now published.

## Changes

- `justfile`: `version` 0.3.2, `prev_version` 0.3.1.
- `pkg/homebrew/mado.rb`, `pkg/scoop/mado.json`, `pkg/winget/mado.yml` and
  `flake.nix`: refreshed with `just update-homebrew`, `just update-scoop`,
  `just update-winget` and `just update-flake`.

Every one of those recipes downloads the assets of the release it hashes, so
this is the earliest they could run — which is why these files named v0.3.1 at
the moment the tag was pushed.

## Verification

Each checksum was re-derived from the published release independently of the
recipes' `sed`, and all nine agree:

| Asset | Manifest |
| --- | --- |
| `mado-macOS-arm64.tar.gz` | `d3164d15…` — homebrew |
| `mado-macOS-x86_64.tar.gz` | `672960fd…` — homebrew |
| `mado-Linux-gnu-arm64.tar.gz` | `64111976…` — homebrew |
| `mado-Linux-gnu-x86_64.tar.gz` | `3d4993a8…` — homebrew |
| `mado-Windows-msvc-x86_64.zip` | `4d04095c…` — scoop, winget |

`flake.nix`'s four base32 hashes were re-derived with `nix-prefetch-url
--unpack` and match, each under the right `system` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV