### PR TITLE
fix: stamp the winget manifest's ReleaseDate with the release being packaged

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,10 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
    release being packaged, so none of them can run any earlier. This is also why
    `flake.nix` and the manifests under `pkg/` still name the previous version at
    the moment the tag is pushed, and why `nix run github:akiomik/mado/vx.y.z`
-   gets the release before it.
+   gets the release before it. `just update-winget` also stamps `ReleaseDate` —
+   the date WinGet shows the installer as released on — from the changelog
+   heading for the version, and stops rather than leave the previous release's
+   date behind if step 1 left that section undated.
 
 CD builds the binaries for every platform and publishes one release once all of
 them are packaged. Its body is that version's changelog section, extracted by

--- a/justfile
+++ b/justfile
@@ -99,10 +99,14 @@ winget-release-date:
     @echo 'Reading the release date for {{ version }} from CHANGELOG.md...'
     @sed -n 's/^## \[{{ version }}\] - \([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\)$/\1/p' CHANGELOG.md \
       > {{ tempdir }}/release-date
-    @if [ ! -s {{ tempdir }}/release-date ]; then \
-         echo 'CHANGELOG.md has no `## [{{ version }}] - YYYY-MM-DD` section' >&2; \
-         exit 1; \
-       fi
+    @dates=`wc -l < {{ tempdir }}/release-date` \
+      && if [ "$dates" -eq 0 ]; then \
+           echo 'CHANGELOG.md has no `## [{{ version }}] - YYYY-MM-DD` section' >&2; \
+           exit 1; \
+         elif [ "$dates" -gt 1 ]; then \
+           echo 'CHANGELOG.md dates `## [{{ version }}]` more than once' >&2; \
+           exit 1; \
+         fi
 
 update-winget: winget-release-date update-winget-hash-all
     @echo 'Updating pkg/winget/mado.yml for {{ version }}...'

--- a/justfile
+++ b/justfile
@@ -90,6 +90,10 @@ update-winget-hash-all: update-winget-hash-windows-amd64
 # the release is dated. Only `YYYY-MM-DD` counts: that is all the manifest
 # schema's `date` format admits, and a heading written any other way does not
 # say which day it means.
+#
+# `update-winget` reads the date through this recipe, before the checksums are
+# downloaded, so a changelog that cannot answer stops it before anything has
+# been written to the manifest.
 [private]
 winget-release-date:
     @echo 'Reading the release date for {{ version }} from CHANGELOG.md...'
@@ -100,14 +104,11 @@ winget-release-date:
          exit 1; \
        fi
 
-# The date is read before the checksums are downloaded, so a changelog that
-# cannot answer stops the recipe before anything has been written to the
-# manifest.
 update-winget: winget-release-date update-winget-hash-all
     @echo 'Updating pkg/winget/mado.yml for {{ version }}...'
     @sed -I '' "s/{{ prev_version }}/{{ version }}/" pkg/winget/mado.yml
     @release_date=`cat {{ tempdir }}/release-date` \
-      && echo "Updating pkg/winget/mado.yml for $release_date..." \
+      && echo "Stamping ReleaseDate as $release_date..." \
       && sed -I '' "s/^ReleaseDate: .*/ReleaseDate: $release_date/" pkg/winget/mado.yml \
       && if ! grep -q "^ReleaseDate: $release_date$" pkg/winget/mado.yml; then \
            echo 'pkg/winget/mado.yml has no ReleaseDate line to stamp' >&2; \

--- a/justfile
+++ b/justfile
@@ -86,18 +86,33 @@ update-winget-hash-all: update-winget-hash-windows-amd64
 
 # `ReleaseDate` is the date WinGet shows the installer as released on, so it has
 # to move with every version. It comes from the changelog rather than today's
-# date: this recipe runs once CD has finished, which is not always the day the
-# release is dated.
-update-winget: update-winget-hash-all
+# date: `update-winget` runs once CD has finished, which is not always the day
+# the release is dated. Only `YYYY-MM-DD` counts: that is all the manifest
+# schema's `date` format admits, and a heading written any other way does not
+# say which day it means.
+[private]
+winget-release-date:
+    @echo 'Reading the release date for {{ version }} from CHANGELOG.md...'
+    @sed -n 's/^## \[{{ version }}\] - \([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\)$/\1/p' CHANGELOG.md \
+      > {{ tempdir }}/release-date
+    @if [ ! -s {{ tempdir }}/release-date ]; then \
+         echo 'CHANGELOG.md has no `## [{{ version }}] - YYYY-MM-DD` section' >&2; \
+         exit 1; \
+       fi
+
+# The date is read before the checksums are downloaded, so a changelog that
+# cannot answer stops the recipe before anything has been written to the
+# manifest.
+update-winget: winget-release-date update-winget-hash-all
     @echo 'Updating pkg/winget/mado.yml for {{ version }}...'
     @sed -I '' "s/{{ prev_version }}/{{ version }}/" pkg/winget/mado.yml
-    @release_date=`sed -n 's/^## \[{{ version }}\] - \([0-9][0-9-]*\)$/\1/p' CHANGELOG.md` \
-      && if [ -z "$release_date" ]; then \
-           echo 'CHANGELOG.md has no dated section for {{ version }}' >&2; \
-           exit 1; \
-         fi \
+    @release_date=`cat {{ tempdir }}/release-date` \
       && echo "Updating pkg/winget/mado.yml for $release_date..." \
-      && sed -I '' "s/^ReleaseDate: .*/ReleaseDate: $release_date/" pkg/winget/mado.yml
+      && sed -I '' "s/^ReleaseDate: .*/ReleaseDate: $release_date/" pkg/winget/mado.yml \
+      && if ! grep -q "^ReleaseDate: $release_date$" pkg/winget/mado.yml; then \
+           echo 'pkg/winget/mado.yml has no ReleaseDate line to stamp' >&2; \
+           exit 1; \
+         fi
 
 [private]
 nix-hash version target:

--- a/justfile
+++ b/justfile
@@ -91,10 +91,16 @@ update-winget-hash-all: update-winget-hash-windows-amd64
 # schema's `date` format admits, and a heading written any other way does not
 # say which day it means.
 #
-# `update-winget` reads the date through this recipe, and checks the manifest
-# still has a `ReleaseDate` line to stamp, before the checksums are downloaded.
-# Whatever cannot be answered stops the recipe while the manifest is still
-# untouched, rather than after the version and the checksum have gone in.
+# `update-winget` reads the date through this recipe, and checks the manifest is
+# the one being replaced and still has a `ReleaseDate` line to stamp, before the
+# checksums are downloaded. Whatever cannot be answered stops the recipe while
+# the manifest is still untouched, rather than after the version and the
+# checksum have gone in.
+#
+# Checking `PackageVersion` is what keeps the stamp honest. It is the one edit
+# in `update-winget` that does not key on `prev_version`, so a `prev_version`
+# left behind would leave the version, the URL and the checksum untouched, stamp
+# the date anyway, and report a finished release in a one-line diff.
 [private]
 winget-release-date:
     @echo 'Reading the release date for {{ version }} from CHANGELOG.md...'
@@ -106,6 +112,11 @@ winget-release-date:
            exit 1; \
          elif [ "$dates" -gt 1 ]; then \
            echo 'CHANGELOG.md dates `## [{{ version }}]` more than once' >&2; \
+           exit 1; \
+         fi
+    @at=`sed -n 's/^PackageVersion: //p' pkg/winget/mado.yml` \
+      && if [ "$at" != '{{ prev_version }}' ]; then \
+           echo "pkg/winget/mado.yml is at '$at'; prev_version in the justfile names {{ prev_version }}" >&2; \
            exit 1; \
          fi
     @if ! grep -q '^ReleaseDate: ' pkg/winget/mado.yml; then \

--- a/justfile
+++ b/justfile
@@ -91,9 +91,10 @@ update-winget-hash-all: update-winget-hash-windows-amd64
 # schema's `date` format admits, and a heading written any other way does not
 # say which day it means.
 #
-# `update-winget` reads the date through this recipe, before the checksums are
-# downloaded, so a changelog that cannot answer stops it before anything has
-# been written to the manifest.
+# `update-winget` reads the date through this recipe, and checks the manifest
+# still has a `ReleaseDate` line to stamp, before the checksums are downloaded.
+# Whatever cannot be answered stops the recipe while the manifest is still
+# untouched, rather than after the version and the checksum have gone in.
 [private]
 winget-release-date:
     @echo 'Reading the release date for {{ version }} from CHANGELOG.md...'
@@ -107,17 +108,17 @@ winget-release-date:
            echo 'CHANGELOG.md dates `## [{{ version }}]` more than once' >&2; \
            exit 1; \
          fi
+    @if ! grep -q '^ReleaseDate: ' pkg/winget/mado.yml; then \
+         echo 'pkg/winget/mado.yml has no ReleaseDate line to stamp' >&2; \
+         exit 1; \
+       fi
 
 update-winget: winget-release-date update-winget-hash-all
     @echo 'Updating pkg/winget/mado.yml for {{ version }}...'
     @sed -I '' "s/{{ prev_version }}/{{ version }}/" pkg/winget/mado.yml
     @release_date=`cat {{ tempdir }}/release-date` \
       && echo "Stamping ReleaseDate as $release_date..." \
-      && sed -I '' "s/^ReleaseDate: .*/ReleaseDate: $release_date/" pkg/winget/mado.yml \
-      && if ! grep -q "^ReleaseDate: $release_date$" pkg/winget/mado.yml; then \
-           echo 'pkg/winget/mado.yml has no ReleaseDate line to stamp' >&2; \
-           exit 1; \
-         fi
+      && sed -I '' "s/^ReleaseDate: .*/ReleaseDate: $release_date/" pkg/winget/mado.yml
 
 [private]
 nix-hash version target:

--- a/justfile
+++ b/justfile
@@ -84,9 +84,20 @@ update-winget-hash-windows-amd64: (update-winget-hash "mado-Windows-msvc-x86_64.
 
 update-winget-hash-all: update-winget-hash-windows-amd64
 
+# `ReleaseDate` is the date WinGet shows the installer as released on, so it has
+# to move with every version. It comes from the changelog rather than today's
+# date: this recipe runs once CD has finished, which is not always the day the
+# release is dated.
 update-winget: update-winget-hash-all
     @echo 'Updating pkg/winget/mado.yml for {{ version }}...'
     @sed -I '' "s/{{ prev_version }}/{{ version }}/" pkg/winget/mado.yml
+    @release_date=`sed -n 's/^## \[{{ version }}\] - \([0-9][0-9-]*\)$/\1/p' CHANGELOG.md` \
+      && if [ -z "$release_date" ]; then \
+           echo 'CHANGELOG.md has no dated section for {{ version }}' >&2; \
+           exit 1; \
+         fi \
+      && echo "Updating pkg/winget/mado.yml for $release_date..." \
+      && sed -I '' "s/^ReleaseDate: .*/ReleaseDate: $release_date/" pkg/winget/mado.yml
 
 [private]
 nix-hash version target:

--- a/pkg/winget/mado.yml
+++ b/pkg/winget/mado.yml
@@ -16,7 +16,7 @@ InstallModes:
   - silent
   - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: 2025-01-17
+ReleaseDate: 2026-09-07
 Installers:
   - Architecture: x64
     InstallerUrl: https://github.com/akiomik/mado/releases/download/v0.3.2/mado-Windows-msvc-x86_64.zip


### PR DESCRIPTION
`ReleaseDate` is the date WinGet shows the installer as released on — the
[manifest schema](https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.9.0/manifest.singleton.1.9.0.json)
calls it "The installer release date" — and nothing moved it. `just
update-winget` refreshed `PackageVersion`, `InstallerUrl` and `InstallerSha256`
and left the date alone, so `pkg/winget/mado.yml` named `2025-01-17`, v0.1.4's
date, through six versions: 0.1.5, 0.2.0, 0.2.2, 0.3.0, 0.3.1 and the 0.3.2
manifest merged in #414.

## Changes

- `pkg/winget/mado.yml`: `ReleaseDate: 2026-09-07`, v0.3.2's date.
- `justfile`: `update-winget` stamps `ReleaseDate`, so it cannot be forgotten
  again. Everything it needs is settled in `winget-release-date`, before the
  checksums are downloaded, so a release it cannot answer for stops the recipe
  with the manifest untouched rather than half written.
- `CONTRIBUTING.md`: say what the recipe stamps, in the release steps.

## Where the date comes from

The changelog heading for the version, not today's date: step 4 runs once CD
has finished, which is not always the day the release is dated. That also keeps
one source of truth — the release notes and the manifest cannot disagree.

## What the guards refuse

`winget-release-date` runs before `update-winget-hash-all`, so each of these
stops with the manifest byte-for-byte unchanged and nothing downloaded:

| | |
| --- | --- |
| no `## [x.y.z] - YYYY-MM-DD` section | `CHANGELOG.md has no ... section` |
| the version dated more than once | `CHANGELOG.md dates ... more than once` |
| the manifest is not at `prev_version` | `pkg/winget/mado.yml is at '0.3.2'; prev_version ... names 0.3.1` |
| no `ReleaseDate` line to stamp | `pkg/winget/mado.yml has no ReleaseDate line to stamp` |

The `prev_version` check is what keeps the stamp honest. Every other edit the
recipe makes keys on `prev_version`, so a forgotten bump used to come out as an
empty diff; stamping the date keys on `^ReleaseDate: .*` instead, which would
have turned that into a one-line diff reading as a finished release.

## Verification

`just update-winget` against the published v0.3.2 release produces the date in
this diff:

```
Updating pkg/winget/mado.yml for 0.3.2...
Stamping ReleaseDate as 2026-09-07...
```

`2026-09-07` matches the release's `publishedAt` of `2026-09-06T16:23:12Z` read
in the author's timezone, which is the date step 1 wrote into the changelog.
Every refusal above was exercised, and the manifest compared byte-for-byte
afterwards.

No changelog entry: a manifest metadata field is packaging internals under the
`CONTRIBUTING.md` rule, not something that changes what `mado check` reports or
how mado installs.

## Left out

- #416 — the recipe guards only reach whoever runs the recipe, so a hand edit
  can still put the stale date back. A CI check was written for this and
  dropped again: it was another hand-written shell script, and #397 and #398
  are the repository already deciding what to do about the ones it has. Worth
  doing on top of something that already exists, or after #397 settles which
  linter holds shell here.
- #417 — every `update-*` recipe interpolates versions and hashes into `sed`
  patterns unescaped. Pre-existing, and shared by the homebrew, scoop and flake
  recipes. The `PackageVersion` check added here compares strings rather than
  matching a pattern, so it does not add to the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV