### PR TITLE
docs: cut the comments the workspace change left behind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,10 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # `--workspace` reaches the fuzz target, whose `libfuzzer-sys` compiles a
       # vendored libFuzzer. `ubuntu-latest` ships a C++ compiler, so this asks
-      # for one only when it is missing. #428 is the same question for the C
-      # compiler every job needs and none of them asks for.
+      # for one only when it is missing, and updates first: an image that has
+      # none is old enough for its index to name a `g++` the archive dropped.
+      # #428 is the same question for the C compiler every job needs and none
+      # of them asks for.
       - name: Install a C++ toolchain for libfuzzer-sys
         run: |
           if ! command -v c++ > /dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,9 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # `--workspace` reaches the fuzz target, whose `libfuzzer-sys` compiles a
       # vendored libFuzzer. `ubuntu-latest` ships a C++ compiler, so this asks
-      # for one only when it is missing, updating the index first: an image
-      # without one can be old enough to name a `g++` the archive has dropped.
+      # for one only when it is missing. `c++` is the name `cc` looks for and
+      # `g++` the package that carries it. `apt-get install` resolves a version
+      # out of the image's index, so the guard updates that first.
       # #428 is the same question for the C compiler every job needs and none
       # of them asks for.
       - name: Install a C++ toolchain for libfuzzer-sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
       # looks for and `g++` the package that carries it. `apt-get install`
       # resolves a version out of the image's index, so the guard updates that
       # first.
+      #
       # #428 is the same question for the C compiler every job that compiles
       # needs and none of them asks for.
       - name: Install a C++ toolchain for libfuzzer-sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,10 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # `--workspace` reaches the fuzz target, whose `libfuzzer-sys` compiles a
       # vendored libFuzzer. `ubuntu-latest` ships a C++ compiler, so this asks
-      # for one only when it is missing. `c++` is the name `cc` looks for and
-      # `g++` the package that carries it. `apt-get install` resolves a version
-      # out of the image's index, so the guard updates that first.
+      # for one only when it is missing. On this runner `c++` is the name `cc`
+      # looks for and `g++` the package that carries it. `apt-get install`
+      # resolves a version out of the image's index, so the guard updates that
+      # first.
       # #428 is the same question for the C compiler every job needs and none
       # of them asks for.
       - name: Install a C++ toolchain for libfuzzer-sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
       # looks for and `g++` the package that carries it. `apt-get install`
       # resolves a version out of the image's index, so the guard updates that
       # first.
-      # #428 is the same question for the C compiler every job needs and none
-      # of them asks for.
+      # #428 is the same question for the C compiler every job that compiles
+      # needs and none of them asks for.
       - name: Install a C++ toolchain for libfuzzer-sys
         run: |
           if ! command -v c++ > /dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,8 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # `--workspace` reaches the fuzz target, whose `libfuzzer-sys` compiles a
       # vendored libFuzzer. `ubuntu-latest` ships a C++ compiler, so this asks
-      # for one only when it is missing, and updates first: an image that has
-      # none is old enough for its index to name a `g++` the archive dropped.
+      # for one only when it is missing. The index is updated first, since an
+      # image that old can name a `g++` the archive no longer carries.
       # #428 is the same question for the C compiler every job needs and none
       # of them asks for.
       - name: Install a C++ toolchain for libfuzzer-sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,33 +78,10 @@ jobs:
           toolchain: "1.91.1"
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-      # `--workspace` reaches the fuzz target, which brings `libfuzzer-sys`,
-      # whose build script compiles a vendored libFuzzer. That is a C++
-      # compiler this job needs and the others do not: a bin is a default
-      # target, so anything that builds default targets picks it up, and
-      # `test`, `docs` and `coverage` are spared by `test`/`doc`/`bench =
-      # false` in `fuzz/Cargo.toml` rather than by anything on their own
-      # command lines. Dropping `--all-targets` from the lint below would not
-      # change that.
-      #
-      # Asked for only when it is missing. `ubuntu-latest` ships one, so the
-      # job says what it depends on without buying a network round trip for
-      # it, and a mirror having a bad minute cannot fail a lint. `update`
-      # inside the guard is not optional: `install` resolves a version out of
-      # the index the image was built with, and an image without a compiler is
-      # old enough for the archive to have dropped the version it names.
-      #
-      # The test is on `c++` because that is what runs. `cc` takes its C++
-      # tool from `$CXX`, then `clang++` where clang is preferred, and
-      # otherwise `c++`; `g++` is its answer on Solaris and illumos alone. The
-      # package is still `g++`, that being what carries a C++ compiler here. A
-      # runner where installing it leaves no `c++` behind fails the way it
-      # would have without this step, so the guard cannot cost anything it
-      # does not already save.
-      #
-      # Debian-family, like the `ubuntu-latest` this job has always run on.
-      # #428 is the same question for the C compiler every job already needs
-      # and none of them asks for, this one included until it moves.
+      # `--workspace` reaches the fuzz target, whose `libfuzzer-sys` compiles a
+      # vendored libFuzzer. `ubuntu-latest` ships a C++ compiler, so this asks
+      # for one only when it is missing. #428 is the same question for the C
+      # compiler every job needs and none of them asks for.
       - name: Install a C++ toolchain for libfuzzer-sys
         run: |
           if ! command -v c++ > /dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,12 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # `--workspace` reaches the fuzz target, whose `libfuzzer-sys` compiles a
-      # vendored libFuzzer. `ubuntu-latest` ships a C++ compiler, so this asks
-      # for one only when it is missing. On this runner `c++` is the name `cc`
-      # looks for and `g++` the package that carries it. `apt-get install`
-      # resolves a version out of the image's index, so the guard updates that
-      # first.
+      # vendored libFuzzer. `ubuntu-latest` ships a C++ compiler, so the step is
+      # here to say what the job depends on rather than to buy it: it installs
+      # only when there is none, and a mirror having a bad minute cannot fail a
+      # lint. On this runner `c++` is the name `cc` looks for and `g++` the
+      # package that carries it. `apt-get install` resolves a version out of the
+      # image's index, so the guard updates that first.
       #
       # #428 is the same question for the C compiler every job that compiles
       # needs and none of them asks for.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,8 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # `--workspace` reaches the fuzz target, whose `libfuzzer-sys` compiles a
       # vendored libFuzzer. `ubuntu-latest` ships a C++ compiler, so this asks
-      # for one only when it is missing. The index is updated first, since an
-      # image that old can name a `g++` the archive no longer carries.
+      # for one only when it is missing, updating the index first: an image
+      # without one can be old enough to name a `g++` the archive has dropped.
       # #428 is the same question for the C compiler every job needs and none
       # of them asks for.
       - name: Install a C++ toolchain for libfuzzer-sys

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-# No trailing slash: git reads a `target` symlinked onto another volume as a
-# file, which `/target/` would not match. `/fuzz/target` is what a checkout
-# from before `fuzz/` joined the workspace still has.
+# Anchored, or `target` would match a nested one as well and mado, which skips
+# what git ignores, would stop linting the Markdown under it. No trailing
+# slash: git reads a `target` symlinked onto another volume as a file, which
+# `/target/` would not match. `/fuzz/target` is what a checkout from before
+# `fuzz/` joined the workspace still has.
 /target
 /fuzz/target
 flamegraph.svg

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,3 @@
-# The workspace's own, and the one an older checkout still has under `fuzz/`
-# from when that was a workspace of its own. Anchored by the leading `/`, so a
-# `target` directory elsewhere in the tree is one the linter still sees: a
-# Markdown fixture inside one would otherwise go untracked and unlinted without
-# saying so. Not out of the published `.crate` — `Cargo.toml` names an
-# `include`, and cargo packages by that rather than by asking git.
-#
-# No trailing slash. That would match directories alone, and git reads a symlink
-# as a file, so a `target` symlinked onto another volume — which is how a Rust
-# checkout is kept out of a backup — would come back as untracked.
 /target
 /fuzz/target
 flamegraph.svg

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # No trailing slash: git reads a `target` symlinked onto another volume as a
-# file, which `/target/` would not match.
+# file, which `/target/` would not match. The second is what a checkout from
+# before `fuzz/` joined the workspace still has.
 /target
 /fuzz/target
 flamegraph.svg

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # No trailing slash: git reads a `target` symlinked onto another volume as a
-# file, which `/target/` would not match. The second is what a checkout from
-# before `fuzz/` joined the workspace still has.
+# file, which `/target/` would not match. `/fuzz/target` is what a checkout
+# from before `fuzz/` joined the workspace still has.
 /target
 /fuzz/target
 flamegraph.svg

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# No trailing slash: git reads a `target` symlinked onto another volume as a
+# file, which `/target/` would not match.
 /target
 /fuzz/target
 flamegraph.svg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ just lint
 `just lint`, and so `just`, needs a C++ toolchain on the machine: it lints the
 whole workspace, which reaches the fuzz target, and `libfuzzer-sys` compiles a
 vendored libFuzzer before anything of mado's is looked at. A machine without one
-fails in `cc`. `just test` does not need a C++ one, for the `false`s in
-`fuzz/Cargo.toml`, and neither does CI's coverage job. CI's Clippy job installs
-`g++` on a runner that has none.
+fails inside that build rather than in anything the change touched. `just test`
+does not need a C++ one, for the `false`s in `fuzz/Cargo.toml`, and neither does
+CI's coverage job. CI's Clippy job installs `g++` on a runner that has none.
 
 ## Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,11 @@ just test
 just lint
 ```
 
-`just lint` needs a C++ toolchain on the machine: it lints the whole workspace,
-which reaches the fuzz target, and `libfuzzer-sys` compiles a vendored libFuzzer
-before anything of mado's is looked at. A machine without one fails in `cc`.
-`just test` does not, and neither does CI's coverage job. CI's Clippy job
-installs `g++` on a runner that has none.
+`just lint`, and so `just`, needs a C++ toolchain on the machine: it lints the
+whole workspace, which reaches the fuzz target, and `libfuzzer-sys` compiles a
+vendored libFuzzer before anything of mado's is looked at. A machine without one
+fails in `cc`. `just test` does not, and neither does CI's coverage job. CI's
+Clippy job installs `g++` on a runner that has none.
 
 ## Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,20 +14,11 @@ just test
 just lint
 ```
 
-`just lint`, and so `just`, needs a C++ toolchain on the machine. It lints the
-whole workspace, which reaches the fuzz target under `fuzz/` — a bin is a
-default target — and that brings `libfuzzer-sys`, whose build script compiles a
-vendored copy of libFuzzer before anything of mado's is looked at. A machine
-without one fails in `cc`, which is what that failure is about rather than
-anything in the diff being checked.
-
-`just test` does not: the fuzz target is a `[[bin]]` with `test`, `bench` and
-`doc` all `false`, so `cargo test` and `cargo doc` skip the package entirely.
-Neither does CI's coverage job, for the same reason. It is those three lines
-that spare them, not anything about how the commands are spelled.
-
-CI's Clippy job runs the same command and so has the same requirement. It
-installs `g++` for itself on a runner that does not already have one.
+`just lint` needs a C++ toolchain on the machine: it lints the whole workspace,
+which reaches the fuzz target, and `libfuzzer-sys` compiles a vendored libFuzzer
+before anything of mado's is looked at. A machine without one fails in `cc`.
+`just test` does not, and neither does CI's coverage job. CI's Clippy job
+installs `g++` on a runner that has none.
 
 ## Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ just lint
 `just lint`, and so `just`, needs a C++ toolchain on the machine: it lints the
 whole workspace, which reaches the fuzz target, and `libfuzzer-sys` compiles a
 vendored libFuzzer before anything of mado's is looked at. A machine without one
-fails in `cc`. `just test` does not, and neither does CI's coverage job. CI's
-Clippy job installs `g++` on a runner that has none.
+fails in `cc`. `just test` does not need a C++ one, and neither does CI's
+coverage job. CI's Clippy job installs `g++` on a runner that has none.
 
 ## Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,9 @@ just lint
 `just lint`, and so `just`, needs a C++ toolchain on the machine: it lints the
 whole workspace, which reaches the fuzz target, and `libfuzzer-sys` compiles a
 vendored libFuzzer before anything of mado's is looked at. A machine without one
-fails in `cc`. `just test` does not need a C++ one, and neither does CI's
-coverage job. CI's Clippy job installs `g++` on a runner that has none.
+fails in `cc`. `just test` does not need a C++ one, for the `false`s in
+`fuzz/Cargo.toml`, and neither does CI's coverage job. CI's Clippy job installs
+`g++` on a runner that has none.
 
 ## Changelog
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,8 @@ rand = "0.10"
 serial_test = "3.5"
 tempfile = "3.27"
 
-# Resolved at the workspace root, so `cargo fuzz` builds with this as well.
+# Resolved at the workspace root, so `cargo fuzz` builds with this as well:
+# slower, and with `mado` and `comrak` inlined into each other in a backtrace.
 # Cargo takes no `lto` in a package profile, so opting `fuzz/` out of it would
 # take a profile of its own and a change to what CD builds.
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serial_test = "3.5"
 tempfile = "3.27"
 
 # Resolved at the workspace root, so `cargo fuzz` builds with this as well.
+# Cargo takes no `lto` in a package profile, so `fuzz/` cannot opt out of it.
 [profile.release]
 lto = "thin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,8 @@ serial_test = "3.5"
 tempfile = "3.27"
 
 # Resolved at the workspace root, so `cargo fuzz` builds with this as well:
-# slower, and with `mado` and `comrak` inlined into each other in a backtrace.
+# slower to build, and coarser backtraces where `mado` and `comrak` inline into
+# each other.
 # Cargo takes no `lto` in a package profile, so opting `fuzz/` out of it would
 # take a profile of its own and a change to what CD builds.
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,11 @@
 [workspace]
 members = ["fuzz"]
 
-# What both packages agree on, so that neither can drift from the other.
 [workspace.package]
 edition = "2024"
 
-# The fuzz target hands a `comrak::Arena` to `mado::Document`, so the two have
-# to be the same comrak; naming the version here is what makes that so rather
-# than hoping.
+# The fuzz target hands a `comrak::Arena` to `mado::Document`, so both packages
+# have to build the same comrak.
 [workspace.dependencies]
 comrak = "0.54"
 
@@ -62,13 +60,7 @@ rand = "0.10"
 serial_test = "3.5"
 tempfile = "3.27"
 
-# Also what `cargo fuzz` builds with, which it did not used to be. A profile is
-# resolved at the workspace root and `fuzz/` is a member rather than a root of
-# its own now, so `lto` here is cross-crate ThinLTO on every fuzz build: slower
-# to build, and coarser backtraces where `mado` and `comrak` inline into each
-# other. It cannot be turned off for the one package — cargo rejects `lto` in a
-# `package` profile — so undoing it would take a profile of its own and a change
-# to what CD passes `cargo build`.
+# Resolved at the workspace root, so `cargo fuzz` builds with this as well.
 [profile.release]
 lto = "thin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tempfile = "3.27"
 
 # Resolved at the workspace root, so `cargo fuzz` builds with this as well.
 # Cargo takes no `lto` in a package profile, so opting `fuzz/` out of it would
-# take a profile of its own, and CD builds `--release`.
+# take a profile of its own and a change to what CD builds.
 [profile.release]
 lto = "thin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tempfile = "3.27"
 
 # Resolved at the workspace root, so `cargo fuzz` builds with this as well.
 # Cargo takes no `lto` in a package profile, so opting `fuzz/` out of it would
-# take a profile of its own.
+# take a profile of its own, and CD builds `--release`.
 [profile.release]
 lto = "thin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ tempfile = "3.27"
 # slower to build, and coarser backtraces where `mado` and `comrak` inline into
 # each other.
 # Cargo takes no `lto` in a package profile and `cargo fuzz` picks only dev or
-# release, so opting `fuzz/` out of it would take a profile of its own and a
-# change to what CD passes `cargo build`.
+# release, so sparing the fuzz build means taking `lto` out of here into a
+# profile CD names on its `cargo build`.
 [profile.release]
 lto = "thin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,9 @@ tempfile = "3.27"
 # Resolved at the workspace root, so `cargo fuzz` builds with this as well:
 # slower to build, and coarser backtraces where `mado` and `comrak` inline into
 # each other.
-# Cargo takes no `lto` in a package profile, so opting `fuzz/` out of it would
-# take a profile of its own and a change to what CD builds.
+# Cargo takes no `lto` in a package profile and `cargo fuzz` picks only dev or
+# release, so opting `fuzz/` out of it would take a profile of its own and a
+# change to what CD passes `cargo build`.
 [profile.release]
 lto = "thin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,8 @@ serial_test = "3.5"
 tempfile = "3.27"
 
 # Resolved at the workspace root, so `cargo fuzz` builds with this as well.
-# Cargo takes no `lto` in a package profile, so `fuzz/` cannot opt out of it.
+# Cargo takes no `lto` in a package profile, so opting `fuzz/` out of it would
+# take a profile of its own.
 [profile.release]
 lto = "thin"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,9 +17,8 @@ comrak.workspace = true
 [dependencies.mado]
 path = ".."
 
-# `test`, `doc` and `bench = false` are what keep this package out of `cargo
-# test`, `cargo doc` and the coverage run, and so off the C++ toolchain
-# `libfuzzer-sys` needs.
+# Without these three, `libfuzzer-sys` and the C++ toolchain its build script
+# compiles are in the graph of every workspace-wide command.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,8 +17,10 @@ comrak.workspace = true
 [dependencies.mado]
 path = ".."
 
-# `libfuzzer-sys` needs a C++ toolchain to build, and the `false`s below are
-# what keep it out of the graph of every workspace-wide command.
+# `cargo test`, `cargo doc` and the coverage run skip this package for the
+# `false`s below. Everything else that builds default targets reaches it,
+# `cargo clippy --workspace` included, and compiles a vendored libFuzzer with
+# a C++ toolchain on the way.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,8 +17,9 @@ comrak.workspace = true
 [dependencies.mado]
 path = ".."
 
-# One key each for `cargo test`, `cargo doc` and `cargo bench`, which is what
-# keeps all three off the C++ toolchain `libfuzzer-sys` needs.
+# `test`, `doc` and `bench = false` are what keep this package out of `cargo
+# test`, `cargo doc` and the coverage run, and so off the C++ toolchain
+# `libfuzzer-sys` needs.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,7 +21,8 @@ path = ".."
 # package for the `false`s below. Everything else that builds default targets
 # reaches it, `cargo clippy --workspace` included, and compiles a vendored
 # libFuzzer with a C++ toolchain on the way. A lib target here would put
-# `libfuzzer-sys` back in all of them; a `tests/` file, in all but `cargo doc`.
+# `libfuzzer-sys` back in all of them; a `tests/` file, in `cargo test` and the
+# coverage run.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,8 +17,8 @@ comrak.workspace = true
 [dependencies.mado]
 path = ".."
 
-# Without these three, `libfuzzer-sys` and the C++ toolchain its build script
-# compiles are in the graph of every workspace-wide command.
+# `libfuzzer-sys` needs a C++ toolchain to build, and the `false`s below are
+# what keep it out of the graph of every workspace-wide command.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,8 +20,8 @@ path = ".."
 # `cargo test`, `cargo doc` and the coverage run skip this package for the
 # `false`s below. Everything else that builds default targets reaches it,
 # `cargo clippy --workspace` included, and compiles a vendored libFuzzer with
-# a C++ toolchain on the way. A `tests/` file or a lib target here would put it
-# back in the first three.
+# a C++ toolchain on the way. A lib target here would put `libfuzzer-sys` back
+# in all three; a `tests/` file, in everything but `cargo doc`.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,8 +17,8 @@ comrak.workspace = true
 [dependencies.mado]
 path = ".."
 
-# `test`, `doc` and `bench` are what keep `cargo test` and `cargo doc` out of
-# this package, and so off the C++ toolchain `libfuzzer-sys` needs.
+# One key each for `cargo test`, `cargo doc` and `cargo bench`, which is what
+# keeps all three off the C++ toolchain `libfuzzer-sys` needs.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,11 +17,11 @@ comrak.workspace = true
 [dependencies.mado]
 path = ".."
 
-# `cargo test`, `cargo doc` and the coverage run skip this package for the
-# `false`s below. Everything else that builds default targets reaches it,
-# `cargo clippy --workspace` included, and compiles a vendored libFuzzer with
-# a C++ toolchain on the way. A lib target here would put `libfuzzer-sys` back
-# in all three; a `tests/` file, in everything but `cargo doc`.
+# `cargo test`, `cargo doc`, `cargo bench` and the coverage run skip this
+# package for the `false`s below. Everything else that builds default targets
+# reaches it, `cargo clippy --workspace` included, and compiles a vendored
+# libFuzzer with a C++ toolchain on the way. A lib target here would put
+# `libfuzzer-sys` back in all of them; a `tests/` file, in all but `cargo doc`.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,8 @@ path = ".."
 # `cargo test`, `cargo doc` and the coverage run skip this package for the
 # `false`s below. Everything else that builds default targets reaches it,
 # `cargo clippy --workspace` included, and compiles a vendored libFuzzer with
-# a C++ toolchain on the way.
+# a C++ toolchain on the way. A `tests/` file or a lib target here would put it
+# back in the first three.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,13 +17,8 @@ comrak.workspace = true
 [dependencies.mado]
 path = ".."
 
-# A bin is a default target, so every `--workspace` command that builds one
-# reaches this crate and the vendored libFuzzer behind it. These three lines are
-# what spare the ones that do not: `cargo test`, `cargo doc` and the coverage
-# run skip the package entirely, and so want no C++ toolchain. A `tests/` file
-# or a lib target here would put `libfuzzer-sys` back in their graph and fail
-# all three in `cc`, which reads as nothing to do with whatever was changed.
-# `CONTRIBUTING.md` says so from the other end.
+# `test`, `doc` and `bench` are what keep `cargo test` and `cargo doc` out of
+# this package, and so off the C++ toolchain `libfuzzer-sys` needs.
 [[bin]]
 name = "linter"
 path = "fuzz_targets/linter.rs"

--- a/fuzz/fuzz_targets/linter.rs
+++ b/fuzz/fuzz_targets/linter.rs
@@ -15,12 +15,7 @@ fuzz_target!(|text: String| {
     let linter = Linter::new(rules);
     let arena = Arena::new();
     let path = Path::new("test.md").to_path_buf();
-    // `Document::new` returns a `Result` it cannot produce an `Err` for: no
-    // branch of it fails today. Unwrapping says so, rather than the target
-    // growing a case the library does not have. Should `new` ever fail, a
-    // panic here is what a fuzz target wants of it anyway. Allowed at the line
-    // rather than by dropping the workspace's lints for the crate, the rest of
-    // which are worth having.
+    // A `new` that fails is something a fuzz target wants to hear about.
     #[allow(clippy::unwrap_used)]
     let doc = Document::new(&arena, path, text).unwrap();
     let _ = linter.check(&doc);

--- a/fuzz/fuzz_targets/linter.rs
+++ b/fuzz/fuzz_targets/linter.rs
@@ -15,7 +15,7 @@ fuzz_target!(|text: String| {
     let linter = Linter::new(rules);
     let arena = Arena::new();
     let path = Path::new("test.md").to_path_buf();
-    // A `new` that fails is something a fuzz target wants to hear about.
+    // The `Result` has no `Err` in it: no branch of `Document::new` fails.
     #[allow(clippy::unwrap_used)]
     let doc = Document::new(&arena, path, text).unwrap();
     let _ = linter.check(&doc);

--- a/justfile
+++ b/justfile
@@ -28,13 +28,8 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# `cargo fuzz` takes no `--locked` and forwards no cargo flags that mean it, so
-# a run whose manifests have moved rewrites the lock on its way past — the one
-# CD builds against and `check-versions.sh` reads, now that `fuzz/` shares it.
-# `cargo metadata --locked` is the same question asked first. Not free on a cold
-# cache — it extracts every package in the resolve, dev-dependencies a fuzz
-# build never touches included — but anyone reaching for `just fuzz` has run
-# `just test` before it.
+# `cargo fuzz` takes no `--locked` and would rewrite the workspace lock on its
+# way past. `cargo metadata` asks the same question first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ flamegraph target="scripts/benchmarks/data/gitlab":
 # `cargo fuzz` takes no `--locked`, and a run whose manifests have moved would
 # rewrite the lock CD builds against on its way past, so `cargo metadata
 # --locked` asks first.
-[doc("Fuzz a target, checking the lock first")]
+# Fuzz a target, checking the lock first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -28,10 +28,9 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# `cargo fuzz` takes no `--locked`, so a run whose manifests have moved rewrites
-# the lock CD builds against on its way past. `cargo metadata --locked` asks
-# first.
-
+# `cargo fuzz` takes no `--locked`, and a run whose manifests have moved would
+# rewrite the lock CD builds against on its way past.
+# Fuzz a target, checking the lock with `cargo metadata` first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# Fuzz a target. `cargo fuzz` can rewrite the lock CD builds against.
+# Fuzz a target. `cargo fuzz` takes no `--locked`, so `cargo metadata` asks first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# Fuzz a target. `cargo fuzz` rewrites CD's lock, so `cargo metadata --locked`.
+# Fuzz a target. `cargo metadata --locked` keeps `cargo fuzz` off CD's lock.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# Fuzz a target. `cargo fuzz` takes no `--locked`; `cargo metadata` asks first.
+# Fuzz a target. `cargo fuzz` rewrites CD's lock, so `cargo metadata --locked`.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -30,6 +30,7 @@ flamegraph target="scripts/benchmarks/data/gitlab":
 
 # `cargo fuzz` takes no `--locked`, and a run whose manifests have moved would
 # rewrite the lock CD builds against on its way past.
+
 # Fuzz a target, checking the lock with `cargo metadata` first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null

--- a/justfile
+++ b/justfile
@@ -28,8 +28,8 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# `cargo fuzz` takes no `--locked` and would rewrite the workspace lock on its
-# way past. `cargo metadata` asks the same question first.
+# `cargo fuzz` takes no `--locked`, so a run whose manifests have moved rewrites
+# the workspace lock on its way past. `cargo metadata --locked` asks first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -28,9 +28,8 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# `cargo fuzz` takes no `--locked`, and a run whose manifests have moved would
-# rewrite the lock CD builds against on its way past, so `cargo metadata
-# --locked` asks first.
+# `cargo fuzz` takes no `--locked`, so a run whose manifests have moved rewrites
+# the lock CD builds against.
 # Fuzz a target, checking the lock first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null

--- a/justfile
+++ b/justfile
@@ -29,9 +29,9 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
 # `cargo fuzz` takes no `--locked`, and a run whose manifests have moved would
-# rewrite the lock CD builds against on its way past.
-
-# Fuzz a target, checking the lock with `cargo metadata` first.
+# rewrite the lock CD builds against on its way past, so `cargo metadata
+# --locked` asks first.
+[doc("Fuzz a target, checking the lock first")]
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ flamegraph target="scripts/benchmarks/data/gitlab":
 # `cargo fuzz` takes no `--locked`, so a run whose manifests have moved rewrites
 # the lock CD builds against on its way past. `cargo metadata --locked` asks
 # first.
+
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -29,7 +29,8 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
 # `cargo fuzz` takes no `--locked`, so a run whose manifests have moved rewrites
-# the workspace lock on its way past. `cargo metadata --locked` asks first.
+# the lock CD builds against on its way past. `cargo metadata --locked` asks
+# first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# Fuzz a target. `cargo fuzz` takes no `--locked`, so `cargo metadata` asks first.
+# Fuzz a target. `cargo fuzz` takes no `--locked`; `cargo metadata` asks first.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/justfile
+++ b/justfile
@@ -28,9 +28,7 @@ flamegraph target="scripts/benchmarks/data/gitlab":
     # See https://github.com/flamegraph-rs/flamegraph#dtrace-on-macos
     cargo flamegraph --root --profile bench --open -- check {{ target }}
 
-# `cargo fuzz` takes no `--locked`, so a run whose manifests have moved rewrites
-# the lock CD builds against.
-# Fuzz a target, checking the lock first.
+# Fuzz a target. `cargo fuzz` can rewrite the lock CD builds against.
 fuzz target="linter":
     cargo metadata --locked --format-version 1 > /dev/null
     cargo +nightly fuzz run {{ target }}

--- a/scripts/release/version.sh
+++ b/scripts/release/version.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
-# The `[package]` table, not the first `version =` in the file: a `version` in
-# `[workspace.package]` above it would otherwise be read as mado's.
+# The `[package]` table, not the first `version =` in the file: a workspace
+# table above it can carry a `version` of its own, and would be read as mado's.
 version=$(sed -n '/^\[package\]$/,/^\[/{
   s/^version = "\{0,1\}\([^"]*\)"\{0,1\}$/\1/p
 }' Cargo.toml | head -1)

--- a/scripts/release/version.sh
+++ b/scripts/release/version.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
-# The `[package]` table, not the first `version =` in the file: a dependency
-# pinned in table form above it would otherwise be read as mado's version.
+# The `[package]` table, not the first `version =` in the file: a `version` in
+# `[workspace.package]` above it would otherwise be read as mado's.
 version=$(sed -n '/^\[package\]$/,/^\[/{
   s/^version = "\{0,1\}\([^"]*\)"\{0,1\}$/\1/p
 }' Cargo.toml | head -1)

--- a/scripts/release/version.sh
+++ b/scripts/release/version.sh
@@ -9,12 +9,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
-# Read the `[package]` table, not the first `version =` in the file: the
-# workspace tables above it can grow one of their own, and a dependency pinned
-# in table form would otherwise be read as mado's version.
-#
-# Take what is between the quotes, or the bare value if there are none, rather
-# than whatever `cut` makes of a line with no delimiter in it.
+# The `[package]` table, not the first `version =` in the file: a dependency
+# pinned in table form above it would otherwise be read as mado's version.
 version=$(sed -n '/^\[package\]$/,/^\[/{
   s/^version = "\{0,1\}\([^"]*\)"\{0,1\}$/\1/p
 }' Cargo.toml | head -1)


### PR DESCRIPTION
#426 wrote about 66 lines of comment over about 27 lines of config. This is 87
lines out and 38 in.

## The trade-off

A long comment is likelier to be complete today and likelier to be wrong in six
months. Every sentence has its own chance to go stale, and sentences that lean
on each other go stale together: changing one glob in `.taplo.toml` falsified
three sentences elsewhere in #433, which is what this repository has already
seen. Cutting length buys durability with completeness, and that is a real
price, not a free win.

What is deliberately given up: an explanation for every choice at the site.
Some questions now need `git log` or the issue rather than the file. Narration
of what would happen under edits nobody has made is given up entirely, as is
the same fact written at three sites — three copies go stale separately, and
a reader who finds two of them cannot tell which is current.

What is not given up is accuracy, and one failure mode in particular. Shortening
a sentence that had two halves leaves a sentence that is true and an omission
that is not: "the `false`s spare `cargo test` and `cargo doc`" is true and
implies `cargo bench` is not spared; "opting `fuzz/` out takes a profile of its
own" is true and implies `cargo fuzz` could then use it. Reviews of this branch
have found that shape eight times and it is the thing worth checking for here.
Each one is fixed in a commit of its own, so the history reads as the argument
it was.

## Cut

- what a trailing slash or a missing anchor in `.gitignore` would match, beyond
  the two sentences saying which behaviour each is there for
- which tool `cc` picks on Solaris and illumos
- that `.gitignore` does not reach the published `.crate`, `Cargo.toml`
  naming an `include` that cargo packages by instead
- what a `tests/` directory or a lib target under `fuzz/` puts back, beyond
  naming the commands
- why the fuzz target wants a C++ toolchain, written at three sites and now at
  one, with the other two naming the file
- that `version.sh` tolerates an unquoted version. Cargo rejects one
  (`invalid type: integer, expected SemVer version`), so the tolerance is for
  something that cannot occur

## Kept

- why comrak is a workspace dependency rather than each package's own
- what `[profile.release]` costs a fuzz build, and what opting out would take
- what `test`/`doc`/`bench = false` spare, and what would undo it
- what `cargo metadata --locked` in `just fuzz` protects
- why `version.sh` anchors on the `[package]` table
- why the CI step exists, why it is guarded, and the link to #428

## Decisions taken

Recorded so they are not reopened. Each was reviewed, and the reason is here
rather than in the file.

**The `fuzz` recipe carries one comment line.** `just` shows the last comment
line above a recipe in `just --list`, so on `main` the listing read
``fuzz target="linter" # `just test` before it.`` — a fragment of a paragraph.
Five shapes were tried: a description last is order-fragile, a description first
does not work at all, a blank line between reads as an orphaned paragraph to one
reviewer and a run-on to another, and `[doc("…")]` needs just 1.27, where an
attribute an older `just` does not know is a parse error for the whole file, so
`just`, `just test` and `just lint` would stop working rather than only
`just fuzz`. Nothing here pins a just version and the newest feature used before
this was `[private]`, from 1.10. One line has no order to get wrong.

**`CONTRIBUTING.md` names `fuzz/Cargo.toml` rather than repeating it.** The
mechanism lives in the manifest; CONTRIBUTING says which file holds it.

**The CI step's `c++` probe is described as this runner's, not as a rule.** `cc`
reads `$CXX` first and prefers `clang++` where clang is; the guard is correct for
the gnu `ubuntu-latest` this job runs on, which is what the comment says.

## Verification

No behaviour changes: every hunk is a comment or prose, and `just --list` is the
only observable difference. `scripts/release/version.sh` still prints `0.3.2`,
and `cargo fmt`, `cargo clippy --locked --all-targets --all-features
--workspace`, `cargo test --locked`, `taplo format --check`, `actionlint`,
`shellcheck` and mado's self-lint all pass.

