### PR TITLE
fix!: honor .gitignore whether or not the tree carries Git metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ parsed and therefore what gets reported.
   no Git metadata: an `.ignore` file above the directory mado was started in is
   no longer read. Inside a repository they are still read from every parent
   directory (#436)
+- Where an `.ignore` file above a path being linted takes a path back with a
+  `!` line, `.gitignore` files go unread for that path outside a repository:
+  nothing mado can hand the walker ranks over a `.gitignore` below the path, and
+  excluding what a clone keeps would be the worse answer. mado says once which
+  `.ignore` file that was (#436)
 - **Breaking:** `service::walker::WalkParallelBuilder::build` returns one walker
   per set of paths that need the same ignore files read for them, rather than a
   single walker for every path given (#436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ parsed and therefore what gets reported.
   the walker's defaults, are no longer consulted. Neither travels with the tree
   being linted (#436)
 - **Breaking:** `service::walker::WalkParallelBuilder::build` returns one walker
-  per set of paths that agree on where their search for ignore files stops,
-  rather than a single walker for every path given (#436)
+  per set of paths that need the same ignore files read for them, rather than a
+  single walker for every path given (#436)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ parsed and therefore what gets reported.
   no longer read. Inside a repository they are still read from every parent
   directory (#436)
 - Where an `.ignore` file above a path being linted takes a path back with a
-  `!` line, `.gitignore` files go unread for that path outside a repository:
-  nothing mado can hand the walker ranks over a `.gitignore` below the path, and
-  excluding what a clone keeps would be the worse answer. mado says once which
-  `.ignore` file that was (#436)
+  `!` line, `.gitignore` files go unread for that path outside a repository and
+  `.ignore` files are read from every parent directory instead: nothing mado can
+  hand the walker ranks over a `.gitignore` below the path, and excluding what a
+  clone keeps would be the worse answer. mado says once which `.ignore` file
+  that was (#436)
 - **Breaking:** `service::walker::WalkParallelBuilder::build` returns one walker
   per set of paths that need the same ignore files read for them, rather than a
   single walker for every path given (#436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ parsed and therefore what gets reported.
   ignore file and `.git/info/exclude`, which mado had been reading by inheriting
   the walker's defaults, are no longer consulted. Neither travels with the tree
   being linted (#436)
+- `respect-ignore` stops where `respect-gitignore` stops for a tree that carries
+  no Git metadata: an `.ignore` file above the directory mado was started in is
+  no longer read. Inside a repository they are still read from every parent
+  directory (#436)
 - **Breaking:** `service::walker::WalkParallelBuilder::build` returns one walker
   per set of paths that need the same ignore files read for them, rather than a
   single walker for every path given (#436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ parsed and therefore what gets reported.
 
 ### Fixed
 
-- A glob mado cannot parse in the ignore file of the directory `mado check` was
-  given is reported, as one in a directory above it already was. The rest of
-  that file applies either way (#436)
 - `respect-gitignore` applies `.gitignore` files whether or not the tree still
   carries Git metadata, so a source archive or a Docker context copied without
   `.git` no longer lints everything `.gitignore` lists. The search for them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ parsed and therefore what gets reported.
   ignore file and `.git/info/exclude`, which mado had been reading by inheriting
   the walker's defaults, are no longer consulted. Neither travels with the tree
   being linted (#436)
-- `respect-ignore` and `respect-gitignore` no longer affect each other. Outside
-  a repository, turning `respect-gitignore` on used to change which directories
-  `.ignore` files were read from (#436)
+- **Breaking:** `service::walker::WalkParallelBuilder::build` returns one walker
+  per set of paths that agree on where their search for ignore files stops,
+  rather than a single walker for every path given (#436)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,19 @@ parsed and therefore what gets reported.
   ignore file and `.git/info/exclude`, which mado had been reading by inheriting
   the walker's defaults, are no longer consulted. Neither travels with the tree
   being linted (#436)
+- `respect-ignore` and `respect-gitignore` no longer affect each other. Outside
+  a repository, turning `respect-gitignore` on used to change which directories
+  `.ignore` files were read from (#436)
 
 ### Fixed
 
 - `respect-gitignore` applies `.gitignore` files whether or not the tree still
   carries Git metadata, so a source archive or a Docker context copied without
-  `.git` no longer lints everything `.gitignore` lists. Outside a repository
-  mado reads ignore files only at or below the paths it was given; inside one
-  the search still stops at the repository root (#436)
+  `.git` no longer lints everything `.gitignore` lists. The search for them
+  stops at the repository root, or, for a tree that has none, at the directory
+  mado was started in. Each path given to `mado check` is judged on its own, so
+  naming a repository and an archive in one command reads both their
+  `.gitignore` files (#436)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ parsed and therefore what gets reported.
   no Git metadata: an `.ignore` file above the directory mado was started in is
   no longer read. Inside a repository they are still read from every parent
   directory (#436)
+- A path named with a `.` component that says nothing — `mado check docs/.` —
+  is reported under the name without it, `docs/bad.md` rather than
+  `docs/./bad.md`, and the ignore files above it now reach it as they reach
+  `docs` (#436)
 - **Breaking:** `service::walker::WalkParallelBuilder::build` returns one walker
   per set of paths that need the same ignore files read for them, rather than a
   single walker for every path given (#436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,6 @@ parsed and therefore what gets reported.
   no Git metadata: an `.ignore` file above the directory mado was started in is
   no longer read. Inside a repository they are still read from every parent
   directory (#436)
-- A path named with steps that lead nowhere — `mado check docs/.` or
-  `mado check d1/docs/../docs` — is reported under the name without them,
-  `docs/bad.md` rather than `docs/./bad.md`, and the ignore files above it now
-  reach it as they reach the name written plainly. A `..` that follows a
-  symbolic link stays where it is, since it undoes where the link led rather
-  than the name before it (#436)
 - **Breaking:** `service::walker::WalkParallelBuilder::build` returns one walker
   per set of paths that need the same ignore files read for them, rather than a
   single walker for every path given (#436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ parsed and therefore what gets reported.
 
 ## [Unreleased]
 
+### Changed
+
+- `respect-gitignore` covers `.gitignore` files and nothing else: the global Git
+  ignore file and `.git/info/exclude`, which mado had been reading by inheriting
+  the walker's defaults, are no longer consulted. Neither travels with the tree
+  being linted (#436)
+
+### Fixed
+
+- `respect-gitignore` applies `.gitignore` files whether or not the tree still
+  carries Git metadata, so a source archive or a Docker context copied without
+  `.git` no longer lints everything `.gitignore` lists. Outside a repository
+  mado reads ignore files only at or below the paths it was given; inside one
+  the search still stops at the repository root (#436)
+
 ## [0.3.2] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ parsed and therefore what gets reported.
   no Git metadata: an `.ignore` file above the directory mado was started in is
   no longer read. Inside a repository they are still read from every parent
   directory (#436)
-- A path named with a `.` component that says nothing — `mado check docs/.` —
-  is reported under the name without it, `docs/bad.md` rather than
-  `docs/./bad.md`, and the ignore files above it now reach it as they reach
-  `docs` (#436)
+- A path named with steps that lead nowhere — `mado check docs/.` or
+  `mado check d1/docs/../docs` — is reported under the name without them,
+  `docs/bad.md` rather than `docs/./bad.md`, and the ignore files above it now
+  reach it as they reach the name written plainly. A `..` that follows a
+  symbolic link stays where it is, since it undoes where the link led rather
+  than the name before it (#436)
 - **Breaking:** `service::walker::WalkParallelBuilder::build` returns one walker
   per set of paths that need the same ignore files read for them, rather than a
   single walker for every path given (#436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ parsed and therefore what gets reported.
 
 ### Fixed
 
+- A glob mado cannot parse in the ignore file of the directory `mado check` was
+  given is reported, as one in a directory above it already was. The rest of
+  that file applies either way (#436)
 - `respect-gitignore` applies `.gitignore` files whether or not the tree still
   carries Git metadata, so a source archive or a Docker context copied without
   `.git` no longer lints everything `.gitignore` lists. The search for them

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ colored = "3.1.1"
 comrak.workspace = true
 etcetera = "0.11.0"
 globset = { version = "0.4.18", features = ["serde1"] }
-ignore = "0.4.25"
+ignore = "0.4.33"
 linkify = "0.11.0"
 miette = { version = "7.6.0", features = ["fancy"] }
 regex = "1.12.2"

--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ well where the path is in one, and does not where the path is not: there,
 `.gitignore` files from above it keep applying inside it.
 
 A path is only read against the files above it where its name leads where it
-reads. `mado check docs` and `mado check ./docs` do; `mado check docs/.`,
+reads. `mado check docs`, `mado check ./docs` and `mado check docs/` do — a
+separator on the end is not a step. `mado check docs/.`,
 `mado check d1/docs/../docs`, and a path reached through a symbolic link do
-not, and each of those is its own boundary — mado reports what an ignore file
+not, and each of those is its own boundary: mado reports what an ignore file
 above them would have excluded, rather than excluding it silently.
 
 `.ignore` files stop at the same place, with one difference: inside a

--- a/README.md
+++ b/README.md
@@ -152,17 +152,29 @@ and [the JSON Schema for `mado.toml`](https://github.com/akiomik/mado/blob/main/
 
 ### Ignore files
 
-`respect-ignore` and `respect-gitignore` decide whether `.ignore` and
-`.gitignore` files exclude what they list. `.gitignore` applies whether or not
-the tree still carries Git metadata, so a clone and a source archive of the same
-tree lint the same files.
+`respect-ignore` and `respect-gitignore` are independent switches, deciding
+whether `.ignore` and `.gitignore` files exclude what they list. Neither moves
+the directories the other is read from.
 
-The search for ignore files stops at the repository root, as Git does. When no
-`.git` is found, mado reads ignore files only at or below the paths it was
-given, rather than searching up to the filesystem root.
+`.gitignore` applies whether or not the tree still carries Git metadata, so a
+clone and a source archive of the same tree lint the same files. Where the
+search for `.gitignore` files stops is decided for each path given to
+`mado check`, in this order:
+
+1. the repository root, if the path sits in one — a `.git` directory, the
+   `.git` file a worktree or submodule carries, or a `.jj` directory
+1. otherwise the directory mado was started in, if the path is below it — the
+   same directory `mado.toml` is looked for in
+1. otherwise the path itself
+
+`.ignore` files stop at the same place, except inside a repository, where they
+are read from every parent directory as [ripgrep] reads them.
 
 The global Git ignore file and `.git/info/exclude` are never read: neither
-travels with the tree being linted.
+travels with the tree being linted, so honouring them would make the result
+depend on the machine and on the clone.
+
+[ripgrep]: https://github.com/BurntSushi/ripgrep
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -193,10 +193,13 @@ be mado excluding a file a clone keeps, so `.gitignore` files are left to
 Git's own rule there and go unread outside a repository, as they did before
 mado read them without one. Any parent directory counts, however far above the
 tree it sits and whether or not the line names anything below it, since the
-walker reads `.ignore` files from all of them. mado says once which `.ignore`
-file it was, since a tree where this happens is a tree whose `.gitignore` files
-go unread. Turning `respect-ignore` off leaves nothing to rank over a
-`.gitignore`, and it applies as usual.
+walker reads `.ignore` files from all of them. Git's own rule is the walker's
+whole arrangement, so `.ignore` files are read from every parent directory
+there as well, rather than stopping where they otherwise would. mado says once
+which `.ignore` file it was, since a tree where this happens is a tree whose
+`.gitignore` files go unread. Turning `respect-ignore` off leaves nothing to
+rank over a `.gitignore`, and it applies as usual. Inside a repository none of
+this arises: the walker finds every one of these files itself.
 
 The global Git ignore file and `.git/info/exclude` are never read: neither
 travels with the tree being linted, so honouring them would make the result

--- a/README.md
+++ b/README.md
@@ -175,10 +175,11 @@ well where the path is in one, and does not where the path is not: there,
 
 A path is only read against the files above it where its name leads where it
 reads. `mado check docs`, `mado check ./docs` and `mado check docs/` do — a
-separator on the end is not a step. `mado check docs/.`,
-`mado check d1/docs/../docs`, and a path reached through a symbolic link do
-not, and each of those is its own boundary: mado reports what an ignore file
-above them would have excluded, rather than excluding it silently.
+separator on either end is not a step. `mado check docs/.`,
+`mado check docs//sub`, `mado check d1/docs/../docs`, and a path reached
+through a symbolic link do not, and each of those is its own boundary: mado
+reports what an ignore file above them would have excluded, rather than
+excluding it silently.
 
 `.ignore` files stop at the same place, with one difference: inside a
 repository they are read from every parent directory, as [ripgrep] reads them.

--- a/README.md
+++ b/README.md
@@ -157,8 +157,11 @@ whether `.ignore` and `.gitignore` files exclude what they list. Neither moves
 the directories the other is read from.
 
 `.gitignore` applies whether or not the tree still carries Git metadata, so a
-clone and a source archive of the same tree lint the same files. Where the
-search for `.gitignore` files stops is decided for each path given to
+tree whose ignore files are all `.gitignore` — the usual case — lints the same
+as a clone and as a source archive. Where `.ignore` files are in play as well,
+two differences remain, both noted below.
+
+Where the search for `.gitignore` files stops is decided for each path given to
 `mado check`, in this order:
 
 1. the repository root, if the path sits in one — a `.git` directory, the
@@ -167,13 +170,12 @@ search for `.gitignore` files stops is decided for each path given to
    same directory `mado.toml` is looked for in
 1. otherwise the path itself
 
-`.ignore` files stop at the same place, except inside a repository, where they
-are read from every parent directory as [ripgrep] reads them.
+`.ignore` files stop at the same place, with one difference: inside a
+repository they are read from every parent directory, as [ripgrep] reads them.
 
-Where an `.ignore` and a `.gitignore` name the same path, `.ignore` wins. There
-is one exception, and it is a place a clone and an archive of the same tree
-still differ: outside a repository, a `.gitignore` below the path being linted
-wins over an `.ignore` above it.
+Where an `.ignore` and a `.gitignore` name the same path, `.ignore` wins, with
+one difference the other way: outside a repository, a `.gitignore` below the
+path being linted wins over an `.ignore` above it.
 
 The global Git ignore file and `.git/info/exclude` are never read: neither
 travels with the tree being linted, so honouring them would make the result

--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ For more details,
 see [the example `mado.toml`](https://github.com/akiomik/mado/blob/main/mado.toml)
 and [the JSON Schema for `mado.toml`](https://github.com/akiomik/mado/blob/main/pkg/json-schema/mado.json).
 
+### Ignore files
+
+`respect-ignore` and `respect-gitignore` decide whether `.ignore` and
+`.gitignore` files exclude what they list. `.gitignore` applies whether or not
+the tree still carries Git metadata, so a clone and a source archive of the same
+tree lint the same files.
+
+The search for ignore files stops at the repository root, as Git does. When no
+`.git` is found, mado reads ignore files only at or below the paths it was
+given, rather than searching up to the filesystem root.
+
+The global Git ignore file and `.git/info/exclude` are never read: neither
+travels with the tree being linted.
+
 ## GitHub Actions
 
 Mado is compatible with GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ repository they are read from every parent directory, as [ripgrep] reads them.
 
 Where an `.ignore` and a `.gitignore` name the same path, `.ignore` wins, with
 one difference the other way: outside a repository, a `.gitignore` below the
-path being linted wins over an `.ignore` above it. Where that `.ignore` takes
-something back — a line opening with a `!` — the difference would be mado
-excluding a file a clone keeps, so outside a repository `.gitignore` files are
-left to Git's own rule there and go unread, as they did before mado read them
-without one.
+path being linted wins over an `.ignore` above it. Where an `.ignore` over the
+path takes something back — a line opening with a `!` — the difference would
+be mado excluding a file a clone keeps, so `.gitignore` files are left to
+Git's own rule there and go unread outside a repository, as they did before
+mado read them without one.
 
 The global Git ignore file and `.git/info/exclude` are never read: neither
 travels with the tree being linted, so honouring them would make the result

--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ path being linted wins over an `.ignore` above it. Where an `.ignore` over the
 path takes something back — a line opening with a `!` — the difference would
 be mado excluding a file a clone keeps, so `.gitignore` files are left to
 Git's own rule there and go unread outside a repository, as they did before
-mado read them without one.
+mado read them without one. Any parent directory counts, however far above the
+tree it sits and whether or not the line names anything below it, since the
+walker reads `.ignore` files from all of them. Turning `respect-ignore` off
+leaves nothing to rank over a `.gitignore`, and it applies as usual.
 
 The global Git ignore file and `.git/info/exclude` are never read: neither
 travels with the tree being linted, so honouring them would make the result

--- a/README.md
+++ b/README.md
@@ -177,9 +177,10 @@ A path is only read against the files above it where its name leads where it
 reads. `mado check docs`, `mado check ./docs` and `mado check docs/` do — a
 separator on either end is not a step. `mado check docs/.`,
 `mado check docs//sub`, `mado check d1/docs/../docs`, and a path reached
-through a symbolic link do not, and each of those is its own boundary: mado
-reports what an ignore file above them would have excluded, rather than
-excluding it silently.
+through a symbolic link do not, and outside a repository each of those is its
+own boundary: mado reports what an ignore file above them would have excluded,
+rather than excluding it silently. Inside one none of this arises — the walker
+finds these files itself there, and reads every spelling against them alike.
 
 `.ignore` files stop at the same place, with one difference: inside a
 repository they are read from every parent directory, as [ripgrep] reads them.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ search for `.gitignore` files stops is decided for each path given to
 `.ignore` files stop at the same place, except inside a repository, where they
 are read from every parent directory as [ripgrep] reads them.
 
+Where an `.ignore` and a `.gitignore` name the same path, `.ignore` wins. There
+is one exception, and it is a place a clone and an archive of the same tree
+still differ: outside a repository, a `.gitignore` below the path being linted
+wins over an `.ignore` above it.
+
 The global Git ignore file and `.git/info/exclude` are never read: neither
 travels with the tree being linted, so honouring them would make the result
 depend on the machine and on the clone.

--- a/README.md
+++ b/README.md
@@ -157,9 +157,8 @@ whether `.ignore` and `.gitignore` files exclude what they list. Neither moves
 the directories the other is read from.
 
 `.gitignore` applies whether or not the tree still carries Git metadata, so a
-tree whose ignore files are all `.gitignore` — the usual case — lints the same
-as a clone and as a source archive. Where `.ignore` files are in play as well,
-two differences remain, both noted below.
+source archive lints the same as a clone of it. Three shapes still differ, each
+noted below where it belongs.
 
 Where the search for `.gitignore` files stops is decided for each path given to
 `mado check`, in this order:
@@ -169,6 +168,10 @@ Where the search for `.gitignore` files stops is decided for each path given to
 1. otherwise the directory mado was started in, if the path is below it — the
    same directory `mado.toml` is looked for in
 1. otherwise the path itself
+
+Those are about the path itself. A repository *below* it stops the search as
+well where the path is in one, and does not where the path is not: there,
+`.gitignore` files from above it keep applying inside it.
 
 `.ignore` files stop at the same place, with one difference: inside a
 repository they are read from every parent directory, as [ripgrep] reads them.

--- a/README.md
+++ b/README.md
@@ -193,8 +193,10 @@ be mado excluding a file a clone keeps, so `.gitignore` files are left to
 Git's own rule there and go unread outside a repository, as they did before
 mado read them without one. Any parent directory counts, however far above the
 tree it sits and whether or not the line names anything below it, since the
-walker reads `.ignore` files from all of them. Turning `respect-ignore` off
-leaves nothing to rank over a `.gitignore`, and it applies as usual.
+walker reads `.ignore` files from all of them. mado says once which `.ignore`
+file it was, since a tree where this happens is a tree whose `.gitignore` files
+go unread. Turning `respect-ignore` off leaves nothing to rank over a
+`.gitignore`, and it applies as usual.
 
 The global Git ignore file and `.git/info/exclude` are never read: neither
 travels with the tree being linted, so honouring them would make the result

--- a/README.md
+++ b/README.md
@@ -186,7 +186,11 @@ repository they are read from every parent directory, as [ripgrep] reads them.
 
 Where an `.ignore` and a `.gitignore` name the same path, `.ignore` wins, with
 one difference the other way: outside a repository, a `.gitignore` below the
-path being linted wins over an `.ignore` above it.
+path being linted wins over an `.ignore` above it. Where that `.ignore` takes
+something back — a line opening with a `!` — the difference would be mado
+excluding a file a clone keeps, so outside a repository `.gitignore` files are
+left to Git's own rule there and go unread, as they did before mado read them
+without one.
 
 The global Git ignore file and `.git/info/exclude` are never read: neither
 travels with the tree being linted, so honouring them would make the result

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ Those are about the path itself. A repository *below* it stops the search as
 well where the path is in one, and does not where the path is not: there,
 `.gitignore` files from above it keep applying inside it.
 
+A path is only read against the files above it where its name leads where it
+reads. `mado check docs` and `mado check ./docs` do; `mado check docs/.`,
+`mado check d1/docs/../docs`, and a path reached through a symbolic link do
+not, and each of those is its own boundary — mado reports what an ignore file
+above them would have excluded, rather than excluding it silently.
+
 `.ignore` files stop at the same place, with one difference: inside a
 repository they are read from every parent directory, as [ripgrep] reads them.
 

--- a/pkg/json-schema/mado.json
+++ b/pkg/json-schema/mado.json
@@ -11,12 +11,12 @@
       "additionalProperties": false,
       "properties": {
         "respect-ignore": {
-          "description": "Exclude files that are ignored by .ignore",
+          "description": "Exclude files that are ignored by .ignore. When no Git repository is found, only .ignore files at or below the paths being linted are read",
           "type": "boolean",
           "default": true
         },
         "respect-gitignore": {
-          "description": "Exclude files that are ignored by .gitignore",
+          "description": "Exclude files that are ignored by .gitignore, whether or not the tree carries Git metadata. The global Git ignore file and .git/info/exclude are never read",
           "type": "boolean",
           "default": true
         },

--- a/pkg/json-schema/mado.json
+++ b/pkg/json-schema/mado.json
@@ -11,7 +11,7 @@
       "additionalProperties": false,
       "properties": {
         "respect-ignore": {
-          "description": "Exclude files that are ignored by .ignore. When no Git repository is found, only .ignore files at or below the paths being linted are read",
+          "description": "Exclude files that are ignored by .ignore. Independent of respect-gitignore",
           "type": "boolean",
           "default": true
         },

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -71,12 +71,10 @@ impl ParallelLintRunner {
             }
         });
 
-        // Each walk holds its visitor for as long as it runs, so the groups
-        // run in batches of as many as the machine has to give, one visitor
-        // apiece, rather than one after another.
-        // One walk at a time at the very least, whatever the count came out as:
-        // a batch of none would leave the loop turning without moving, and a
-        // walk the batch has no visitor for would go unwalked without a word.
+        // Each walk holds its visitor while it runs, so a batch gets one
+        // visitor apiece and the batches run one after another. At least one
+        // walk per batch: a batch of none would loop without ever moving on,
+        // and a walk with no visitor would not be walked at all.
         let at_once = walks_at_once(thread_budget(), self.walkers.len()).max(1);
         let mut remaining = self.walkers;
         // A clone of the factory keeps the note of what has been said, so a

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -80,7 +80,10 @@ impl ParallelLintRunner {
             .map(|_| MarkdownLintVisitorFactory::new(self.config.clone(), tx.clone()))
             .collect::<Result<Vec<_>>>()?;
         while !remaining.is_empty() {
-            let rest = remaining.split_off(remaining.len().min(concurrency));
+            // One a batch at the very least, whatever the count came out as:
+            // a batch of none would leave the loop turning without moving.
+            let batch = remaining.len().min(concurrency).max(1);
+            let rest = remaining.split_off(batch);
             thread::scope(|scope| {
                 for (walker, builder) in remaining.into_iter().zip(builders.iter_mut()) {
                     scope.spawn(move || walker.visit(builder));

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use comrak::Arena;
+use core::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, mpsc};
 use std::thread;
@@ -71,13 +72,27 @@ impl ParallelLintRunner {
             }
         });
 
-        let mut builder = MarkdownLintVisitorFactory::new(self.config, tx)?;
-        for walker in self.walkers {
-            walker.visit(&mut builder);
+        // Each walk holds its visitor for as long as it runs, so the groups
+        // run in batches of as many as the machine has to give, one visitor
+        // apiece, rather than one after another.
+        let concurrency = thread::available_parallelism().map_or(1, NonZero::get);
+        let mut remaining = self.walkers;
+        let mut builders = (0..concurrency.min(remaining.len()))
+            .map(|_| MarkdownLintVisitorFactory::new(self.config.clone(), tx.clone()))
+            .collect::<Result<Vec<_>>>()?;
+        while !remaining.is_empty() {
+            let rest = remaining.split_off(remaining.len().min(concurrency));
+            thread::scope(|scope| {
+                for (walker, builder) in remaining.into_iter().zip(builders.iter_mut()) {
+                    scope.spawn(move || walker.visit(builder));
+                }
+            });
+            remaining = rest;
         }
 
         // Wait for the completion
-        drop(builder);
+        drop(builders);
+        drop(tx);
         thread
             .join()
             .map_err(|err| miette!("Failed to join thread. {:?}", err))?;

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -79,9 +79,17 @@ impl ParallelLintRunner {
         // walk the batch has no visitor for would go unwalked without a word.
         let at_once = walks_at_once(thread_budget(), self.walkers.len()).max(1);
         let mut remaining = self.walkers;
-        let mut builders = (0..at_once.min(remaining.len()))
-            .map(|_| MarkdownLintVisitorFactory::new(self.config.clone(), tx.clone()))
-            .collect::<Result<Vec<_>>>()?;
+        // The visitors share one note of what has been said, so a broken
+        // ignore file several groups read is reported once for the run.
+        let wanted = at_once.min(remaining.len());
+        let mut builders: Vec<MarkdownLintVisitorFactory> = Vec::with_capacity(wanted);
+        for _ in 0..wanted {
+            let next = match builders.first() {
+                Some(first) => first.sharing(),
+                None => MarkdownLintVisitorFactory::new(self.config.clone(), tx.clone())?,
+            };
+            builders.push(next);
+        }
         while !remaining.is_empty() {
             let rest = remaining.split_off(remaining.len().min(at_once));
             thread::scope(|scope| {

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -74,16 +74,16 @@ impl ParallelLintRunner {
         // Each walk holds its visitor for as long as it runs, so the groups
         // run in batches of as many as the machine has to give, one visitor
         // apiece, rather than one after another.
-        let concurrency = walks_at_once(thread_budget(), self.walkers.len());
+        // One walk at a time at the very least, whatever the count came out as:
+        // a batch of none would leave the loop turning without moving, and a
+        // walk the batch has no visitor for would go unwalked without a word.
+        let at_once = walks_at_once(thread_budget(), self.walkers.len()).max(1);
         let mut remaining = self.walkers;
-        let mut builders = (0..concurrency.min(remaining.len()))
+        let mut builders = (0..at_once.min(remaining.len()))
             .map(|_| MarkdownLintVisitorFactory::new(self.config.clone(), tx.clone()))
             .collect::<Result<Vec<_>>>()?;
         while !remaining.is_empty() {
-            // One a batch at the very least, whatever the count came out as:
-            // a batch of none would leave the loop turning without moving.
-            let batch = remaining.len().min(concurrency).max(1);
-            let rest = remaining.split_off(batch);
+            let rest = remaining.split_off(remaining.len().min(at_once));
             thread::scope(|scope| {
                 for (walker, builder) in remaining.into_iter().zip(builders.iter_mut()) {
                     scope.spawn(move || walker.visit(builder));

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -33,7 +33,7 @@ impl LintRunner {
 }
 
 pub struct ParallelLintRunner {
-    walker: WalkParallel,
+    walkers: Vec<WalkParallel>,
     config: Config,
     capacity: usize,
 }
@@ -41,14 +41,14 @@ pub struct ParallelLintRunner {
 impl ParallelLintRunner {
     #[inline]
     pub fn new(patterns: &[PathBuf], config: Config, capacity: usize) -> Result<Self> {
-        let walker = WalkParallelBuilder::build(
+        let walkers = WalkParallelBuilder::build(
             patterns,
             config.lint.respect_ignore,
             config.lint.respect_gitignore,
         )?;
 
         Ok(Self {
-            walker,
+            walkers,
             config,
             capacity,
         })
@@ -72,7 +72,9 @@ impl ParallelLintRunner {
         });
 
         let mut builder = MarkdownLintVisitorFactory::new(self.config, tx)?;
-        self.walker.visit(&mut builder);
+        for walker in self.walkers {
+            walker.visit(&mut builder);
+        }
 
         // Wait for the completion
         drop(builder);
@@ -117,6 +119,12 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn parallel_lint_runner_new_empty_patterns() {
+        let result = ParallelLintRunner::new(&[], Config::default(), 0);
+        assert!(result.is_err());
+    }
 
     #[test]
     fn parallel_lint_runner_run() -> Result<()> {

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -79,17 +79,12 @@ impl ParallelLintRunner {
         // walk the batch has no visitor for would go unwalked without a word.
         let at_once = walks_at_once(thread_budget(), self.walkers.len()).max(1);
         let mut remaining = self.walkers;
-        // The visitors share one note of what has been said, so a broken
-        // ignore file several groups read is reported once for the run.
-        let wanted = at_once.min(remaining.len());
-        let mut builders: Vec<MarkdownLintVisitorFactory> = Vec::with_capacity(wanted);
-        for _ in 0..wanted {
-            let next = match builders.first() {
-                Some(first) => first.sharing(),
-                None => MarkdownLintVisitorFactory::new(self.config.clone(), tx.clone())?,
-            };
-            builders.push(next);
-        }
+        // A clone of the factory keeps the note of what has been said, so a
+        // broken ignore file several groups read is reported once for the run.
+        let first = MarkdownLintVisitorFactory::new(self.config, tx.clone())?;
+        let alongside = at_once.min(remaining.len()).saturating_sub(1);
+        let mut builders = vec![first.clone(); alongside];
+        builders.push(first);
         while !remaining.is_empty() {
             let rest = remaining.split_off(remaining.len().min(at_once));
             thread::scope(|scope| {
@@ -149,6 +144,23 @@ mod tests {
     fn parallel_lint_runner_new_empty_patterns() {
         let result = ParallelLintRunner::new(&[], Config::default(), 0);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parallel_lint_runner_run_several_groups() -> Result<()> {
+        let mut config = Config::default();
+        config.lint.rules = vec![];
+
+        // Nothing is read for a file and something is for a directory, so the
+        // two are walked as two groups.
+        let patterns = [
+            Path::new("README.md").to_path_buf(),
+            Path::new("src").to_path_buf(),
+        ];
+        let runner = ParallelLintRunner::new(&patterns, config, 0)?;
+        let actual = runner.run()?;
+        assert_eq!(actual, vec![]);
+        Ok(())
     }
 
     #[test]

--- a/src/service/runner.rs
+++ b/src/service/runner.rs
@@ -2,7 +2,6 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use comrak::Arena;
-use core::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, mpsc};
 use std::thread;
@@ -13,7 +12,7 @@ use miette::{IntoDiagnostic as _, Result};
 
 use super::Linter;
 use super::visitor::MarkdownLintVisitorFactory;
-use super::walker::WalkParallelBuilder;
+use super::walker::{WalkParallelBuilder, thread_budget, walks_at_once};
 use crate::config::Config;
 use crate::{Document, Violation};
 
@@ -75,7 +74,7 @@ impl ParallelLintRunner {
         // Each walk holds its visitor for as long as it runs, so the groups
         // run in batches of as many as the machine has to give, one visitor
         // apiece, rather than one after another.
-        let concurrency = thread::available_parallelism().map_or(1, NonZero::get);
+        let concurrency = walks_at_once(thread_budget(), self.walkers.len());
         let mut remaining = self.walkers;
         let mut builders = (0..concurrency.min(remaining.len()))
             .map(|_| MarkdownLintVisitorFactory::new(self.config.clone(), tx.clone()))

--- a/src/service/visitor.rs
+++ b/src/service/visitor.rs
@@ -1,5 +1,10 @@
+extern crate alloc;
+
+use alloc::sync::Arc;
 use core::result::Result;
+use std::collections::HashSet;
 use std::path::{Component, PathBuf};
+use std::sync::Mutex;
 use std::sync::mpsc::SyncSender;
 
 use comrak::Arena;
@@ -14,6 +19,7 @@ pub struct MarkdownLintVisitor {
     linter: Linter,
     exclusion: GlobSet,
     tx: SyncSender<Vec<Violation>>,
+    said: Option<Arc<Mutex<HashSet<String>>>>,
 }
 
 impl MarkdownLintVisitor {
@@ -24,6 +30,30 @@ impl MarkdownLintVisitor {
             linter,
             exclusion,
             tx,
+            said: None,
+        }
+    }
+
+    /// This visitor, sharing `said` as the note of what has been said already.
+    /// A tree is walked a group at a time, and a broken ignore file several
+    /// groups read has as much to say to each of them.
+    #[inline]
+    #[must_use]
+    pub fn saying_each_thing_once(mut self, said: Arc<Mutex<HashSet<String>>>) -> Self {
+        self.said = Some(said);
+        self
+    }
+
+    /// Say `message`, unless it has been said already. A note that cannot be
+    /// read leaves it said again rather than unsaid.
+    fn say(&self, message: &str) {
+        let fresh = self.said.as_ref().is_none_or(|said| {
+            said.lock()
+                .is_ok_and(|mut said| said.insert(message.to_owned()))
+        });
+
+        if fresh {
+            eprintln!("{message}");
         }
     }
 
@@ -61,7 +91,7 @@ impl ParallelVisitor for MarkdownLintVisitor {
     fn visit(&mut self, either_entry: Result<DirEntry, Error>) -> WalkState {
         if let Err(err) = self.visit_inner(either_entry) {
             // TODO: Handle errors
-            eprintln!("{err}");
+            self.say(&err.to_string());
         }
         WalkState::Continue
     }
@@ -71,6 +101,7 @@ pub struct MarkdownLintVisitorFactory {
     config: Config,
     exclusion: GlobSet,
     tx: SyncSender<Vec<Violation>>,
+    said: Arc<Mutex<HashSet<String>>>,
 }
 
 impl MarkdownLintVisitorFactory {
@@ -81,7 +112,21 @@ impl MarkdownLintVisitorFactory {
             config,
             exclusion,
             tx,
+            said: Arc::new(Mutex::new(HashSet::new())),
         })
+    }
+
+    /// Another factory like this one, whose visitors say what this one's have
+    /// said no more than once between them.
+    #[inline]
+    #[must_use]
+    pub fn sharing(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            exclusion: self.exclusion.clone(),
+            tx: self.tx.clone(),
+            said: Arc::clone(&self.said),
+        }
     }
 }
 
@@ -89,11 +134,10 @@ impl<'s> ParallelVisitorBuilder<'s> for MarkdownLintVisitorFactory {
     #[inline]
     fn build(&mut self) -> Box<dyn ParallelVisitor + 's> {
         let linter = Linter::from(&self.config);
-        Box::new(MarkdownLintVisitor::new(
-            linter,
-            self.exclusion.clone(),
-            self.tx.clone(),
-        ))
+        Box::new(
+            MarkdownLintVisitor::new(linter, self.exclusion.clone(), self.tx.clone())
+                .saying_each_thing_once(Arc::clone(&self.said)),
+        )
     }
 }
 
@@ -118,6 +162,29 @@ mod tests {
 
         drop(visitor);
         assert!(rx.recv().is_err()); // Because rx has not received any messages
+        Ok(())
+    }
+
+    #[test]
+    fn markdown_lint_visitor_says_each_thing_once() {
+        let said = Arc::new(Mutex::new(HashSet::new()));
+        let (tx, _rx) = mpsc::sync_channel::<Vec<Violation>>(0);
+        let visitor = MarkdownLintVisitor::new(Linter::new(vec![]), GlobSet::empty(), tx)
+            .saying_each_thing_once(Arc::clone(&said));
+
+        visitor.say("one thing");
+        visitor.say("one thing");
+
+        assert!(said.lock().is_ok_and(|note| note.len() == 1));
+    }
+
+    #[test]
+    fn markdown_lint_visitor_factory_sharing() -> miette::Result<()> {
+        let (tx, _rx) = mpsc::sync_channel::<Vec<Violation>>(0);
+        let first = MarkdownLintVisitorFactory::new(Config::default(), tx)?;
+        let second = first.sharing();
+
+        assert!(Arc::ptr_eq(&first.said, &second.said));
         Ok(())
     }
 

--- a/src/service/visitor.rs
+++ b/src/service/visitor.rs
@@ -97,6 +97,7 @@ impl ParallelVisitor for MarkdownLintVisitor {
     }
 }
 
+#[derive(Clone)]
 pub struct MarkdownLintVisitorFactory {
     config: Config,
     exclusion: GlobSet,
@@ -105,6 +106,8 @@ pub struct MarkdownLintVisitorFactory {
 }
 
 impl MarkdownLintVisitorFactory {
+    /// A factory whose visitors keep their own note of what has been said. A
+    /// clone of it keeps that note rather than starting one.
     #[inline]
     pub fn new(config: Config, tx: SyncSender<Vec<Violation>>) -> miette::Result<Self> {
         let exclusion = config.lint.exclude_set()?;
@@ -114,19 +117,6 @@ impl MarkdownLintVisitorFactory {
             tx,
             said: Arc::new(Mutex::new(HashSet::new())),
         })
-    }
-
-    /// Another factory like this one, whose visitors say what this one's have
-    /// said no more than once between them.
-    #[inline]
-    #[must_use]
-    pub fn sharing(&self) -> Self {
-        Self {
-            config: self.config.clone(),
-            exclusion: self.exclusion.clone(),
-            tx: self.tx.clone(),
-            said: Arc::clone(&self.said),
-        }
     }
 }
 
@@ -179,10 +169,10 @@ mod tests {
     }
 
     #[test]
-    fn markdown_lint_visitor_factory_sharing() -> miette::Result<()> {
+    fn markdown_lint_visitor_factory_clone_keeps_the_note() -> miette::Result<()> {
         let (tx, _rx) = mpsc::sync_channel::<Vec<Violation>>(0);
         let first = MarkdownLintVisitorFactory::new(Config::default(), tx)?;
-        let second = first.sharing();
+        let second = first.clone();
 
         assert!(Arc::ptr_eq(&first.said, &second.said));
         Ok(())

--- a/src/service/visitor.rs
+++ b/src/service/visitor.rs
@@ -53,9 +53,11 @@ impl MarkdownLintVisitor {
         })
     }
 
-    /// Report `message` unless it has been reported already. Only the walk's
-    /// own errors come here; an error about a file is reported every time,
-    /// since two files can fail with the same message.
+    /// Report `message` unless the same message has been reported already.
+    /// What the walk has to say names the file it is about -- an ignore file
+    /// it could not parse, a directory it could not read -- so only a true
+    /// repeat is dropped. An error from linting a file does not come here,
+    /// since two files can fail with the same words.
     fn say_once(&self, message: &str) {
         if self.unsaid(message) {
             eprintln!("{message}");

--- a/src/service/visitor.rs
+++ b/src/service/visitor.rs
@@ -34,9 +34,9 @@ impl MarkdownLintVisitor {
         }
     }
 
-    /// This visitor, sharing `said` as the note of what the walks have said
-    /// about themselves. A tree is walked a group at a time, and an ignore
-    /// file several groups read has as much to say to each of them.
+    /// This visitor, sharing `said` as the note of what has been reported. A
+    /// tree is walked a group at a time, and without the note an ignore file
+    /// several groups read reports its errors once per group.
     #[inline]
     #[must_use]
     pub fn saying_each_thing_once(mut self, said: Arc<Mutex<HashSet<String>>>) -> Self {
@@ -44,9 +44,8 @@ impl MarkdownLintVisitor {
         self
     }
 
-    /// Whether `message` is yet to be said. A note that cannot be read leaves
-    /// it said again rather than unsaid: saying a thing twice is the smaller
-    /// fault of the two.
+    /// Whether `message` has yet to be reported. An unreadable note reports
+    /// again rather than staying silent.
     fn unsaid(&self, message: &str) -> bool {
         self.said.as_ref().is_none_or(|said| {
             said.lock()
@@ -54,8 +53,9 @@ impl MarkdownLintVisitor {
         })
     }
 
-    /// Say what the walk has to say about itself, unless it has been said
-    /// already. What a file has to say is its own and is said either way.
+    /// Report `message` unless it has been reported already. Only the walk's
+    /// own errors come here; an error about a file is reported every time,
+    /// since two files can fail with the same message.
     fn say_once(&self, message: &str) {
         if self.unsaid(message) {
             eprintln!("{message}");
@@ -95,8 +95,8 @@ impl ParallelVisitor for MarkdownLintVisitor {
     fn visit(&mut self, either_entry: Result<DirEntry, Error>) -> WalkState {
         // TODO: Handle errors
         match either_entry {
-            // The walk speaks here of the files it read to walk by, which are
-            // one file's worth of trouble however many walks read them.
+            // Errors about the ignore files the walk read: one broken file is
+            // one error, however many walks read it.
             Err(err) => self.say_once(&err.to_string()),
             Ok(entry) => {
                 if let Err(err) = self.visit_inner(&entry) {

--- a/src/service/visitor.rs
+++ b/src/service/visitor.rs
@@ -34,9 +34,9 @@ impl MarkdownLintVisitor {
         }
     }
 
-    /// This visitor, sharing `said` as the note of what has been said already.
-    /// A tree is walked a group at a time, and a broken ignore file several
-    /// groups read has as much to say to each of them.
+    /// This visitor, sharing `said` as the note of what the walks have said
+    /// about themselves. A tree is walked a group at a time, and an ignore
+    /// file several groups read has as much to say to each of them.
     #[inline]
     #[must_use]
     pub fn saying_each_thing_once(mut self, said: Arc<Mutex<HashSet<String>>>) -> Self {
@@ -44,21 +44,25 @@ impl MarkdownLintVisitor {
         self
     }
 
-    /// Say `message`, unless it has been said already. A note that cannot be
-    /// read leaves it said again rather than unsaid.
-    fn say(&self, message: &str) {
-        let fresh = self.said.as_ref().is_none_or(|said| {
+    /// Whether `message` is yet to be said. A note that cannot be read leaves
+    /// it said again rather than unsaid: saying a thing twice is the smaller
+    /// fault of the two.
+    fn unsaid(&self, message: &str) -> bool {
+        self.said.as_ref().is_none_or(|said| {
             said.lock()
-                .is_ok_and(|mut said| said.insert(message.to_owned()))
-        });
+                .map_or(true, |mut said| said.insert(message.to_owned()))
+        })
+    }
 
-        if fresh {
+    /// Say what the walk has to say about itself, unless it has been said
+    /// already. What a file has to say is its own and is said either way.
+    fn say_once(&self, message: &str) {
+        if self.unsaid(message) {
             eprintln!("{message}");
         }
     }
 
-    fn visit_inner(&self, either_entry: Result<DirEntry, Error>) -> miette::Result<()> {
-        let entry = either_entry.into_diagnostic()?;
+    fn visit_inner(&self, entry: &DirEntry) -> miette::Result<()> {
         let path = entry.path();
         if path.is_file() && path.extension() == Some("md".as_ref()) {
             // Strip a leading "./" so that exclude patterns match regardless of
@@ -89,10 +93,18 @@ impl MarkdownLintVisitor {
 impl ParallelVisitor for MarkdownLintVisitor {
     #[inline]
     fn visit(&mut self, either_entry: Result<DirEntry, Error>) -> WalkState {
-        if let Err(err) = self.visit_inner(either_entry) {
-            // TODO: Handle errors
-            self.say(&err.to_string());
+        // TODO: Handle errors
+        match either_entry {
+            // The walk speaks here of the files it read to walk by, which are
+            // one file's worth of trouble however many walks read them.
+            Err(err) => self.say_once(&err.to_string()),
+            Ok(entry) => {
+                if let Err(err) = self.visit_inner(&entry) {
+                    eprintln!("{err}");
+                }
+            }
         }
+
         WalkState::Continue
     }
 }
@@ -134,6 +146,7 @@ impl<'s> ParallelVisitorBuilder<'s> for MarkdownLintVisitorFactory {
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc;
+    use std::thread;
 
     use ignore::Walk;
 
@@ -146,8 +159,8 @@ mod tests {
         let exclusion = GlobSet::empty();
         let visitor = MarkdownLintVisitor::new(linter, exclusion, tx);
 
-        for entry in Walk::new(".") {
-            visitor.visit_inner(entry)?;
+        for entry in Walk::new(".").flatten() {
+            visitor.visit_inner(&entry)?;
         }
 
         drop(visitor);
@@ -162,10 +175,39 @@ mod tests {
         let visitor = MarkdownLintVisitor::new(Linter::new(vec![]), GlobSet::empty(), tx)
             .saying_each_thing_once(Arc::clone(&said));
 
-        visitor.say("one thing");
-        visitor.say("one thing");
+        assert!(visitor.unsaid("one thing"));
+        assert!(!visitor.unsaid("one thing"));
+        assert!(visitor.unsaid("another thing"));
+    }
 
-        assert!(said.lock().is_ok_and(|note| note.len() == 1));
+    #[test]
+    fn markdown_lint_visitor_says_what_it_cannot_take_a_note_of() {
+        let said = Arc::new(Mutex::new(HashSet::new()));
+        let (tx, _rx) = mpsc::sync_channel::<Vec<Violation>>(0);
+        let visitor = MarkdownLintVisitor::new(Linter::new(vec![]), GlobSet::empty(), tx)
+            .saying_each_thing_once(Arc::clone(&said));
+
+        let poisoning = Arc::clone(&said);
+        drop(
+            thread::spawn(move || {
+                let _held = poisoning.lock();
+                panic!("poison the note");
+            })
+            .join(),
+        );
+
+        // The note is unreadable now, and a thing said twice beats one lost.
+        assert!(visitor.unsaid("one thing"));
+        assert!(visitor.unsaid("one thing"));
+    }
+
+    #[test]
+    fn markdown_lint_visitor_without_a_note_says_everything() {
+        let (tx, _rx) = mpsc::sync_channel::<Vec<Violation>>(0);
+        let visitor = MarkdownLintVisitor::new(Linter::new(vec![]), GlobSet::empty(), tx);
+
+        assert!(visitor.unsaid("one thing"));
+        assert!(visitor.unsaid("one thing"));
     }
 
     #[test]

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -219,16 +219,18 @@ impl WalkParallelBuilder {
         if Self::is_repository_root(pattern) {
             return None;
         }
-        // The walk reads the ignore files of a directory it is handed, so for
-        // one only what is above it is left to put back.
-        if pattern
-            .canonicalize()
-            .is_ok_and(|path| path == *current_dir)
-        {
-            return Some(vec![]);
-        }
 
-        files
+        // The walk descends into the pattern, so its own last step counts as
+        // much as the ones above it: a name that leaves the boundary anywhere
+        // along its length is bounded by itself, not by what it was written
+        // under.
+        match pattern.canonicalize() {
+            // The walk reads the ignore files of a directory it is handed, so
+            // for the boundary itself only what is above is left to put back.
+            Ok(at) if at == *current_dir => Some(vec![]),
+            Ok(at) if at.starts_with(current_dir) => files,
+            _ => Self::bounds_itself(pattern),
+        }
     }
 
     /// One walker for `patterns`, which need the same ignore files handed
@@ -362,6 +364,11 @@ impl WalkParallelBuilder {
     /// One walker per set of patterns that need the same ignore files handed
     /// back. Which files those are is a property of a single pattern, but
     /// patterns that need the same ones can be walked together.
+    ///
+    /// Each walker is given a share of the threads rather than the run of the
+    /// machine, on the understanding that `walks_at_once` of them are visited
+    /// alongside each other. Visiting them one at a time is correct and slower;
+    /// visiting all of them at once asks the machine for more than it has.
     fn build_from(
         patterns: &[PathBuf],
         current_dir: &Path,
@@ -433,6 +440,8 @@ impl WalkParallelBuilder {
             .collect()
     }
 
+    /// The walkers a command's paths need, ready to be visited. See
+    /// `build_from` for what each of them expects of the visiting.
     #[inline]
     pub fn build(
         patterns: &[PathBuf],

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -13,6 +13,40 @@ use miette::IntoDiagnostic as _;
 use miette::Result;
 use miette::miette;
 
+/// What the walker would spend on a walk of its own on a machine with `cores`.
+/// Its own default stops at twelve however many there are, and a walk mado
+/// sizes by hand would pass that without stopping there as well.
+fn budget_for(cores: usize) -> usize {
+    cores.min(12)
+}
+
+/// `budget_for` this machine.
+pub(crate) fn thread_budget() -> usize {
+    budget_for(thread::available_parallelism().map_or(1, NonZero::get))
+}
+
+/// How many of `walks` walks may run alongside each other on `budget` threads.
+pub(crate) fn walks_at_once(budget: usize, walks: usize) -> usize {
+    walks.min(budget).max(1)
+}
+
+/// What one walk may spend on itself where a command makes `walks` of them, and
+/// `0` -- as many as it likes -- where it makes only one. Between them the ones
+/// running alongside each other spend no more than `budget`.
+pub(crate) fn threads_per_walk(budget: usize, walks: usize) -> usize {
+    if walks < 2 {
+        return 0;
+    }
+
+    #[expect(
+        clippy::integer_division_remainder_used,
+        reason = "sharing a budget out is what division is for, and what is left over is meant to be dropped"
+    )]
+    let threads = budget / walks_at_once(budget, walks);
+
+    threads.max(1)
+}
+
 #[non_exhaustive]
 pub struct WalkParallelBuilder;
 
@@ -252,10 +286,14 @@ impl WalkParallelBuilder {
                 if let Some(err) = builder.add_ignore(file)
                     && !respect_gitignore
                     && !err.is_io()
-                    && !reported.contains(file)
                 {
-                    reported.push(file.clone());
-                    eprintln!("{err}");
+                    // Two groups can name one file two ways, and it is still
+                    // one file with one thing wrong with it.
+                    let at = file.canonicalize().unwrap_or_else(|_| file.clone());
+                    if !reported.contains(&at) {
+                        reported.push(at);
+                        eprintln!("{err}");
+                    }
                 }
             }
         }
@@ -308,19 +346,11 @@ impl WalkParallelBuilder {
             }
         }
 
-        // The runner runs a machine's worth of groups alongside each other, so
-        // the machine is shared out between them rather than handed whole to
-        // each in turn: a walk of its own for every group would spend more on
-        // starting threads than on walking.
-        let threads = if groups.len() > 1 {
-            thread::available_parallelism()
-                .map_or(1, NonZero::get)
-                .div_ceil(groups.len())
-        } else {
-            // As many as the walk likes, which is what it did before there
-            // was ever more than one of them.
-            0
-        };
+        // The runner runs several of these alongside each other, so the walks
+        // share out between them what one of them would have spent: a walk of
+        // its own for every group would spend more on starting threads than on
+        // walking.
+        let threads = threads_per_walk(thread_budget(), groups.len());
         let mut reported = vec![];
         groups
             .iter()
@@ -371,7 +401,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
-    use super::WalkParallelBuilder;
+    use super::{WalkParallelBuilder, budget_for, threads_per_walk, walks_at_once};
 
     struct PathCollector {
         paths: Arc<Mutex<Vec<PathBuf>>>,
@@ -516,6 +546,32 @@ mod tests {
     fn build_empty_patterns() {
         let result = WalkParallelBuilder::build(&[], true, true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn the_budget_is_what_the_walker_would_have_spent() {
+        // The walker's own default stops at twelve however many cores it is
+        // run on, and a walk mado sizes by hand would pass it without this.
+        assert_eq!(budget_for(64), 12);
+        assert_eq!(budget_for(12), 12);
+        assert_eq!(budget_for(4), 4);
+    }
+
+    #[test]
+    fn walks_never_spend_more_than_one_of_them_would() {
+        for budget in [1_usize, 2, 8, 10, 12] {
+            // One walk is left to spend what the walker would have on it.
+            assert_eq!(threads_per_walk(budget, 1), 0);
+            assert_eq!(walks_at_once(budget, 1), 1);
+
+            // Several share it out between them instead.
+            for walks in [2_usize, 3, 5, 7, 12, 13, 200] {
+                let at = format!("{budget} threads over {walks} walks");
+                let threads = threads_per_walk(budget, walks);
+                assert!(threads >= 1, "{at}");
+                assert!(walks_at_once(budget, walks) * threads <= budget, "{at}");
+            }
+        }
     }
 
     #[test]

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -162,13 +162,26 @@ impl WalkParallelBuilder {
     /// The whole way up is asked, not the part mado hands back: the walker
     /// reads an `.ignore` however far over the tree it sits, so one that far
     /// over ranks over a `.gitignore` in it just the same.
-    fn taken_back_over(pattern: &Path) -> Option<PathBuf> {
-        pattern.canonicalize().ok().and_then(|at| {
-            at.ancestors()
-                .skip(1)
-                .map(|over| over.join(".ignore"))
-                .find(|file| file.is_file() && Self::takes_something_back(file))
-        })
+    ///
+    /// The answer belongs to the directory `pattern` sits in, so `seen`
+    /// remembers it: a command naming every directory in one place asks the
+    /// same question once per name.
+    fn taken_back_over(
+        pattern: &Path,
+        seen: &mut Vec<(PathBuf, Option<PathBuf>)>,
+    ) -> Option<PathBuf> {
+        let over = pattern.canonicalize().ok()?.parent()?.to_path_buf();
+        if let Some((_, found)) = seen.iter().find(|(dir, _)| *dir == over) {
+            return found.clone();
+        }
+
+        let found = over
+            .ancestors()
+            .map(|at| at.join(".ignore"))
+            .find(|file| file.is_file() && Self::takes_something_back(file));
+        seen.push((over, found.clone()));
+
+        found
     }
 
     /// The ignore files `dirs` hold, in the order to hand them over. Every
@@ -391,44 +404,42 @@ impl WalkParallelBuilder {
             .skip(1)
             .any(Self::is_repository_root);
         let mut seen = vec![];
+        let mut taken = vec![];
         let mut explained = vec![];
         let mut groups: Vec<(Option<Vec<PathBuf>>, Vec<&PathBuf>)> = vec![];
         for pattern in patterns {
-            // Whatever mado does with the files over this one, they end up
-            // under what the walk finds for itself, and one of them taking
-            // something back is one the walk would then drop. The walker's own
-            // arrangement is left to answer instead, which keeps what it
-            // should and reports more besides. With `.ignore` files left
-            // unread there is nothing over the walk's own answers to begin
-            // with.
-            let taken_back = (respect_ignore && respect_gitignore && pattern.is_dir())
-                .then(|| Self::taken_back_over(pattern))
+            let mut files = Self::ignore_files_for(
+                pattern,
+                current_dir,
+                above_is_repository,
+                respect_ignore,
+                respect_gitignore,
+                &mut seen,
+            );
+            // Whatever mado hands back ends up under what the walk finds for
+            // itself, and one of the files over this one taking something back
+            // is one the walk would then drop. The walker's own arrangement is
+            // left to answer instead, which keeps what it should and reports
+            // more besides. There is nothing to arrange where the walker finds
+            // the files itself, which is what `None` says, nor where `.ignore`
+            // files go unread and nothing stands over the walk's own answers.
+            let taken_back = (files.is_some() && respect_ignore && respect_gitignore)
+                .then(|| Self::taken_back_over(pattern, &mut taken))
                 .flatten();
-            if let Some(file) = taken_back
-                .as_ref()
-                .filter(|file| !explained.contains(*file))
-            {
-                explained.push(file.clone());
-                eprintln!(
-                    "{}: takes a path back with a `!` line, which ranks over any .gitignore \
-                     below it, and mado cannot arrange that without Git metadata, so \
-                     .gitignore files go unread here",
-                    file.display()
-                );
+            if let Some(file) = taken_back {
+                files = None;
+                if !explained.contains(&file) {
+                    eprintln!(
+                        "{}: takes a path back with a `!` line, which ranks over any .gitignore \
+                         below it, and mado cannot arrange that without Git metadata, so \
+                         .gitignore files go unread here and `.ignore` files are read from \
+                         every parent directory",
+                        file.display()
+                    );
+                    explained.push(file);
+                }
             }
 
-            let files = if taken_back.is_some() {
-                None
-            } else {
-                Self::ignore_files_for(
-                    pattern,
-                    current_dir,
-                    above_is_repository,
-                    respect_ignore,
-                    respect_gitignore,
-                    &mut seen,
-                )
-            };
             // Two names for one directory are two keys, and have to be: the
             // walker roots a file it is handed at the name it was handed, and
             // matches it against paths built from the name a pattern was
@@ -679,6 +690,26 @@ mod tests {
                 assert!(walks_at_once(budget, walks) * threads <= budget, "{at}");
             }
         }
+    }
+
+    #[test]
+    fn taken_back_over_answers_for_a_directory_once() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        let root = tmp_dir.path();
+        write(&root.join(".ignore"), "!kept.md\n")?;
+        write(&root.join("d1/one/a.md"), "# Fine\n")?;
+        write(&root.join("d1/two/a.md"), "# Fine\n")?;
+
+        // Both names sit in `d1`, and what is over `d1` is over both of them.
+        let mut seen = vec![];
+        let one = WalkParallelBuilder::taken_back_over(&root.join("d1/one"), &mut seen);
+        let two = WalkParallelBuilder::taken_back_over(&root.join("d1/two"), &mut seen);
+
+        assert!(one.is_some());
+        assert_eq!(one, two);
+        assert_eq!(seen.len(), 1);
+
+        tmp_dir.close().into_diagnostic()
     }
 
     #[test]

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -16,8 +16,8 @@ use miette::Result;
 use miette::miette;
 
 /// What the walker would spend on a walk of its own on a machine with `cores`.
-/// Its own default stops at twelve however many there are, and a walk mado
-/// sizes by hand would pass that without stopping there as well.
+/// Its own default stops at twelve; a walk mado sizes by hand would pass that
+/// without the same limit.
 fn budget_for(cores: usize) -> usize {
     cores.min(12)
 }
@@ -105,8 +105,8 @@ impl WalkParallelBuilder {
     /// its own boundary. `above_is_repository` answers for the directories
     /// over `current_dir`, which no pattern can reach by walking up.
     ///
-    /// Every name that gets here leads where it reads, so where each step
-    /// stands can be read off the name rather than asked after.
+    /// Every name that reaches this leads where it reads, so each step's place
+    /// can be read off the name without resolving it.
     fn ignore_files_of(
         dir: &Path,
         current_dir: &Path,
@@ -141,31 +141,21 @@ impl WalkParallelBuilder {
         Self::bounds_itself(dir)
     }
 
-    /// Whether `path` takes something back. A line that opens with a `!` in an
-    /// ignore file undoes what an earlier one said, and the walker ranks an
-    /// `.ignore` over every `.gitignore` wherever the two sit, which nothing
-    /// mado can hand a file back through will do.
+    /// Whether `path` has a line starting with `!`, which keeps a path an
+    /// earlier line excluded. A `!` meant literally is escaped with a
+    /// backslash, so it cannot start a line.
     fn takes_something_back(path: &Path) -> bool {
-        // A `!` opens a line that takes back; one written for itself is
-        // escaped, and so opens with a backslash.
         fs::read_to_string(path).is_ok_and(|text| text.lines().any(|line| line.starts_with('!')))
     }
 
-    /// Whether an `.ignore` over `pattern` takes something back that a
-    /// `.gitignore` under it could be excluding. Reading these files for
-    /// `pattern` -- or leaving them unread, which comes to the same -- puts
-    /// them under every file the walk finds for itself, so the walk would drop
-    /// what it should keep, quietly, and where a clone of the same tree keeps
-    /// it. The walker's own arrangement is left to answer instead, which keeps
-    /// what it should and reports more besides.
+    /// The nearest `.ignore` over `pattern` with a `!` line, if there is one.
+    /// `seen` remembers the answer for the directory `pattern` sits in.
     ///
-    /// The whole way up is asked, not the part mado hands back: the walker
-    /// reads an `.ignore` however far over the tree it sits, so one that far
-    /// over ranks over a `.gitignore` in it just the same.
-    ///
-    /// The answer belongs to the directory `pattern` sits in, so `seen`
-    /// remembers it: a command naming every directory in one place asks the
-    /// same question once per name.
+    /// Every parent is asked, not only the ones mado hands back. The walker
+    /// reads `.ignore` files from all of them and ranks them over every
+    /// `.gitignore`; `add_ignore` cannot, since it puts a file below
+    /// everything the walk finds for itself. So a `!` line anywhere over the
+    /// path can have mado exclude a file a clone keeps.
     fn taken_back_over(
         pattern: &Path,
         seen: &mut Vec<(PathBuf, Option<PathBuf>)>,
@@ -417,15 +407,11 @@ impl WalkParallelBuilder {
                 respect_gitignore,
                 &mut seen,
             );
-            // Whatever mado hands back ends up under what the walk finds for
-            // itself, and one of the files over this one taking something back
-            // is one the walk would then drop. The walker's own arrangement is
-            // left to answer instead, which keeps what it should and reports
-            // more besides. There is nothing to arrange where the walker finds
-            // the files itself, which is what `None` says, nor where `.ignore`
-            // files go unread and nothing stands over the walk's own answers,
-            // nor for a path that is not a directory, which the walk hands back
-            // without asking any ignore file about it.
+            // A `!` line over the path would outrank a `.gitignore` under it
+            // in a clone and not here, so mado hands nothing back and lets the
+            // walker arrange it: that reports more and drops nothing. Only
+            // where mado had files to hand back (`Some`), the path is a
+            // directory, and `.ignore` files are read at all.
             let taken_back =
                 (files.is_some() && pattern.is_dir() && respect_ignore && respect_gitignore)
                     .then(|| Self::taken_back_over(pattern, &mut taken))

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -423,10 +423,13 @@ impl WalkParallelBuilder {
             // left to answer instead, which keeps what it should and reports
             // more besides. There is nothing to arrange where the walker finds
             // the files itself, which is what `None` says, nor where `.ignore`
-            // files go unread and nothing stands over the walk's own answers.
-            let taken_back = (files.is_some() && respect_ignore && respect_gitignore)
-                .then(|| Self::taken_back_over(pattern, &mut taken))
-                .flatten();
+            // files go unread and nothing stands over the walk's own answers,
+            // nor for a path that is not a directory, which the walk hands back
+            // without asking any ignore file about it.
+            let taken_back =
+                (files.is_some() && pattern.is_dir() && respect_ignore && respect_gitignore)
+                    .then(|| Self::taken_back_over(pattern, &mut taken))
+                    .flatten();
             if let Some(file) = taken_back {
                 files = None;
                 if !explained.contains(&file) {

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -31,9 +31,19 @@ impl WalkParallelBuilder {
         }
     }
 
+    /// The directory `path` sits in, named the way `path` names it, or `None`
+    /// at the filesystem root. `Path::parent` drops the last component, which
+    /// walks the wrong way when that component is a `..`.
+    fn parent_of(path: &Path) -> Option<PathBuf> {
+        if matches!(path.components().next_back(), Some(Component::ParentDir)) {
+            return Some(path.join(".."));
+        }
+        path.parent().map(Self::named)
+    }
+
     /// The directory `pattern` sits in, named the way `pattern` names it.
     fn directory_of(pattern: &Path) -> PathBuf {
-        Self::named(pattern.parent().unwrap_or(pattern))
+        Self::parent_of(pattern).unwrap_or_else(|| Self::named(pattern))
     }
 
     /// Whether `dir` can only name something below the directory it is read
@@ -61,32 +71,31 @@ impl WalkParallelBuilder {
         respect_gitignore: bool,
     ) -> Option<Vec<PathBuf>> {
         let mut dirs = vec![];
-        let mut at = dir;
+        let mut at = dir.to_path_buf();
         loop {
-            let named = Self::named(at);
-            if Self::is_repository_root(&named) {
+            if Self::is_repository_root(&at) {
                 return None;
             }
 
-            let at_boundary = if named == Path::new(".") {
+            let at_boundary = if at == Path::new(".") {
                 true
-            } else if Self::stays_below(&named) {
+            } else if Self::stays_below(&at) {
                 false
             } else {
-                match named.canonicalize() {
+                match at.canonicalize() {
                     Ok(canonical) if canonical == *current_dir => true,
                     Ok(canonical) if canonical.starts_with(current_dir) => false,
                     // Past the boundary, which a name written with `..` can be
-                    // however far the walk up has left to go.
-                    Ok(canonical) => {
-                        return (!canonical.ancestors().any(Self::is_repository_root))
-                            .then(Vec::new);
+                    // however far the walk up has left to go, or gone.
+                    canonical => {
+                        let in_repository = canonical
+                            .is_ok_and(|path| path.ancestors().any(Self::is_repository_root));
+                        return (!in_repository).then(Vec::new);
                     }
-                    Err(_) => return Some(vec![]),
                 }
             };
 
-            dirs.push(named);
+            dirs.push(at.clone());
             if at_boundary {
                 if above_is_repository {
                     return None;
@@ -99,9 +108,7 @@ impl WalkParallelBuilder {
                 ));
             }
 
-            // `Path::parent` gives the filesystem root and the empty path
-            // themselves, so the walk up has to stop on its own.
-            match at.parent() {
+            match Self::parent_of(&at) {
                 Some(parent) if parent != at => at = parent,
                 _ => return Some(vec![]),
             }
@@ -139,6 +146,13 @@ impl WalkParallelBuilder {
         respect_gitignore: bool,
         seen: &mut Vec<(PathBuf, Option<Vec<PathBuf>>)>,
     ) -> Option<Vec<PathBuf>> {
+        // The walk hands back a path that is not a directory without asking
+        // any ignore file about it, so reading them for one cannot change what
+        // it reports, and a command can name a great many files.
+        if !pattern.is_dir() {
+            return Some(vec![]);
+        }
+
         let dir = Self::directory_of(pattern);
         let files = if let Some((_, files)) = seen.iter().find(|(at, _)| *at == dir) {
             files.clone()
@@ -155,21 +169,17 @@ impl WalkParallelBuilder {
         };
 
         files.as_ref()?;
-        // Both of the questions left are about directories, and a command can
-        // name a great many files.
-        if pattern.is_dir() {
-            // A pattern that is a repository root is in one, whatever holds it.
-            if Self::is_repository_root(pattern) {
-                return None;
-            }
-            // The walk reads the ignore files of a directory it is handed, so
-            // for one only what is above it is left to put back.
-            if pattern
-                .canonicalize()
-                .is_ok_and(|path| path == *current_dir)
-            {
-                return Some(vec![]);
-            }
+        // A pattern that is a repository root is in one, whatever holds it.
+        if Self::is_repository_root(pattern) {
+            return None;
+        }
+        // The walk reads the ignore files of a directory it is handed, so for
+        // one only what is above it is left to put back.
+        if pattern
+            .canonicalize()
+            .is_ok_and(|path| path == *current_dir)
+        {
+            return Some(vec![]);
         }
 
         files
@@ -216,6 +226,9 @@ impl WalkParallelBuilder {
                 // directory's patterns keep their own anchoring.
                 let dir = Self::named(file.parent().unwrap_or(file));
                 builder.current_dir(dir);
+                // The walker reads every one of these on its own to answer
+                // about the paths above the boundary, and reports what it
+                // cannot parse, so the copy handed back here says nothing.
                 drop(builder.add_ignore(file));
             }
         }
@@ -458,32 +471,32 @@ mod tests {
         let tmp_dir = TempDir::new().into_diagnostic()?;
         write_tree(tmp_dir.path())?;
 
-        // Every file mado is run from sits in one directory, so one walk
-        // covers them all however many are named.
+        // Nothing has to be read for a file, so one walk covers them all.
         let alongside = vec![
             Path::new("README.md").to_path_buf(),
             Path::new("CHANGELOG.md").to_path_buf(),
-            Path::new("mado.toml").to_path_buf(),
+            tmp_dir.path().join("keep.md"),
         ];
         let alongside_walkers = WalkParallelBuilder::build(&alongside, true, true)?;
         assert_eq!(alongside_walkers.len(), 1);
 
-        // A tree elsewhere answers differently and gets its own walk.
-        let mut with_elsewhere = alongside;
-        with_elsewhere.push(tmp_dir.path().to_path_buf());
-        let elsewhere_walkers = WalkParallelBuilder::build(&with_elsewhere, true, true)?;
-        assert_eq!(elsewhere_walkers.len(), 2);
+        // A directory has to be answered for, and answers differently from a
+        // file, so it gets its own walk.
+        let mut with_directory = alongside;
+        with_directory.push(Path::new("action").to_path_buf());
+        let directory_walkers = WalkParallelBuilder::build(&with_directory, true, true)?;
+        assert_eq!(directory_walkers.len(), 2);
 
         tmp_dir.close().into_diagnostic()
     }
 
-    /// A tree of sibling directories under one boundary, none of them holding
-    /// an ignore file of its own.
+    /// A tree of sibling directories under one boundary, each holding a
+    /// directory to lint and none of them an ignore file of its own.
     fn write_siblings(root: &Path, count: usize) -> miette::Result<Vec<PathBuf>> {
         (0..count)
             .map(|at| {
-                let path = root.join(format!("d{at}/a.md"));
-                write(&path, "# Fine\n")?;
+                let path = root.join(format!("d{at}/sub"));
+                write(&path.join("a.md"), "# Fine\n")?;
                 Ok(path)
             })
             .collect()
@@ -510,6 +523,25 @@ mod tests {
     }
 
     #[test]
+    fn build_walks_every_named_file_together() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        let current_dir = tmp_dir.path().canonicalize().into_diagnostic()?;
+        write_siblings(&current_dir, 8)?;
+        write(&current_dir.join("d0/.gitignore"), "a.md\n")?;
+
+        // The walk hands a path that is not a directory back without asking
+        // any ignore file about it, so no file needs one read for it and they
+        // all belong to the same walk, whatever directories they sit in.
+        let patterns: Vec<PathBuf> = (0..8)
+            .map(|at| current_dir.join(format!("d{at}/sub/a.md")))
+            .collect();
+        let walkers = WalkParallelBuilder::build_from(&patterns, &current_dir, true, true)?;
+        assert_eq!(walkers.len(), 1);
+
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
     fn gitignore_up_to_a_repository_root_above_the_boundary() -> miette::Result<()> {
         let tmp_dir = TempDir::new().into_diagnostic()?;
         let root = tmp_dir.path().canonicalize().into_diagnostic()?;
@@ -527,7 +559,7 @@ mod tests {
     }
 
     #[test]
-    fn gitignore_for_a_directory_that_is_not_there() -> miette::Result<()> {
+    fn gitignore_for_a_path_that_is_not_there() -> miette::Result<()> {
         let tmp_dir = TempDir::new().into_diagnostic()?;
         write_tree(tmp_dir.path())?;
 

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -213,10 +213,11 @@ impl WalkParallelBuilder {
         builder.git_exclude(false);
 
         if let Some(files) = files {
-            // Outside a repository the walker drops `.gitignore` entirely, and
-            // `require_git(false)` on its own would read ignore files every
-            // directory up to the filesystem root. Stop its parent search and
-            // put back the files between here and the boundary.
+            // Outside a repository the walker drops `.gitignore` entirely.
+            // `require_git(false)` puts it back, and `parents(false)` leaves
+            // what the walker finds above a root out of the matching -- it
+            // still reads it -- so the files between the boundary and the root
+            // are handed back below.
             builder.require_git(false);
             builder.parents(false);
 
@@ -226,10 +227,16 @@ impl WalkParallelBuilder {
                 // directory's patterns keep their own anchoring.
                 let dir = Self::named(file.parent().unwrap_or(file));
                 builder.current_dir(dir);
-                // The walker reads every one of these on its own to answer
-                // about the paths above the boundary, and reports what it
-                // cannot parse, so the copy handed back here says nothing.
-                drop(builder.add_ignore(file));
+                // The walker reads these itself, and reports what it cannot
+                // parse, whenever it has a `.gitignore` to look for above a
+                // root. Without one it never looks up there, and this is the
+                // only reading they get.
+                if let Some(err) = builder.add_ignore(file)
+                    && !respect_gitignore
+                    && !err.is_io()
+                {
+                    eprintln!("{err}");
+                }
             }
         }
 

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -35,29 +36,69 @@ impl WalkParallelBuilder {
         Self::named(pattern.parent().unwrap_or(pattern))
     }
 
-    /// Where the search for ignore files stops for a pattern sitting in `dir`:
-    /// `None` in a repository, where the walker finds the root on its own, and
-    /// otherwise the directories to read ignore files from, outermost first.
-    /// Those run from `current_dir` down to `dir`, and are empty when `dir`
-    /// lies outside `current_dir`, leaving the pattern its own boundary.
-    fn boundary_of(dir: &Path, current_dir: &Path) -> Option<Vec<PathBuf>> {
-        if dir
-            .canonicalize()
-            .is_ok_and(|path| path.ancestors().any(Self::is_repository_root))
-        {
-            return None;
-        }
+    /// Whether `dir` can only name something below the directory it is read
+    /// from, which a relative name that neither starts at the filesystem root
+    /// nor climbs with `..` always does. Answering this without asking the
+    /// filesystem is what keeps a command spread over many directories cheap.
+    fn stays_below(dir: &Path) -> bool {
+        dir.is_relative()
+            && dir
+                .components()
+                .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+    }
 
+    /// The ignore files a pattern sitting in `dir` needs handed back, or
+    /// `None` in a repository, where the walker finds them on its own. They
+    /// come from the directories between `current_dir` and `dir`, and are
+    /// empty when `dir` lies outside `current_dir`, which leaves the pattern
+    /// its own boundary. `above_is_repository` answers for the directories
+    /// over `current_dir`, which no pattern can reach by walking up.
+    fn ignore_files_of(
+        dir: &Path,
+        current_dir: &Path,
+        above_is_repository: bool,
+        respect_ignore: bool,
+        respect_gitignore: bool,
+    ) -> Option<Vec<PathBuf>> {
         let mut dirs = vec![];
         let mut at = dir;
         loop {
             let named = Self::named(at);
-            let reached = named.canonicalize().is_ok_and(|path| path == current_dir);
-            dirs.push(named);
-            if reached {
-                dirs.reverse();
-                return Some(dirs);
+            if Self::is_repository_root(&named) {
+                return None;
             }
+
+            let at_boundary = if named == Path::new(".") {
+                true
+            } else if Self::stays_below(&named) {
+                false
+            } else {
+                match named.canonicalize() {
+                    Ok(canonical) if canonical == *current_dir => true,
+                    Ok(canonical) if canonical.starts_with(current_dir) => false,
+                    // Past the boundary, which a name written with `..` can be
+                    // however far the walk up has left to go.
+                    Ok(canonical) => {
+                        return (!canonical.ancestors().any(Self::is_repository_root))
+                            .then(Vec::new);
+                    }
+                    Err(_) => return Some(vec![]),
+                }
+            };
+
+            dirs.push(named);
+            if at_boundary {
+                if above_is_repository {
+                    return None;
+                }
+                dirs.reverse();
+                return Some(Self::ignore_files_in(
+                    &dirs,
+                    respect_ignore,
+                    respect_gitignore,
+                ));
+            }
+
             // `Path::parent` gives the filesystem root and the empty path
             // themselves, so the walk up has to stop on its own.
             match at.parent() {
@@ -67,24 +108,53 @@ impl WalkParallelBuilder {
         }
     }
 
-    /// `boundary_of` for the directory `pattern` sits in, remembering answers:
-    /// a command naming every file in a directory asks the same question once
-    /// per file.
-    fn boundary_for(
+    /// The ignore files `dirs` hold, in the order to hand them over. Every
+    /// `.gitignore` goes in before any `.ignore` so the kinds stay ranked, and
+    /// each kind outermost first so the nearer file wins within a kind: the
+    /// walker takes the last file it was handed as the one that wins.
+    fn ignore_files_in(
+        dirs: &[PathBuf],
+        respect_ignore: bool,
+        respect_gitignore: bool,
+    ) -> Vec<PathBuf> {
+        [
+            (".gitignore", respect_gitignore),
+            (".ignore", respect_ignore),
+        ]
+        .into_iter()
+        .filter(|&(_, wanted)| wanted)
+        .flat_map(|(name, _)| dirs.iter().map(move |dir| dir.join(name)))
+        .filter(|path| path.is_file())
+        .collect()
+    }
+
+    /// `ignore_files_of` for the directory `pattern` sits in, remembering
+    /// answers: a command naming every file in a directory asks the same
+    /// question once per file.
+    fn ignore_files_for(
         pattern: &Path,
         current_dir: &Path,
+        above_is_repository: bool,
+        respect_ignore: bool,
+        respect_gitignore: bool,
         seen: &mut Vec<(PathBuf, Option<Vec<PathBuf>>)>,
     ) -> Option<Vec<PathBuf>> {
         let dir = Self::directory_of(pattern);
-        let boundary = if let Some((_, boundary)) = seen.iter().find(|(at, _)| *at == dir) {
-            boundary.clone()
+        let files = if let Some((_, files)) = seen.iter().find(|(at, _)| *at == dir) {
+            files.clone()
         } else {
-            let boundary = Self::boundary_of(&dir, current_dir);
-            seen.push((dir, boundary.clone()));
-            boundary
+            let files = Self::ignore_files_of(
+                &dir,
+                current_dir,
+                above_is_repository,
+                respect_ignore,
+                respect_gitignore,
+            );
+            seen.push((dir, files.clone()));
+            files
         };
 
-        boundary.as_ref()?;
+        files.as_ref()?;
         // Both of the questions left are about directories, and a command can
         // name a great many files.
         if pattern.is_dir() {
@@ -94,31 +164,23 @@ impl WalkParallelBuilder {
             }
             // The walk reads the ignore files of a directory it is handed, so
             // for one only what is above it is left to put back.
-            if pattern.canonicalize().is_ok_and(|path| path == current_dir) {
+            if pattern
+                .canonicalize()
+                .is_ok_and(|path| path == *current_dir)
+            {
                 return Some(vec![]);
             }
         }
 
-        boundary
+        files
     }
 
-    /// Adds `path` as an ignore file rooted at `dir`. `WalkBuilder` roots the
-    /// files it is handed at whatever `current_dir` was last set to, which is
-    /// what lets each directory's patterns keep their own anchoring.
-    fn add_ignore_file(builder: &mut WalkBuilder, dir: &Path, name: &str) {
-        let path = dir.join(name);
-        if path.is_file() {
-            builder.current_dir(dir);
-            drop(builder.add_ignore(path));
-        }
-    }
-
-    /// One walker for `patterns`, which share where their search for ignore
-    /// files stops. `ancestors` is the directories to read it from, outermost
-    /// first, or `None` for a repository, where the walker finds them itself.
+    /// One walker for `patterns`, which need the same ignore files handed
+    /// back. `files` is those, in the order to hand them over, or `None` for a
+    /// repository, where the walker finds them itself.
     fn build_group(
         patterns: &[&PathBuf],
-        ancestors: Option<&[PathBuf]>,
+        files: Option<&[PathBuf]>,
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> Result<WalkParallel> {
@@ -140,7 +202,7 @@ impl WalkParallelBuilder {
         builder.git_global(false);
         builder.git_exclude(false);
 
-        if let Some(ancestors) = ancestors {
+        if let Some(files) = files {
             // Outside a repository the walker drops `.gitignore` entirely, and
             // `require_git(false)` on its own would read ignore files every
             // directory up to the filesystem root. Stop its parent search and
@@ -148,20 +210,13 @@ impl WalkParallelBuilder {
             builder.require_git(false);
             builder.parents(false);
 
-            // The walker takes the last file added as the one that wins, so
-            // every `.gitignore` goes in before any `.ignore`, and each kind
-            // outermost first. That keeps `.ignore` ahead of `.gitignore`
-            // whatever directory either sits in, and the nearer file ahead of
-            // the further one within a kind.
-            if respect_gitignore {
-                for dir in ancestors {
-                    Self::add_ignore_file(&mut builder, dir, ".gitignore");
-                }
-            }
-            if respect_ignore {
-                for dir in ancestors {
-                    Self::add_ignore_file(&mut builder, dir, ".ignore");
-                }
+            for file in files {
+                // `WalkBuilder` roots the files it is handed at whatever
+                // `current_dir` was last set to, which is what lets each
+                // directory's patterns keep their own anchoring.
+                let dir = Self::named(file.parent().unwrap_or(file));
+                builder.current_dir(dir);
+                drop(builder.add_ignore(file));
             }
         }
 
@@ -176,12 +231,12 @@ impl WalkParallelBuilder {
         Ok(builder.build_parallel())
     }
 
-    /// One walker per set of patterns that share where their search for ignore
-    /// files stops. Where it stops is a property of a single pattern, but
-    /// patterns that agree on it can be walked together.
-    #[inline]
-    pub fn build(
+    /// One walker per set of patterns that need the same ignore files handed
+    /// back. Which files those are is a property of a single pattern, but
+    /// patterns that need the same ones can be walked together.
+    fn build_from(
         patterns: &[PathBuf],
+        current_dir: &Path,
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> Result<Vec<WalkParallel>> {
@@ -189,31 +244,47 @@ impl WalkParallelBuilder {
             return Err(miette!("files must be non-empty"));
         }
 
-        // A directory mado cannot name is one no pattern can be found under.
-        let current_dir = env::current_dir()
-            .and_then(|dir| dir.canonicalize())
-            .unwrap_or_default();
+        let above_is_repository = current_dir
+            .ancestors()
+            .skip(1)
+            .any(Self::is_repository_root);
         let mut seen = vec![];
         let mut groups: Vec<(Option<Vec<PathBuf>>, Vec<&PathBuf>)> = vec![];
         for pattern in patterns {
-            let boundary = Self::boundary_for(pattern, &current_dir, &mut seen);
-            match groups.iter_mut().find(|(at, _)| *at == boundary) {
+            let files = Self::ignore_files_for(
+                pattern,
+                current_dir,
+                above_is_repository,
+                respect_ignore,
+                respect_gitignore,
+                &mut seen,
+            );
+            match groups.iter_mut().find(|(at, _)| *at == files) {
                 Some((_, members)) => members.push(pattern),
-                None => groups.push((boundary, vec![pattern])),
+                None => groups.push((files, vec![pattern])),
             }
         }
 
         groups
             .iter()
-            .map(|(boundary, members)| {
-                Self::build_group(
-                    members,
-                    boundary.as_deref(),
-                    respect_ignore,
-                    respect_gitignore,
-                )
+            .map(|(files, members)| {
+                Self::build_group(members, files.as_deref(), respect_ignore, respect_gitignore)
             })
             .collect()
+    }
+
+    #[inline]
+    pub fn build(
+        patterns: &[PathBuf],
+        respect_ignore: bool,
+        respect_gitignore: bool,
+    ) -> Result<Vec<WalkParallel>> {
+        // A directory mado cannot name is one no pattern can be found under.
+        let current_dir = env::current_dir()
+            .and_then(|dir| dir.canonicalize())
+            .unwrap_or_default();
+
+        Self::build_from(patterns, &current_dir, respect_ignore, respect_gitignore)
     }
 }
 
@@ -224,6 +295,7 @@ mod tests {
     use alloc::sync::Arc;
     use miette::{Context as _, IntoDiagnostic as _};
     use std::{
+        env,
         ffi::OsStr,
         fs,
         path::{Path, PathBuf},
@@ -292,11 +364,30 @@ mod tests {
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> miette::Result<Vec<PathBuf>> {
+        let current_dir = env::current_dir()
+            .and_then(|dir| dir.canonicalize())
+            .into_diagnostic()?;
+        walk_markdown_from(root, &current_dir, respect_ignore, respect_gitignore)
+    }
+
+    /// `walk_markdown` for a mado started in `current_dir` rather than
+    /// wherever the tests happen to run.
+    fn walk_markdown_from(
+        root: &Path,
+        current_dir: &Path,
+        respect_ignore: bool,
+        respect_gitignore: bool,
+    ) -> miette::Result<Vec<PathBuf>> {
         let patterns = vec![root.to_path_buf()];
-        let walkers = WalkParallelBuilder::build(&patterns, respect_ignore, respect_gitignore)?;
+        let built = WalkParallelBuilder::build_from(
+            &patterns,
+            current_dir,
+            respect_ignore,
+            respect_gitignore,
+        );
         let collector = PathCollector::new();
 
-        for walker in walkers {
+        for walker in built? {
             walker.run(|| Box::new(collector.gen_visitor()));
         }
 
@@ -383,6 +474,94 @@ mod tests {
         let elsewhere_walkers = WalkParallelBuilder::build(&with_elsewhere, true, true)?;
         assert_eq!(elsewhere_walkers.len(), 2);
 
+        tmp_dir.close().into_diagnostic()
+    }
+
+    /// A tree of sibling directories under one boundary, none of them holding
+    /// an ignore file of its own.
+    fn write_siblings(root: &Path, count: usize) -> miette::Result<Vec<PathBuf>> {
+        (0..count)
+            .map(|at| {
+                let path = root.join(format!("d{at}/a.md"));
+                write(&path, "# Fine\n")?;
+                Ok(path)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_walks_siblings_under_one_boundary_together() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        let current_dir = tmp_dir.path().canonicalize().into_diagnostic()?;
+        let patterns = write_siblings(&current_dir, 8)?;
+
+        // Each of these sits in a directory of its own, but they all read the
+        // same ignore files, so one walk covers them however many there are.
+        let shared = WalkParallelBuilder::build_from(&patterns, &current_dir, true, true)?;
+        assert_eq!(shared.len(), 1);
+
+        // One of them holding an ignore file the others must not see splits
+        // that one off, and no more.
+        write(&current_dir.join("d0/.gitignore"), "a.md\n")?;
+        let split = WalkParallelBuilder::build_from(&patterns, &current_dir, true, true)?;
+        assert_eq!(split.len(), 2);
+
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn gitignore_up_to_a_repository_root_above_the_boundary() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        let root = tmp_dir.path().canonicalize().into_diagnostic()?;
+        fs::create_dir(root.join(".git")).into_diagnostic()?;
+        write(&root.join(".gitignore"), "above.md\n")?;
+        let current_dir = root.join("proj");
+        write(&current_dir.join("docs/above.md"), "# Above\n")?;
+        write(&current_dir.join("docs/keep.md"), "# Keep\n")?;
+
+        // The repository holds the directory mado was started in, so its root
+        // is the boundary and its `.gitignore` still counts.
+        let actual = walk_markdown_from(&current_dir.join("docs"), &current_dir, true, true)?;
+        assert_eq!(actual, vec![Path::new("keep.md").to_path_buf()]);
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn gitignore_for_a_directory_that_is_not_there() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write_tree(tmp_dir.path())?;
+
+        // A path mado cannot look above must not stop the ones it can walk.
+        let patterns = vec![
+            tmp_dir.path().join("missing/a.md"),
+            tmp_dir.path().to_path_buf(),
+        ];
+        let current_dir = tmp_dir.path().canonicalize().into_diagnostic()?;
+        let walkers = WalkParallelBuilder::build_from(&patterns, &current_dir, true, true)?;
+        let collector = PathCollector::new();
+        for walker in walkers {
+            walker.run(|| Box::new(collector.gen_visitor()));
+        }
+        let markdown = collector
+            .paths()?
+            .into_iter()
+            .filter(|path| path.extension() == Some(OsStr::new("md")))
+            .count();
+        assert_eq!(markdown, kept().len());
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn gitignore_when_the_boundary_cannot_be_named() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write(&tmp_dir.path().join(".gitignore"), "keep.md\n")?;
+        let root = tmp_dir.path().join("project");
+        write_tree(&root)?;
+
+        // With no directory to measure against, every path bounds itself, so
+        // nothing above it is read.
+        let actual = walk_markdown_from(&root, Path::new(""), true, true)?;
+        assert_eq!(actual, kept());
         tmp_dir.close().into_diagnostic()
     }
 

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -1,4 +1,5 @@
 use core::num::NonZero;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::path::Component;
@@ -158,18 +159,32 @@ impl WalkParallelBuilder {
     /// path can have mado exclude a file a clone keeps.
     fn taken_back_over(
         pattern: &Path,
-        seen: &mut Vec<(PathBuf, Option<PathBuf>)>,
+        seen: &mut HashMap<PathBuf, Option<PathBuf>>,
     ) -> Option<PathBuf> {
-        let over = pattern.canonicalize().ok()?.parent()?.to_path_buf();
-        if let Some((_, found)) = seen.iter().find(|(dir, _)| *dir == over) {
+        let at = pattern.canonicalize().ok()?;
+
+        Self::takes_back_at_or_over(at.parent()?, seen)
+    }
+
+    /// `taken_back_over` for a directory. Every directory on the way up is
+    /// remembered, not just the one asked after, so directories sharing a
+    /// parent ask about what is over them once between them.
+    fn takes_back_at_or_over(
+        dir: &Path,
+        seen: &mut HashMap<PathBuf, Option<PathBuf>>,
+    ) -> Option<PathBuf> {
+        if let Some(found) = seen.get(dir) {
             return found.clone();
         }
 
-        let found = over
-            .ancestors()
-            .map(|at| at.join(".ignore"))
-            .find(|file| file.is_file() && Self::takes_something_back(file));
-        seen.push((over, found.clone()));
+        let file = dir.join(".ignore");
+        let found = if file.is_file() && Self::takes_something_back(&file) {
+            Some(file)
+        } else {
+            dir.parent()
+                .and_then(|over| Self::takes_back_at_or_over(over, seen))
+        };
+        seen.insert(dir.to_path_buf(), found.clone());
 
         found
     }
@@ -204,7 +219,7 @@ impl WalkParallelBuilder {
         above_is_repository: bool,
         respect_ignore: bool,
         respect_gitignore: bool,
-        seen: &mut Vec<(PathBuf, Option<Vec<PathBuf>>)>,
+        seen: &mut HashMap<PathBuf, Option<Vec<PathBuf>>>,
     ) -> Option<Vec<PathBuf>> {
         // The walk hands back a path that is not a directory without asking
         // any ignore file about it, so reading them for one cannot change what
@@ -220,9 +235,7 @@ impl WalkParallelBuilder {
         }
 
         let dir = Self::parent_of(pattern);
-        let files = if let Some((_, files)) = seen.iter().find(|(at, _)| *at == dir) {
-            files.clone()
-        } else {
+        let files = seen.get(&dir).cloned().unwrap_or_else(|| {
             let files = Self::ignore_files_of(
                 &dir,
                 current_dir,
@@ -230,9 +243,9 @@ impl WalkParallelBuilder {
                 respect_ignore,
                 respect_gitignore,
             );
-            seen.push((dir, files.clone()));
+            seen.insert(dir, files.clone());
             files
-        };
+        });
 
         files.as_ref()?;
         // A pattern that is a repository root is in one, whatever holds it.
@@ -394,10 +407,13 @@ impl WalkParallelBuilder {
             .ancestors()
             .skip(1)
             .any(Self::is_repository_root);
-        let mut seen = vec![];
-        let mut taken = vec![];
-        let mut explained = vec![];
+        let mut seen = HashMap::new();
+        let mut taken = HashMap::new();
+        let mut explained = HashSet::new();
+        // The groups keep the order the patterns arrived in, and `at_group`
+        // finds the one a pattern belongs to without walking them all.
         let mut groups: Vec<(Option<Vec<PathBuf>>, Vec<&PathBuf>)> = vec![];
+        let mut at_group: HashMap<Option<Vec<PathBuf>>, usize> = HashMap::new();
         for pattern in patterns {
             let mut files = Self::ignore_files_for(
                 pattern,
@@ -418,7 +434,7 @@ impl WalkParallelBuilder {
                     .flatten();
             if let Some(file) = taken_back {
                 files = None;
-                if !explained.contains(&file) {
+                if explained.insert(file.clone()) {
                     eprintln!(
                         "{}: takes a path back with a `!` line, which ranks over any .gitignore \
                          below it, and mado cannot arrange that without Git metadata, so \
@@ -426,7 +442,6 @@ impl WalkParallelBuilder {
                          every parent directory",
                         file.display()
                     );
-                    explained.push(file);
                 }
             }
 
@@ -435,9 +450,13 @@ impl WalkParallelBuilder {
             // matches it against paths built from the name a pattern was
             // written as. A group named `sub/../d1` cannot be handed the file
             // `./d1` walks by, so the two walk separately.
-            match groups.iter_mut().find(|(at, _)| *at == files) {
-                Some((_, members)) => members.push(pattern),
-                None => groups.push((files, vec![pattern])),
+            if let Some(&at) = at_group.get(&files)
+                && let Some((_, members)) = groups.get_mut(at)
+            {
+                members.push(pattern);
+            } else {
+                at_group.insert(files.clone(), groups.len());
+                groups.push((files, vec![pattern]));
             }
         }
 
@@ -493,6 +512,7 @@ mod tests {
     use alloc::sync::Arc;
     use miette::{Context as _, IntoDiagnostic as _};
     use std::{
+        collections::HashMap,
         env,
         ffi::OsStr,
         fs,
@@ -691,13 +711,14 @@ mod tests {
         write(&root.join("d1/two/a.md"), "# Fine\n")?;
 
         // Both names sit in `d1`, and what is over `d1` is over both of them.
-        let mut seen = vec![];
+        let mut seen = HashMap::new();
         let one = WalkParallelBuilder::taken_back_over(&root.join("d1/one"), &mut seen);
+        let asked = seen.len();
         let two = WalkParallelBuilder::taken_back_over(&root.join("d1/two"), &mut seen);
 
         assert!(one.is_some());
         assert_eq!(one, two);
-        assert_eq!(seen.len(), 1);
+        assert_eq!(seen.len(), asked);
 
         tmp_dir.close().into_diagnostic()
     }

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -13,48 +13,93 @@ use miette::miette;
 pub struct WalkParallelBuilder;
 
 impl WalkParallelBuilder {
-    /// Whether `path` or any directory above it holds a repository marker.
-    /// `.git` is a directory in a clone and a file in a worktree or a
-    /// submodule, and `.jj` is the other marker the `ignore` crate stops at.
-    fn in_repository(path: &Path) -> bool {
-        path.canonicalize().is_ok_and(|path| {
-            path.ancestors()
-                .any(|dir| dir.join(".git").exists() || dir.join(".jj").exists())
-        })
+    /// Whether `path` holds a repository marker. `.git` is a directory in a
+    /// clone and a file in a worktree or a submodule, and `.jj` is the other
+    /// marker the `ignore` crate stops at.
+    fn is_repository_root(path: &Path) -> bool {
+        path.join(".git").exists() || path.join(".jj").exists()
     }
 
-    /// The directories above `pattern` up to and including the one mado was
-    /// started in, outermost first. Each is named the way `pattern` names it,
-    /// so that the ignore files found there match the paths the walk yields.
-    /// Empty when `pattern` is that directory, or lies outside it.
-    fn ancestors_up_to_current_dir(pattern: &Path) -> Vec<PathBuf> {
-        // A directory mado cannot name is one no pattern can be found under.
-        let current_dir = env::current_dir()
-            .and_then(|dir| dir.canonicalize())
-            .unwrap_or_default();
-        if pattern.canonicalize().is_ok_and(|path| path == current_dir) {
-            return vec![];
+    /// `path` under a name a file can be opened by. `Path::parent` names the
+    /// directory a relative path sits in with the empty path, which is not one.
+    fn named(path: &Path) -> PathBuf {
+        if path.as_os_str().is_empty() {
+            Path::new(".").to_path_buf()
+        } else {
+            path.to_path_buf()
+        }
+    }
+
+    /// The directory `pattern` sits in, named the way `pattern` names it.
+    fn directory_of(pattern: &Path) -> PathBuf {
+        Self::named(pattern.parent().unwrap_or(pattern))
+    }
+
+    /// Where the search for ignore files stops for a pattern sitting in `dir`:
+    /// `None` in a repository, where the walker finds the root on its own, and
+    /// otherwise the directories to read ignore files from, outermost first.
+    /// Those run from `current_dir` down to `dir`, and are empty when `dir`
+    /// lies outside `current_dir`, leaving the pattern its own boundary.
+    fn boundary_of(dir: &Path, current_dir: &Path) -> Option<Vec<PathBuf>> {
+        if dir
+            .canonicalize()
+            .is_ok_and(|path| path.ancestors().any(Self::is_repository_root))
+        {
+            return None;
         }
 
         let mut dirs = vec![];
-        let mut ancestor = pattern.parent();
-        while let Some(dir) = ancestor {
-            // `Path::parent` names the directory a relative path sits in with
-            // the empty path, which no file can be opened under.
-            let named = if dir.as_os_str().is_empty() {
-                Path::new(".")
-            } else {
-                dir
-            };
-            dirs.push(named.to_path_buf());
-            if named.canonicalize().is_ok_and(|path| path == current_dir) {
+        let mut at = dir;
+        loop {
+            let named = Self::named(at);
+            let reached = named.canonicalize().is_ok_and(|path| path == current_dir);
+            dirs.push(named);
+            if reached {
                 dirs.reverse();
-                return dirs;
+                return Some(dirs);
             }
-            ancestor = dir.parent();
+            // `Path::parent` gives the filesystem root and the empty path
+            // themselves, so the walk up has to stop on its own.
+            match at.parent() {
+                Some(parent) if parent != at => at = parent,
+                _ => return Some(vec![]),
+            }
+        }
+    }
+
+    /// `boundary_of` for the directory `pattern` sits in, remembering answers:
+    /// a command naming every file in a directory asks the same question once
+    /// per file.
+    fn boundary_for(
+        pattern: &Path,
+        current_dir: &Path,
+        seen: &mut Vec<(PathBuf, Option<Vec<PathBuf>>)>,
+    ) -> Option<Vec<PathBuf>> {
+        let dir = Self::directory_of(pattern);
+        let boundary = if let Some((_, boundary)) = seen.iter().find(|(at, _)| *at == dir) {
+            boundary.clone()
+        } else {
+            let boundary = Self::boundary_of(&dir, current_dir);
+            seen.push((dir, boundary.clone()));
+            boundary
+        };
+
+        boundary.as_ref()?;
+        // Both of the questions left are about directories, and a command can
+        // name a great many files.
+        if pattern.is_dir() {
+            // A pattern that is a repository root is in one, whatever holds it.
+            if Self::is_repository_root(pattern) {
+                return None;
+            }
+            // The walk reads the ignore files of a directory it is handed, so
+            // for one only what is above it is left to put back.
+            if pattern.canonicalize().is_ok_and(|path| path == current_dir) {
+                return Some(vec![]);
+            }
         }
 
-        vec![]
+        boundary
     }
 
     /// Adds `path` as an ignore file rooted at `dir`. `WalkBuilder` roots the
@@ -68,12 +113,23 @@ impl WalkParallelBuilder {
         }
     }
 
-    fn build_one(
-        pattern: &Path,
+    /// One walker for `patterns`, which share where their search for ignore
+    /// files stops. `ancestors` is the directories to read it from, outermost
+    /// first, or `None` for a repository, where the walker finds them itself.
+    fn build_group(
+        patterns: &[&PathBuf],
+        ancestors: Option<&[PathBuf]>,
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> Result<WalkParallel> {
-        let mut builder = WalkBuilder::new(pattern);
+        let (head_pattern, tail_patterns) = patterns
+            .split_first()
+            .ok_or_else(|| miette!("files must be non-empty"))?;
+        let mut builder = WalkBuilder::new(head_pattern);
+        for pattern in tail_patterns {
+            builder.add(pattern);
+        }
+
         builder.ignore(respect_ignore);
         builder.git_ignore(respect_gitignore);
 
@@ -84,23 +140,27 @@ impl WalkParallelBuilder {
         builder.git_global(false);
         builder.git_exclude(false);
 
-        if !Self::in_repository(pattern) {
+        if let Some(ancestors) = ancestors {
             // Outside a repository the walker drops `.gitignore` entirely, and
             // `require_git(false)` on its own would read ignore files every
             // directory up to the filesystem root. Stop its parent search and
-            // put back the files between here and the directory mado was
-            // started in, which is the root the rest of mado resolves against.
+            // put back the files between here and the boundary.
             builder.require_git(false);
             builder.parents(false);
 
-            for dir in Self::ancestors_up_to_current_dir(pattern) {
-                // Added outermost first, and `.gitignore` before `.ignore`, so
-                // that the nearer file wins where both name the same path.
-                if respect_gitignore {
-                    Self::add_ignore_file(&mut builder, &dir, ".gitignore");
+            // The walker takes the last file added as the one that wins, so
+            // every `.gitignore` goes in before any `.ignore`, and each kind
+            // outermost first. That keeps `.ignore` ahead of `.gitignore`
+            // whatever directory either sits in, and the nearer file ahead of
+            // the further one within a kind.
+            if respect_gitignore {
+                for dir in ancestors {
+                    Self::add_ignore_file(&mut builder, dir, ".gitignore");
                 }
-                if respect_ignore {
-                    Self::add_ignore_file(&mut builder, &dir, ".ignore");
+            }
+            if respect_ignore {
+                for dir in ancestors {
+                    Self::add_ignore_file(&mut builder, dir, ".ignore");
                 }
             }
         }
@@ -116,8 +176,9 @@ impl WalkParallelBuilder {
         Ok(builder.build_parallel())
     }
 
-    /// One walker per pattern: the repository a pattern sits in, and so where
-    /// its search for ignore files stops, is a property of that pattern alone.
+    /// One walker per set of patterns that share where their search for ignore
+    /// files stops. Where it stops is a property of a single pattern, but
+    /// patterns that agree on it can be walked together.
     #[inline]
     pub fn build(
         patterns: &[PathBuf],
@@ -128,9 +189,30 @@ impl WalkParallelBuilder {
             return Err(miette!("files must be non-empty"));
         }
 
-        patterns
+        // A directory mado cannot name is one no pattern can be found under.
+        let current_dir = env::current_dir()
+            .and_then(|dir| dir.canonicalize())
+            .unwrap_or_default();
+        let mut seen = vec![];
+        let mut groups: Vec<(Option<Vec<PathBuf>>, Vec<&PathBuf>)> = vec![];
+        for pattern in patterns {
+            let boundary = Self::boundary_for(pattern, &current_dir, &mut seen);
+            match groups.iter_mut().find(|(at, _)| *at == boundary) {
+                Some((_, members)) => members.push(pattern),
+                None => groups.push((boundary, vec![pattern])),
+            }
+        }
+
+        groups
             .iter()
-            .map(|pattern| Self::build_one(pattern, respect_ignore, respect_gitignore))
+            .map(|(boundary, members)| {
+                Self::build_group(
+                    members,
+                    boundary.as_deref(),
+                    respect_ignore,
+                    respect_gitignore,
+                )
+            })
             .collect()
     }
 }
@@ -278,6 +360,30 @@ mod tests {
     fn build_empty_patterns() {
         let result = WalkParallelBuilder::build(&[], true, true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_groups_patterns_that_share_a_boundary() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write_tree(tmp_dir.path())?;
+
+        // Every file mado is run from sits in one directory, so one walk
+        // covers them all however many are named.
+        let alongside = vec![
+            Path::new("README.md").to_path_buf(),
+            Path::new("CHANGELOG.md").to_path_buf(),
+            Path::new("mado.toml").to_path_buf(),
+        ];
+        let alongside_walkers = WalkParallelBuilder::build(&alongside, true, true)?;
+        assert_eq!(alongside_walkers.len(), 1);
+
+        // A tree elsewhere answers differently and gets its own walk.
+        let mut with_elsewhere = alongside;
+        with_elsewhere.push(tmp_dir.path().to_path_buf());
+        let elsewhere_walkers = WalkParallelBuilder::build(&with_elsewhere, true, true)?;
+        assert_eq!(elsewhere_walkers.len(), 2);
+
+        tmp_dir.close().into_diagnostic()
     }
 
     #[test]

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -162,12 +162,12 @@ impl WalkParallelBuilder {
     /// The whole way up is asked, not the part mado hands back: the walker
     /// reads an `.ignore` however far over the tree it sits, so one that far
     /// over ranks over a `.gitignore` in it just the same.
-    fn taken_back_over(pattern: &Path) -> bool {
-        pattern.canonicalize().is_ok_and(|at| {
+    fn taken_back_over(pattern: &Path) -> Option<PathBuf> {
+        pattern.canonicalize().ok().and_then(|at| {
             at.ancestors()
                 .skip(1)
                 .map(|over| over.join(".ignore"))
-                .any(|file| file.is_file() && Self::takes_something_back(&file))
+                .find(|file| file.is_file() && Self::takes_something_back(file))
         })
     }
 
@@ -210,13 +210,6 @@ impl WalkParallelBuilder {
             return Some(vec![]);
         }
 
-        // Whatever mado does with the files over this one, they end up under
-        // what the walk finds for itself, and one of them taking something
-        // back is one the walk would then drop. With `.ignore` files left
-        // unread there is nothing over the walk's own answers to begin with.
-        if respect_ignore && respect_gitignore && Self::taken_back_over(pattern) {
-            return None;
-        }
         // A name that does not lead where it reads bounds itself: nothing
         // above it can be rooted at a name the walk's answers begin with.
         if !Self::leads_where_it_reads(pattern) {
@@ -398,16 +391,44 @@ impl WalkParallelBuilder {
             .skip(1)
             .any(Self::is_repository_root);
         let mut seen = vec![];
+        let mut explained = vec![];
         let mut groups: Vec<(Option<Vec<PathBuf>>, Vec<&PathBuf>)> = vec![];
         for pattern in patterns {
-            let files = Self::ignore_files_for(
-                pattern,
-                current_dir,
-                above_is_repository,
-                respect_ignore,
-                respect_gitignore,
-                &mut seen,
-            );
+            // Whatever mado does with the files over this one, they end up
+            // under what the walk finds for itself, and one of them taking
+            // something back is one the walk would then drop. The walker's own
+            // arrangement is left to answer instead, which keeps what it
+            // should and reports more besides. With `.ignore` files left
+            // unread there is nothing over the walk's own answers to begin
+            // with.
+            let taken_back = (respect_ignore && respect_gitignore && pattern.is_dir())
+                .then(|| Self::taken_back_over(pattern))
+                .flatten();
+            if let Some(file) = taken_back
+                .as_ref()
+                .filter(|file| !explained.contains(*file))
+            {
+                explained.push(file.clone());
+                eprintln!(
+                    "{}: takes a path back with a `!` line, which ranks over any .gitignore \
+                     below it, and mado cannot arrange that without Git metadata, so \
+                     .gitignore files go unread here",
+                    file.display()
+                );
+            }
+
+            let files = if taken_back.is_some() {
+                None
+            } else {
+                Self::ignore_files_for(
+                    pattern,
+                    current_dir,
+                    above_is_repository,
+                    respect_ignore,
+                    respect_gitignore,
+                    &mut seen,
+                )
+            };
             // Two names for one directory are two keys, and have to be: the
             // walker roots a file it is handed at the name it was handed, and
             // matches it against paths built from the name a pattern was

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use ignore::WalkBuilder;
 use ignore::WalkParallel;
+use ignore::types::Types;
 use ignore::types::TypesBuilder;
 use miette::IntoDiagnostic as _;
 use miette::Result;
@@ -187,10 +188,14 @@ impl WalkParallelBuilder {
 
     /// One walker for `patterns`, which need the same ignore files handed
     /// back. `files` is those, in the order to hand them over, or `None` for a
-    /// repository, where the walker finds them itself.
+    /// repository, where the walker finds them itself. `threads` is what the
+    /// walk may spend on itself, `0` meaning as many as it likes.
     fn build_group(
         patterns: &[&PathBuf],
         files: Option<&[PathBuf]>,
+        types: &Types,
+        threads: usize,
+        reported: &mut Vec<PathBuf>,
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> Result<WalkParallel> {
@@ -202,6 +207,7 @@ impl WalkParallelBuilder {
             builder.add(pattern);
         }
 
+        builder.threads(threads);
         builder.ignore(respect_ignore);
         builder.git_ignore(respect_gitignore);
 
@@ -230,23 +236,20 @@ impl WalkParallelBuilder {
                 // The walker reads these itself, and reports what it cannot
                 // parse, whenever it has a `.gitignore` to look for above a
                 // root. Without one it never looks up there, and this is the
-                // only reading they get.
+                // only reading they get. A file two groups both need is still
+                // one file with one thing wrong with it.
                 if let Some(err) = builder.add_ignore(file)
                     && !respect_gitignore
                     && !err.is_io()
+                    && !reported.contains(file)
                 {
+                    reported.push(file.clone());
                     eprintln!("{err}");
                 }
             }
         }
 
-        // NOTE: Expect performance improvements with pre-filtering
-        let types = TypesBuilder::new()
-            .add_defaults()
-            .select("markdown")
-            .build()
-            .into_diagnostic()?;
-        builder.types(types);
+        builder.types(types.clone());
 
         Ok(builder.build_parallel())
     }
@@ -263,6 +266,15 @@ impl WalkParallelBuilder {
         if patterns.is_empty() {
             return Err(miette!("files must be non-empty"));
         }
+
+        // NOTE: Expect performance improvements with pre-filtering. Built the
+        // once: every group selects the same thing, and reading the table of
+        // file types in again for each of them costs more than the walk does.
+        let types = TypesBuilder::new()
+            .add_defaults()
+            .select("markdown")
+            .build()
+            .into_diagnostic()?;
 
         let above_is_repository = current_dir
             .ancestors()
@@ -285,10 +297,23 @@ impl WalkParallelBuilder {
             }
         }
 
+        // A walk of its own for every group would spend more on starting
+        // threads than on walking. One each, and the runner runs the groups
+        // alongside each other, is cheaper wherever there is more than one.
+        let threads = usize::from(groups.len() > 1);
+        let mut reported = vec![];
         groups
             .iter()
             .map(|(files, members)| {
-                Self::build_group(members, files.as_deref(), respect_ignore, respect_gitignore)
+                Self::build_group(
+                    members,
+                    files.as_deref(),
+                    &types,
+                    threads,
+                    &mut reported,
+                    respect_ignore,
+                    respect_gitignore,
+                )
             })
             .collect()
     }

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -340,6 +340,11 @@ impl WalkParallelBuilder {
                 respect_gitignore,
                 &mut seen,
             );
+            // Two names for one directory are two keys, and have to be: the
+            // walker roots a file it is handed at the name it was handed, and
+            // matches it against paths built from the name a pattern was
+            // written as. A group named `sub/../d1` cannot be handed the file
+            // `./d1` walks by, so the two walk separately.
             match groups.iter_mut().find(|(at, _)| *at == files) {
                 Some((_, members)) => members.push(pattern),
                 None => groups.push((files, vec![pattern])),

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -89,17 +89,6 @@ impl WalkParallelBuilder {
         path.parent().map_or_else(|| Self::named(path), Self::named)
     }
 
-    /// Whether `dir` can only name something below the directory it is read
-    /// from, which a relative name that neither starts at the filesystem root
-    /// nor climbs with `..` always does. Answering this without asking the
-    /// filesystem is what keeps a command spread over many directories cheap.
-    fn stays_below(dir: &Path) -> bool {
-        dir.is_relative()
-            && dir
-                .components()
-                .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
-    }
-
     /// The answer for a `dir` with no boundary over it: it bounds itself, and
     /// nothing above it is read, unless it turns out to be in a repository
     /// after all.
@@ -314,12 +303,58 @@ impl WalkParallelBuilder {
         Ok(builder.build_parallel())
     }
 
-    /// `pattern` with the `.` components that say nothing left out, keeping a
-    /// leading one. A walk names what it finds by joining onto the name it was
-    /// given, so `docs/.` has it answering about `docs/./a.md`, and no ignore
-    /// file above it can be rooted at a name that lines that up.
-    fn without_idle_dots(pattern: &Path) -> PathBuf {
-        pattern.components().collect()
+    /// Whether `dir` can only name something below the directory it is read
+    /// from. A relative name that neither starts at the filesystem root nor
+    /// climbs with `..` does, so long as no step of it is a link, which could
+    /// lead anywhere. Answering it this way costs a look at each step rather
+    /// than a resolution of the whole name.
+    fn stays_below(dir: &Path) -> bool {
+        if dir.is_absolute() {
+            return false;
+        }
+
+        let mut at = PathBuf::new();
+        for component in dir.components() {
+            match component {
+                Component::CurDir => continue,
+                Component::Normal(step) => at.push(step),
+                _ => return false,
+            }
+
+            if at.symlink_metadata().is_ok_and(|step| step.is_symlink()) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// `pattern` with the steps that lead nowhere left out: the `.`s, and the
+    /// `..`s that undo a directory that is one rather than a link to one. A
+    /// walk names what it finds by joining onto the name it was given, so
+    /// `d1/docs/../docs` has it answering about `d1/docs/../docs/a.md`, and no
+    /// ignore file above it can be rooted at a name that lines that up.
+    fn without_idle_steps(pattern: &Path) -> PathBuf {
+        let mut kept: Vec<Component<'_>> = vec![];
+        for component in pattern.components() {
+            // A `..` after a link undoes where the link led, not the name
+            // before it, so only a directory of its own can be dropped here.
+            let undoes_a_directory = component == Component::ParentDir
+                && matches!(kept.last(), Some(Component::Normal(_)))
+                && kept
+                    .iter()
+                    .collect::<PathBuf>()
+                    .symlink_metadata()
+                    .is_ok_and(|at| at.is_dir());
+
+            if undoes_a_directory {
+                kept.pop();
+            } else {
+                kept.push(component);
+            }
+        }
+
+        kept.iter().collect()
     }
 
     /// One walker per set of patterns that need the same ignore files handed
@@ -350,7 +385,7 @@ impl WalkParallelBuilder {
             .any(Self::is_repository_root);
         let patterns: Vec<PathBuf> = patterns
             .iter()
-            .map(|p| Self::without_idle_dots(p))
+            .map(|p| Self::without_idle_steps(p))
             .collect();
         let mut seen = vec![];
         let mut groups: Vec<(Option<Vec<PathBuf>>, Vec<&PathBuf>)> = vec![];

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -292,20 +292,25 @@ impl WalkParallelBuilder {
     /// with that step taken off, which the walk up would otherwise read off
     /// the name.
     ///
-    /// A trailing separator is not a step, and neither is a leading `./`,
+    /// A separator on either end is not a step, and neither is a leading `./`,
     /// which the walker takes off a name and a root alike before comparing
-    /// them.
+    /// them. A separator run in the middle of a name is: it is dropped the way
+    /// a `.` is, and leaves the same gap between the name and the answers.
     fn leads_where_it_reads(pattern: &Path) -> bool {
         // `Path::components` drops a `.` that is not the first step, so the
         // steps are counted off the name as it was written. Separators and a
         // `.` are ASCII, which survives a name that is not text being read as
         // text, and re-serialising the name would not: a `/` written on
         // Windows comes back a `\`.
-        let says_nothing = pattern
-            .to_string_lossy()
-            .split(is_separator)
-            .enumerate()
-            .any(|(at, step)| step == "." && at > 0);
+        let written = pattern.to_string_lossy();
+        let steps: Vec<&str> = written.split(is_separator).collect();
+        let last = steps.len().saturating_sub(1);
+        let says_nothing = steps.iter().enumerate().any(|(at, step)| {
+            // A separator run says nothing where it is not the one that
+            // starts the name or the one that ends it, and `Path::components`
+            // drops it the way it drops a `.`.
+            (*step == "." && at > 0) || (step.is_empty() && at > 0 && at < last)
+        });
         if says_nothing {
             return false;
         }

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -254,18 +254,15 @@ impl WalkParallelBuilder {
                 // `current_dir` was last set to, which is what lets each
                 // directory's patterns keep their own anchoring.
                 let dir = Self::named(file.parent().unwrap_or(file));
-                // The walker reads what is over a root itself, and reports the
-                // globs it cannot parse there, so long as it has a
-                // `.gitignore` to go looking for. It never reads over a root
-                // it has no reason to look above, and never reads a file that
-                // sits at a root rather than over it, and what it does not
-                // read it cannot report.
-                let told_by_the_walker =
-                    respect_gitignore && patterns.iter().any(|pattern| Self::named(pattern) != dir);
-
                 builder.current_dir(dir);
+                // The walker reads what is over a root itself, and reports the
+                // globs it cannot parse there, whenever it has a `.gitignore`
+                // to go looking for. Without one it never looks up there, and
+                // this reading is the only one those files get. What it makes
+                // of a file at a root rather than over one it keeps to itself,
+                // here as on `main`.
                 if let Some(err) = builder.add_ignore(file)
-                    && !told_by_the_walker
+                    && !respect_gitignore
                     && !err.is_io()
                 {
                     // Two groups can name one file two ways, and it is still

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -1,5 +1,6 @@
 use core::num::NonZero;
 use std::env;
+use std::fs;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
@@ -127,11 +128,7 @@ impl WalkParallelBuilder {
                     return None;
                 }
                 dirs.reverse();
-                return Some(Self::ignore_files_in(
-                    &dirs,
-                    respect_ignore,
-                    respect_gitignore,
-                ));
+                return Self::ignore_files_in(&dirs, respect_ignore, respect_gitignore);
             }
         }
 
@@ -140,16 +137,33 @@ impl WalkParallelBuilder {
         Self::bounds_itself(dir)
     }
 
+    /// Whether `path` takes something back. A line that opens with a `!` in an
+    /// ignore file undoes what an earlier one said, and the walker ranks an
+    /// `.ignore` over every `.gitignore` wherever the two sit, which nothing
+    /// mado can hand a file back through will do.
+    fn takes_something_back(path: &Path) -> bool {
+        // A `!` opens a line that takes back; one written for itself is
+        // escaped, and so opens with a backslash.
+        fs::read_to_string(path).is_ok_and(|text| text.lines().any(|line| line.starts_with('!')))
+    }
+
     /// The ignore files `dirs` hold, in the order to hand them over. Every
     /// `.gitignore` goes in before any `.ignore` so the kinds stay ranked, and
-    /// each kind outermost first so the nearer file wins within a kind: the
-    /// walker takes the last file it was handed as the one that wins.
+    /// each kind outermost first so the nearer file wins within a kind:
+    /// `WalkBuilder` takes the last file handed to it as the one that wins.
+    ///
+    /// `None` where an `.ignore` over the path takes something back that a
+    /// `.gitignore` under it could be excluding. Handing these files back puts
+    /// them below every file the walk finds for itself, so the walk would drop
+    /// what it should keep -- quietly, and where a clone of the same tree
+    /// keeps it. The walker's own arrangement is left to answer instead, which
+    /// keeps what it should and reports more besides.
     fn ignore_files_in(
         dirs: &[PathBuf],
         respect_ignore: bool,
         respect_gitignore: bool,
-    ) -> Vec<PathBuf> {
-        [
+    ) -> Option<Vec<PathBuf>> {
+        let files: Vec<PathBuf> = [
             (".gitignore", respect_gitignore),
             (".ignore", respect_ignore),
         ]
@@ -157,7 +171,14 @@ impl WalkParallelBuilder {
         .filter(|&(_, wanted)| wanted)
         .flat_map(|(name, _)| dirs.iter().map(move |dir| dir.join(name)))
         .filter(|path| path.is_file())
-        .collect()
+        .collect();
+
+        let takes_back = respect_gitignore
+            && files
+                .iter()
+                .any(|file| file.ends_with(".ignore") && Self::takes_something_back(file));
+
+        (!takes_back).then_some(files)
     }
 
     /// `ignore_files_of` for the directory `pattern` sits in, remembering

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -34,19 +34,14 @@ impl WalkParallelBuilder {
         }
     }
 
-    /// The directory `path` sits in, named the way `path` names it, or `None`
-    /// at the filesystem root. `Path::parent` drops the last component, which
-    /// walks the wrong way when that component is a `..`.
-    fn parent_of(path: &Path) -> Option<PathBuf> {
+    /// The directory `path` sits in, named the way `path` names it, and `path`
+    /// itself where there is nothing above it. `Path::parent` drops the last
+    /// component, which walks the wrong way when that component is a `..`.
+    fn parent_of(path: &Path) -> PathBuf {
         if matches!(path.components().next_back(), Some(Component::ParentDir)) {
-            return Some(path.join(".."));
+            return path.join("..");
         }
-        path.parent().map(Self::named)
-    }
-
-    /// The directory `pattern` sits in, named the way `pattern` names it.
-    fn directory_of(pattern: &Path) -> PathBuf {
-        Self::parent_of(pattern).unwrap_or_else(|| Self::named(pattern))
+        path.parent().map_or_else(|| Self::named(path), Self::named)
     }
 
     /// Whether `dir` can only name something below the directory it is read
@@ -97,6 +92,7 @@ impl WalkParallelBuilder {
                 return None;
             }
 
+            let parent = Self::parent_of(&at);
             let at_boundary = if at == Path::new(".") {
                 true
             } else if Self::stays_below(&at) {
@@ -104,10 +100,11 @@ impl WalkParallelBuilder {
             } else {
                 match at.canonicalize() {
                     Ok(canonical) if canonical == *current_dir => true,
-                    Ok(canonical) if canonical.starts_with(current_dir) => false,
+                    Ok(canonical) if canonical.starts_with(current_dir) && parent != at => false,
                     // Past the boundary, which a name written with `..` can be
-                    // however far the walk up has left to go, or gone.
-                    _ => return Self::bounds_itself(&at),
+                    // however far the walk up has left to go, and the root of
+                    // a tree the boundary is not in always is.
+                    _ => break,
                 }
             };
 
@@ -124,11 +121,10 @@ impl WalkParallelBuilder {
                 ));
             }
 
-            match Self::parent_of(&at) {
-                Some(parent) if parent != at => at = parent,
-                _ => return Self::bounds_itself(&at),
-            }
+            at = parent;
         }
+
+        Self::bounds_itself(&at)
     }
 
     /// The ignore files `dirs` hold, in the order to hand them over. Every
@@ -169,7 +165,7 @@ impl WalkParallelBuilder {
             return Some(vec![]);
         }
 
-        let dir = Self::directory_of(pattern);
+        let dir = Self::parent_of(pattern);
         let files = if let Some((_, files)) = seen.iter().find(|(at, _)| *at == dir) {
             files.clone()
         } else {

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
+use std::path::is_separator;
 use std::thread;
 
 use ignore::WalkBuilder;
@@ -178,8 +179,7 @@ impl WalkParallelBuilder {
         }
 
         // A name that does not lead where it reads bounds itself: nothing
-        // above it can be rooted at a name the walk's answers begin with. That
-        // covers `mado check .`, whose own files the walk reads for itself.
+        // above it can be rooted at a name the walk's answers begin with.
         if !Self::leads_where_it_reads(pattern) {
             return Self::bounds_itself(pattern);
         }
@@ -254,14 +254,18 @@ impl WalkParallelBuilder {
                 // `current_dir` was last set to, which is what lets each
                 // directory's patterns keep their own anchoring.
                 let dir = Self::named(file.parent().unwrap_or(file));
+                // The walker reads what is over a root itself, and reports the
+                // globs it cannot parse there, so long as it has a
+                // `.gitignore` to go looking for. It never reads over a root
+                // it has no reason to look above, and never reads a file that
+                // sits at a root rather than over it, and what it does not
+                // read it cannot report.
+                let told_by_the_walker =
+                    respect_gitignore && patterns.iter().any(|pattern| Self::named(pattern) != dir);
+
                 builder.current_dir(dir);
-                // The walker reads these itself, and reports what it cannot
-                // parse, whenever it has a `.gitignore` to look for above a
-                // root. Without one it never looks up there, and this is the
-                // only reading they get. A file two groups both need is still
-                // one file with one thing wrong with it.
                 if let Some(err) = builder.add_ignore(file)
-                    && !respect_gitignore
+                    && !told_by_the_walker
                     && !err.is_io()
                 {
                     // Two groups can name one file two ways, and it is still
@@ -281,33 +285,39 @@ impl WalkParallelBuilder {
     }
 
     /// Whether `pattern` leads where it reads. The walk answers by joining
-    /// onto the name it was given, so a `.` or a `..` written in the middle of
-    /// that name is in the middle of every answer, and no ignore file above it
-    /// can be rooted at a name those answers begin with. A link makes the
-    /// directory above a step something other than the name with that step
-    /// taken off, which the walk up would otherwise read off the name.
+    /// onto the name it was given, so a `.` written in the middle of that name
+    /// is in the middle of every answer, and no ignore file above it can be
+    /// rooted at a name those answers begin with. A `..` is the same, and a
+    /// link makes the directory above a step something other than the name
+    /// with that step taken off, which the walk up would otherwise read off
+    /// the name.
     ///
-    /// A trailing separator is not a step -- joining onto the name takes it --
-    /// and neither is a leading `./`, which the walker takes off a name and a
-    /// root alike before it compares them.
+    /// A trailing separator is not a step, and neither is a leading `./`,
+    /// which the walker takes off a name and a root alike before comparing
+    /// them.
     fn leads_where_it_reads(pattern: &Path) -> bool {
-        // Joined onto the way the walk will join onto it, so that a trailing
-        // separator counts for as little here as it does there.
-        const STEP: &str = "a";
-
-        let read: PathBuf = pattern.components().collect();
-        if pattern.join(STEP).as_os_str() != read.join(STEP).as_os_str() {
+        // `Path::components` drops a `.` that is not the first step, so the
+        // steps are counted off the name as it was written. Separators and a
+        // `.` are ASCII, which survives a name that is not text being read as
+        // text, and re-serialising the name would not: a `/` written on
+        // Windows comes back a `\`.
+        let says_nothing = pattern
+            .to_string_lossy()
+            .split(is_separator)
+            .enumerate()
+            .any(|(at, step)| step == "." && at > 0);
+        if says_nothing {
             return false;
         }
 
         let mut at = PathBuf::new();
-        for step in read.components() {
+        for step in pattern.components() {
             if step == Component::ParentDir {
                 return false;
             }
 
             at.push(step);
-            if at.symlink_metadata().is_ok_and(|at| at.is_symlink()) {
+            if at.symlink_metadata().is_ok_and(|found| found.is_symlink()) {
                 return false;
             }
         }
@@ -390,18 +400,24 @@ impl WalkParallelBuilder {
             .collect()
     }
 
-    /// The walkers a command's paths need, ready to be visited. See
-    /// `build_from` for what each of them expects of the visiting.
+    /// The walkers a command's paths need, ready to be visited.
+    ///
+    /// Each is given a share of the threads rather than the run of the
+    /// machine, on the understanding that several are visited alongside each
+    /// other. Visiting them one at a time is correct and slower; visiting all
+    /// of them at once asks the machine for more than it has.
     #[inline]
     pub fn build(
         patterns: &[PathBuf],
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> Result<Vec<WalkParallel>> {
-        // A directory mado cannot name is one no pattern can be found under.
-        let current_dir = env::current_dir()
-            .and_then(|dir| dir.canonicalize())
-            .unwrap_or_default();
+        // The names paths are written under are compared with this, so it is
+        // the one the operating system gives rather than one resolved into a
+        // shape nobody writes: `fs::canonicalize` answers on Windows with a
+        // `\\?\C:\...` that no name reaches by walking up. A directory mado
+        // cannot name at all is one no pattern can be found under.
+        let current_dir = env::current_dir().unwrap_or_default();
 
         Self::build_from(patterns, &current_dir, respect_ignore, respect_gitignore)
     }

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::path::PathBuf;
 
 use ignore::WalkBuilder;
@@ -11,6 +12,13 @@ use miette::miette;
 pub struct WalkParallelBuilder;
 
 impl WalkParallelBuilder {
+    /// Whether `path` or any of its ancestors holds Git metadata. `.git` is a
+    /// directory in a clone and a file in a worktree or a submodule.
+    fn in_git_repository(path: &Path) -> bool {
+        path.canonicalize()
+            .is_ok_and(|path| path.ancestors().any(|dir| dir.join(".git").exists()))
+    }
+
     #[inline]
     pub fn build(
         patterns: &[PathBuf],
@@ -27,6 +35,22 @@ impl WalkParallelBuilder {
 
         builder.ignore(respect_ignore);
         builder.git_ignore(respect_gitignore);
+
+        // `respect-gitignore` covers `.gitignore` files and nothing else. The
+        // global Git ignore file and `.git/info/exclude` do not travel with the
+        // tree, so reading them would make the result depend on the machine.
+        builder.git_global(false);
+        builder.git_exclude(false);
+
+        // Outside a repository `ignore` drops `.gitignore` altogether, which
+        // makes the result depend on whether the tree still carries `.git`.
+        // `require_git(false)` applies it anyway, and with no repository root
+        // to stop at, `parents(false)` bounds the search at the given paths
+        // rather than letting it run to the filesystem root.
+        if respect_gitignore && !patterns.iter().any(|p| Self::in_git_repository(p)) {
+            builder.require_git(false);
+            builder.parents(false);
+        }
 
         // NOTE: Expect performance improvements with pre-filtering
         let types = TypesBuilder::new()
@@ -47,12 +71,15 @@ mod tests {
     use alloc::sync::Arc;
     use miette::{Context as _, IntoDiagnostic as _};
     use std::{
+        ffi::OsStr,
+        fs,
         path::{Path, PathBuf},
         sync::Mutex,
     };
 
     use ignore::{DirEntry, WalkState};
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
 
     use super::WalkParallelBuilder;
 
@@ -87,6 +114,67 @@ mod tests {
         }
     }
 
+    /// Writes `content` to `path`, creating the directories leading to it.
+    fn write(path: &Path, content: &str) -> miette::Result<()> {
+        let parent = path.parent().wrap_err("path must have a parent")?;
+        fs::create_dir_all(parent).into_diagnostic()?;
+        fs::write(path, content).into_diagnostic()
+    }
+
+    /// Lays out a tree with a `.gitignore` at its root and another one nested
+    /// inside it, each ignoring one of the Markdown files beside it.
+    fn write_tree(root: &Path) -> miette::Result<()> {
+        write(&root.join(".gitignore"), "root-ignored.md\n")?;
+        write(&root.join("keep.md"), "# Keep\n")?;
+        write(&root.join("root-ignored.md"), "# Root ignored\n")?;
+        write(&root.join("nested/.gitignore"), "nested-ignored.md\n")?;
+        write(&root.join("nested/keep.md"), "# Nested keep\n")?;
+        write(&root.join("nested/nested-ignored.md"), "# Nested ignored\n")
+    }
+
+    /// Walks `root` and returns the Markdown files it yields, relative to
+    /// `root` and sorted.
+    fn walk_markdown(
+        root: &Path,
+        respect_ignore: bool,
+        respect_gitignore: bool,
+    ) -> miette::Result<Vec<PathBuf>> {
+        let patterns = vec![root.to_path_buf()];
+        let walker = WalkParallelBuilder::build(&patterns, respect_ignore, respect_gitignore)?;
+        let collector = PathCollector::new();
+
+        walker.run(|| Box::new(collector.gen_visitor()));
+
+        let mut paths = collector
+            .paths()?
+            .into_iter()
+            .filter(|path| path.extension() == Some(OsStr::new("md")))
+            .map(|path| {
+                path.strip_prefix(root)
+                    .map(Path::to_path_buf)
+                    .into_diagnostic()
+            })
+            .collect::<miette::Result<Vec<_>>>()?;
+        paths.sort();
+        Ok(paths)
+    }
+
+    fn kept() -> Vec<PathBuf> {
+        vec![
+            Path::new("keep.md").to_path_buf(),
+            Path::new("nested/keep.md").to_path_buf(),
+        ]
+    }
+
+    fn everything() -> Vec<PathBuf> {
+        vec![
+            Path::new("keep.md").to_path_buf(),
+            Path::new("nested/keep.md").to_path_buf(),
+            Path::new("nested/nested-ignored.md").to_path_buf(),
+            Path::new("root-ignored.md").to_path_buf(),
+        ]
+    }
+
     #[test]
     fn build_and_run() -> miette::Result<()> {
         let paths = vec![
@@ -115,5 +203,93 @@ mod tests {
     fn build_empty_patterns() {
         let result = WalkParallelBuilder::build(&[], true, true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn gitignore_without_git_metadata() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write_tree(tmp_dir.path())?;
+
+        assert_eq!(walk_markdown(tmp_dir.path(), true, true)?, kept());
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn gitignore_with_git_directory() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write_tree(tmp_dir.path())?;
+        fs::create_dir(tmp_dir.path().join(".git")).into_diagnostic()?;
+
+        assert_eq!(walk_markdown(tmp_dir.path(), true, true)?, kept());
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn gitignore_with_git_file() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write_tree(tmp_dir.path())?;
+        write(
+            &tmp_dir.path().join(".git"),
+            "gitdir: ../.git/worktrees/tree\n",
+        )?;
+
+        assert_eq!(walk_markdown(tmp_dir.path(), true, true)?, kept());
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn gitignore_disabled_without_git_metadata() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write_tree(tmp_dir.path())?;
+
+        assert_eq!(walk_markdown(tmp_dir.path(), true, false)?, everything());
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn gitignore_disabled_with_git_directory() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write_tree(tmp_dir.path())?;
+        fs::create_dir(tmp_dir.path().join(".git")).into_diagnostic()?;
+
+        assert_eq!(walk_markdown(tmp_dir.path(), true, false)?, everything());
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn git_info_exclude_is_not_read() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write_tree(tmp_dir.path())?;
+        write(&tmp_dir.path().join(".git/info/exclude"), "keep.md\n")?;
+
+        assert_eq!(walk_markdown(tmp_dir.path(), true, true)?, kept());
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn ancestor_gitignore_without_git_metadata() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write(&tmp_dir.path().join(".gitignore"), "ancestor-ignored.md\n")?;
+        let root = tmp_dir.path().join("project");
+        write_tree(&root)?;
+        write(&root.join("ancestor-ignored.md"), "# Ancestor ignored\n")?;
+
+        let mut expected = kept();
+        expected.insert(0, Path::new("ancestor-ignored.md").to_path_buf());
+        assert_eq!(walk_markdown(&root, true, true)?, expected);
+        tmp_dir.close().into_diagnostic()
+    }
+
+    #[test]
+    fn ancestor_gitignore_up_to_the_repository_root() -> miette::Result<()> {
+        let tmp_dir = TempDir::new().into_diagnostic()?;
+        write(&tmp_dir.path().join(".gitignore"), "ancestor-ignored.md\n")?;
+        fs::create_dir(tmp_dir.path().join(".git")).into_diagnostic()?;
+        let root = tmp_dir.path().join("project");
+        write_tree(&root)?;
+        write(&root.join("ancestor-ignored.md"), "# Ancestor ignored\n")?;
+
+        assert_eq!(walk_markdown(&root, true, true)?, kept());
+        tmp_dir.close().into_diagnostic()
     }
 }

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -354,7 +354,9 @@ impl WalkParallelBuilder {
             }
         }
 
-        kept.iter().collect()
+        // A name that undoes itself, such as `docs/..`, names the directory
+        // mado was started in, and the walk has to be given one to open.
+        Self::named(&kept.iter().collect::<PathBuf>())
     }
 
     /// One walker per set of patterns that need the same ignore files handed

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -228,10 +228,8 @@ mod tests {
     fn gitignore_with_git_file() -> miette::Result<()> {
         let tmp_dir = TempDir::new().into_diagnostic()?;
         write_tree(tmp_dir.path())?;
-        write(
-            &tmp_dir.path().join(".git"),
-            "gitdir: ../.git/worktrees/tree\n",
-        )?;
+        let git_file = tmp_dir.path().join(".git");
+        write(&git_file, "gitdir: ../.git/worktrees/tree\n")?;
 
         assert_eq!(walk_markdown(tmp_dir.path(), true, true)?, kept());
         tmp_dir.close().into_diagnostic()

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -39,6 +39,11 @@ pub(crate) fn walks_at_once(budget: usize, walks: usize) -> usize {
 /// What one walk may spend on itself where a command makes `walks` of them, and
 /// `0` -- as many as it likes -- where it makes only one. Between them the ones
 /// running alongside each other spend no more than `budget`.
+///
+/// A count is all there is to go on here, and it cannot say which walk holds
+/// the tree, so this hands the budget to one walk at a time while there are no
+/// more walks than threads. That is what a big walk among small ones needs and
+/// what a crowd of small ones does not -- see #444.
 pub(crate) fn threads_per_walk(budget: usize, walks: usize) -> usize {
     if walks < 2 {
         return 0;
@@ -309,6 +314,14 @@ impl WalkParallelBuilder {
         Ok(builder.build_parallel())
     }
 
+    /// `pattern` with the `.` components that say nothing left out, keeping a
+    /// leading one. A walk names what it finds by joining onto the name it was
+    /// given, so `docs/.` has it answering about `docs/./a.md`, and no ignore
+    /// file above it can be rooted at a name that lines that up.
+    fn without_idle_dots(pattern: &Path) -> PathBuf {
+        pattern.components().collect()
+    }
+
     /// One walker per set of patterns that need the same ignore files handed
     /// back. Which files those are is a property of a single pattern, but
     /// patterns that need the same ones can be walked together.
@@ -335,9 +348,13 @@ impl WalkParallelBuilder {
             .ancestors()
             .skip(1)
             .any(Self::is_repository_root);
+        let patterns: Vec<PathBuf> = patterns
+            .iter()
+            .map(|p| Self::without_idle_dots(p))
+            .collect();
         let mut seen = vec![];
         let mut groups: Vec<(Option<Vec<PathBuf>>, Vec<&PathBuf>)> = vec![];
-        for pattern in patterns {
+        for pattern in &patterns {
             let files = Self::ignore_files_for(
                 pattern,
                 current_dir,

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -1,5 +1,6 @@
 use core::num::NonZero;
 use std::env;
+use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 use std::thread;
@@ -179,7 +180,7 @@ impl WalkParallelBuilder {
         // A name that does not lead where it reads bounds itself: nothing
         // above it can be rooted at a name the walk's answers begin with. That
         // covers `mado check .`, whose own files the walk reads for itself.
-        if !Self::leads_where_it_reads(pattern, current_dir) {
+        if !Self::leads_where_it_reads(pattern) {
             return Self::bounds_itself(pattern);
         }
 
@@ -279,18 +280,39 @@ impl WalkParallelBuilder {
         Ok(builder.build_parallel())
     }
 
-    /// Whether `pattern` leads where it reads: the walk answers with names
-    /// built by joining onto it, and `Gitignore` strips the root it was given
-    /// as a string, so an ignore file above a name can only be rooted at one
-    /// the walk's answers begin with. A `.`, a `..` or a link anywhere in a
-    /// name breaks that; a leading `./` does not, since the walker takes one
-    /// off a name it is matching before it looks at the root.
-    fn leads_where_it_reads(pattern: &Path, current_dir: &Path) -> bool {
-        let plain = pattern.strip_prefix(".").unwrap_or(pattern);
+    /// Whether `pattern` leads where it reads. The walk answers by joining
+    /// onto the name it was given, so a `.` or a `..` written in the middle of
+    /// that name is in the middle of every answer, and no ignore file above it
+    /// can be rooted at a name those answers begin with. A link makes the
+    /// directory above a step something other than the name with that step
+    /// taken off, which the walk up would otherwise read off the name.
+    ///
+    /// A trailing separator is not a step -- joining onto the name takes it --
+    /// and neither is a leading `./`, which the walker takes off a name and a
+    /// root alike before it compares them.
+    fn leads_where_it_reads(pattern: &Path) -> bool {
+        // Joined onto the way the walk will join onto it, so that a trailing
+        // separator counts for as little here as it does there.
+        const STEP: &str = "a";
 
-        pattern
-            .canonicalize()
-            .is_ok_and(|at| at.as_os_str() == current_dir.join(plain).as_os_str())
+        let read: PathBuf = pattern.components().collect();
+        if pattern.join(STEP).as_os_str() != read.join(STEP).as_os_str() {
+            return false;
+        }
+
+        let mut at = PathBuf::new();
+        for step in read.components() {
+            if step == Component::ParentDir {
+                return false;
+            }
+
+            at.push(step);
+            if at.symlink_metadata().is_ok_and(|at| at.is_symlink()) {
+                return false;
+            }
+        }
+
+        true
     }
 
     /// One walker per set of patterns that need the same ignore files handed

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -1,7 +1,9 @@
+use core::num::NonZero;
 use std::env;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
+use std::thread;
 
 use ignore::WalkBuilder;
 use ignore::WalkParallel;
@@ -58,6 +60,17 @@ impl WalkParallelBuilder {
                 .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
     }
 
+    /// The answer for a `dir` with no boundary over it: it bounds itself, and
+    /// nothing above it is read, unless it turns out to be in a repository
+    /// after all.
+    fn bounds_itself(dir: &Path) -> Option<Vec<PathBuf>> {
+        let in_repository = dir
+            .canonicalize()
+            .is_ok_and(|path| path.ancestors().any(Self::is_repository_root));
+
+        (!in_repository).then(Vec::new)
+    }
+
     /// The ignore files a pattern sitting in `dir` needs handed back, or
     /// `None` in a repository, where the walker finds them on its own. They
     /// come from the directories between `current_dir` and `dir`, and are
@@ -71,6 +84,12 @@ impl WalkParallelBuilder {
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> Option<Vec<PathBuf>> {
+        // A directory mado cannot name is one nothing can be found under, so
+        // no path has a boundary over it to walk up to and read from.
+        if current_dir.as_os_str().is_empty() {
+            return Self::bounds_itself(dir);
+        }
+
         let mut dirs = vec![];
         let mut at = dir.to_path_buf();
         loop {
@@ -88,11 +107,7 @@ impl WalkParallelBuilder {
                     Ok(canonical) if canonical.starts_with(current_dir) => false,
                     // Past the boundary, which a name written with `..` can be
                     // however far the walk up has left to go, or gone.
-                    canonical => {
-                        let in_repository = canonical
-                            .is_ok_and(|path| path.ancestors().any(Self::is_repository_root));
-                        return (!in_repository).then(Vec::new);
-                    }
+                    _ => return Self::bounds_itself(&at),
                 }
             };
 
@@ -111,7 +126,7 @@ impl WalkParallelBuilder {
 
             match Self::parent_of(&at) {
                 Some(parent) if parent != at => at = parent,
-                _ => return Some(vec![]),
+                _ => return Self::bounds_itself(&at),
             }
         }
     }
@@ -297,10 +312,19 @@ impl WalkParallelBuilder {
             }
         }
 
-        // A walk of its own for every group would spend more on starting
-        // threads than on walking. One each, and the runner runs the groups
-        // alongside each other, is cheaper wherever there is more than one.
-        let threads = usize::from(groups.len() > 1);
+        // The runner runs a machine's worth of groups alongside each other, so
+        // the machine is shared out between them rather than handed whole to
+        // each in turn: a walk of its own for every group would spend more on
+        // starting threads than on walking.
+        let threads = if groups.len() > 1 {
+            thread::available_parallelism()
+                .map_or(1, NonZero::get)
+                .div_ceil(groups.len())
+        } else {
+            // As many as the walk likes, which is what it did before there
+            // was ever more than one of them.
+            0
+        };
         let mut reported = vec![];
         groups
             .iter()

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -158,6 +158,10 @@ impl WalkParallelBuilder {
     /// what it should keep, quietly, and where a clone of the same tree keeps
     /// it. The walker's own arrangement is left to answer instead, which keeps
     /// what it should and reports more besides.
+    ///
+    /// The whole way up is asked, not the part mado hands back: the walker
+    /// reads an `.ignore` however far over the tree it sits, so one that far
+    /// over ranks over a `.gitignore` in it just the same.
     fn taken_back_over(pattern: &Path) -> bool {
         pattern.canonicalize().is_ok_and(|at| {
             at.ancestors()
@@ -208,8 +212,9 @@ impl WalkParallelBuilder {
 
         // Whatever mado does with the files over this one, they end up under
         // what the walk finds for itself, and one of them taking something
-        // back is one the walk would then drop.
-        if respect_gitignore && Self::taken_back_over(pattern) {
+        // back is one the walk would then drop. With `.ignore` files left
+        // unread there is nothing over the walk's own answers to begin with.
+        if respect_ignore && respect_gitignore && Self::taken_back_over(pattern) {
             return None;
         }
         // A name that does not lead where it reads bounds itself: nothing

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -305,7 +305,8 @@ impl WalkParallelBuilder {
                 // to go looking for. Without one it never looks up there, and
                 // this reading is the only one those files get. What it makes
                 // of a file at a root rather than over one it keeps to itself,
-                // here as on `main`.
+                // here as on `main`. It reads higher up than the boundary lets
+                // mado apply, and speaks about those files too -- see #441.
                 if let Some(err) = builder.add_ignore(file)
                     && !respect_gitignore
                     && !err.is_io()

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -12,44 +13,96 @@ use miette::miette;
 pub struct WalkParallelBuilder;
 
 impl WalkParallelBuilder {
-    /// Whether `path` or any of its ancestors holds Git metadata. `.git` is a
-    /// directory in a clone and a file in a worktree or a submodule.
-    fn in_git_repository(path: &Path) -> bool {
-        path.canonicalize()
-            .is_ok_and(|path| path.ancestors().any(|dir| dir.join(".git").exists()))
+    /// Whether `path` or any directory above it holds a repository marker.
+    /// `.git` is a directory in a clone and a file in a worktree or a
+    /// submodule, and `.jj` is the other marker the `ignore` crate stops at.
+    fn in_repository(path: &Path) -> bool {
+        path.canonicalize().is_ok_and(|path| {
+            path.ancestors()
+                .any(|dir| dir.join(".git").exists() || dir.join(".jj").exists())
+        })
     }
 
-    #[inline]
-    pub fn build(
-        patterns: &[PathBuf],
+    /// The directories above `pattern` up to and including the one mado was
+    /// started in, outermost first. Each is named the way `pattern` names it,
+    /// so that the ignore files found there match the paths the walk yields.
+    /// Empty when `pattern` is that directory, or lies outside it.
+    fn ancestors_up_to_current_dir(pattern: &Path) -> Vec<PathBuf> {
+        // A directory mado cannot name is one no pattern can be found under.
+        let current_dir = env::current_dir()
+            .and_then(|dir| dir.canonicalize())
+            .unwrap_or_default();
+        if pattern.canonicalize().is_ok_and(|path| path == current_dir) {
+            return vec![];
+        }
+
+        let mut dirs = vec![];
+        let mut ancestor = pattern.parent();
+        while let Some(dir) = ancestor {
+            // `Path::parent` names the directory a relative path sits in with
+            // the empty path, which no file can be opened under.
+            let named = if dir.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                dir
+            };
+            dirs.push(named.to_path_buf());
+            if named.canonicalize().is_ok_and(|path| path == current_dir) {
+                dirs.reverse();
+                return dirs;
+            }
+            ancestor = dir.parent();
+        }
+
+        vec![]
+    }
+
+    /// Adds `path` as an ignore file rooted at `dir`. `WalkBuilder` roots the
+    /// files it is handed at whatever `current_dir` was last set to, which is
+    /// what lets each directory's patterns keep their own anchoring.
+    fn add_ignore_file(builder: &mut WalkBuilder, dir: &Path, name: &str) {
+        let path = dir.join(name);
+        if path.is_file() {
+            builder.current_dir(dir);
+            drop(builder.add_ignore(path));
+        }
+    }
+
+    fn build_one(
+        pattern: &Path,
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> Result<WalkParallel> {
-        let (head_pattern, tail_patterns) = patterns
-            .split_first()
-            .ok_or_else(|| miette!("files must be non-empty"))?;
-        let mut builder = WalkBuilder::new(head_pattern);
-        for pattern in tail_patterns {
-            builder.add(pattern);
-        }
-
+        let mut builder = WalkBuilder::new(pattern);
         builder.ignore(respect_ignore);
         builder.git_ignore(respect_gitignore);
 
         // `respect-gitignore` covers `.gitignore` files and nothing else. The
-        // global Git ignore file and `.git/info/exclude` do not travel with the
-        // tree, so reading them would make the result depend on the machine.
+        // global Git ignore file and `.git/info/exclude` do not travel with
+        // the tree, so reading them would make the result depend on the
+        // machine and on the clone.
         builder.git_global(false);
         builder.git_exclude(false);
 
-        // Outside a repository `ignore` drops `.gitignore` altogether, which
-        // makes the result depend on whether the tree still carries `.git`.
-        // `require_git(false)` applies it anyway, and with no repository root
-        // to stop at, `parents(false)` bounds the search at the given paths
-        // rather than letting it run to the filesystem root.
-        if respect_gitignore && !patterns.iter().any(|p| Self::in_git_repository(p)) {
+        if !Self::in_repository(pattern) {
+            // Outside a repository the walker drops `.gitignore` entirely, and
+            // `require_git(false)` on its own would read ignore files every
+            // directory up to the filesystem root. Stop its parent search and
+            // put back the files between here and the directory mado was
+            // started in, which is the root the rest of mado resolves against.
             builder.require_git(false);
             builder.parents(false);
+
+            for dir in Self::ancestors_up_to_current_dir(pattern) {
+                // Added outermost first, and `.gitignore` before `.ignore`, so
+                // that the nearer file wins where both name the same path.
+                if respect_gitignore {
+                    Self::add_ignore_file(&mut builder, &dir, ".gitignore");
+                }
+                if respect_ignore {
+                    Self::add_ignore_file(&mut builder, &dir, ".ignore");
+                }
+            }
         }
 
         // NOTE: Expect performance improvements with pre-filtering
@@ -61,6 +114,24 @@ impl WalkParallelBuilder {
         builder.types(types);
 
         Ok(builder.build_parallel())
+    }
+
+    /// One walker per pattern: the repository a pattern sits in, and so where
+    /// its search for ignore files stops, is a property of that pattern alone.
+    #[inline]
+    pub fn build(
+        patterns: &[PathBuf],
+        respect_ignore: bool,
+        respect_gitignore: bool,
+    ) -> Result<Vec<WalkParallel>> {
+        if patterns.is_empty() {
+            return Err(miette!("files must be non-empty"));
+        }
+
+        patterns
+            .iter()
+            .map(|pattern| Self::build_one(pattern, respect_ignore, respect_gitignore))
+            .collect()
     }
 }
 
@@ -140,10 +211,12 @@ mod tests {
         respect_gitignore: bool,
     ) -> miette::Result<Vec<PathBuf>> {
         let patterns = vec![root.to_path_buf()];
-        let walker = WalkParallelBuilder::build(&patterns, respect_ignore, respect_gitignore)?;
+        let walkers = WalkParallelBuilder::build(&patterns, respect_ignore, respect_gitignore)?;
         let collector = PathCollector::new();
 
-        walker.run(|| Box::new(collector.gen_visitor()));
+        for walker in walkers {
+            walker.run(|| Box::new(collector.gen_visitor()));
+        }
 
         let mut paths = collector
             .paths()?
@@ -182,10 +255,12 @@ mod tests {
             Path::new("mado.toml").to_path_buf(),
             Path::new("README.md").to_path_buf(),
         ];
-        let builder = WalkParallelBuilder::build(&paths, true, true)?;
+        let walkers = WalkParallelBuilder::build(&paths, true, true)?;
         let collector = PathCollector::new();
 
-        builder.run(|| Box::new(collector.gen_visitor()));
+        for walker in walkers {
+            walker.run(|| Box::new(collector.gen_visitor()));
+        }
 
         let mut actual = collector.paths()?;
         actual.sort();

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -27,7 +27,13 @@ pub(crate) fn thread_budget() -> usize {
 
 /// How many of `walks` walks may run alongside each other on `budget` threads.
 pub(crate) fn walks_at_once(budget: usize, walks: usize) -> usize {
-    walks.min(budget).max(1)
+    #[expect(
+        clippy::integer_division_remainder_used,
+        reason = "sharing a budget out is what division is for, and what is left over is meant to be dropped"
+    )]
+    let at_once = budget / threads_per_walk(budget, walks).max(1);
+
+    at_once.min(walks).max(1)
 }
 
 /// What one walk may spend on itself where a command makes `walks` of them, and
@@ -42,7 +48,7 @@ pub(crate) fn threads_per_walk(budget: usize, walks: usize) -> usize {
         clippy::integer_division_remainder_used,
         reason = "sharing a budget out is what division is for, and what is left over is meant to be dropped"
     )]
-    let threads = budget / walks_at_once(budget, walks);
+    let threads = budget / walks.div_ceil(budget.max(1));
 
     threads.max(1)
 }
@@ -564,6 +570,11 @@ mod tests {
 
     #[test]
     fn walks_never_spend_more_than_one_of_them_would() {
+        // The runner leans on there being one to run, and asks for one of its
+        // own besides.
+        assert!(walks_at_once(0, 0) >= 1);
+        assert!(walks_at_once(0, 8) >= 1);
+
         for budget in [1_usize, 2, 8, 10, 12] {
             // One walk is left to spend what the walker would have on it.
             assert_eq!(threads_per_walk(budget, 1), 0);

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -1,6 +1,5 @@
 use core::num::NonZero;
 use std::env;
-use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 use std::thread;
@@ -80,12 +79,8 @@ impl WalkParallelBuilder {
     }
 
     /// The directory `path` sits in, named the way `path` names it, and `path`
-    /// itself where there is nothing above it. `Path::parent` drops the last
-    /// component, which walks the wrong way when that component is a `..`.
+    /// itself where there is nothing above it.
     fn parent_of(path: &Path) -> PathBuf {
-        if matches!(path.components().next_back(), Some(Component::ParentDir)) {
-            return path.join("..");
-        }
         path.parent().map_or_else(|| Self::named(path), Self::named)
     }
 
@@ -106,6 +101,9 @@ impl WalkParallelBuilder {
     /// empty when `dir` lies outside `current_dir`, which leaves the pattern
     /// its own boundary. `above_is_repository` answers for the directories
     /// over `current_dir`, which no pattern can reach by walking up.
+    ///
+    /// Every name that gets here leads where it reads, so where each step
+    /// stands can be read off the name rather than asked after.
     fn ignore_files_of(
         dir: &Path,
         current_dir: &Path,
@@ -113,36 +111,15 @@ impl WalkParallelBuilder {
         respect_ignore: bool,
         respect_gitignore: bool,
     ) -> Option<Vec<PathBuf>> {
-        // A directory mado cannot name is one nothing can be found under, so
-        // no path has a boundary over it to walk up to and read from.
-        if current_dir.as_os_str().is_empty() {
-            return Self::bounds_itself(dir);
-        }
-
         let mut dirs = vec![];
-        let mut at = dir.to_path_buf();
-        loop {
-            if Self::is_repository_root(&at) {
+        for at in dir.ancestors() {
+            let named = Self::named(at);
+            if Self::is_repository_root(&named) {
                 return None;
             }
 
-            let parent = Self::parent_of(&at);
-            let at_boundary = if at == Path::new(".") {
-                true
-            } else if Self::stays_below(&at) {
-                false
-            } else {
-                match at.canonicalize() {
-                    Ok(canonical) if canonical == *current_dir => true,
-                    Ok(canonical) if canonical.starts_with(current_dir) && parent != at => false,
-                    // Past the boundary, which a name written with `..` can be
-                    // however far the walk up has left to go, and the root of
-                    // a tree the boundary is not in always is.
-                    _ => break,
-                }
-            };
-
-            dirs.push(at.clone());
+            let at_boundary = named == *current_dir || named == Path::new(".");
+            dirs.push(named);
             if at_boundary {
                 if above_is_repository {
                     return None;
@@ -154,11 +131,11 @@ impl WalkParallelBuilder {
                     respect_gitignore,
                 ));
             }
-
-            at = parent;
         }
 
-        Self::bounds_itself(&at)
+        // The walk up ran out without meeting the boundary, so `dir` is not
+        // under it and the pattern is bounded by itself.
+        Self::bounds_itself(dir)
     }
 
     /// The ignore files `dirs` hold, in the order to hand them over. Every
@@ -199,6 +176,13 @@ impl WalkParallelBuilder {
             return Some(vec![]);
         }
 
+        // A name that does not lead where it reads bounds itself: nothing
+        // above it can be rooted at a name the walk's answers begin with. That
+        // covers `mado check .`, whose own files the walk reads for itself.
+        if !Self::leads_where_it_reads(pattern, current_dir) {
+            return Self::bounds_itself(pattern);
+        }
+
         let dir = Self::parent_of(pattern);
         let files = if let Some((_, files)) = seen.iter().find(|(at, _)| *at == dir) {
             files.clone()
@@ -220,17 +204,7 @@ impl WalkParallelBuilder {
             return None;
         }
 
-        // The walk descends into the pattern, so its own last step counts as
-        // much as the ones above it: a name that leaves the boundary anywhere
-        // along its length is bounded by itself, not by what it was written
-        // under.
-        match pattern.canonicalize() {
-            // The walk reads the ignore files of a directory it is handed, so
-            // for the boundary itself only what is above is left to put back.
-            Ok(at) if at == *current_dir => Some(vec![]),
-            Ok(at) if at.starts_with(current_dir) => files,
-            _ => Self::bounds_itself(pattern),
-        }
+        files
     }
 
     /// One walker for `patterns`, which need the same ignore files handed
@@ -305,60 +279,18 @@ impl WalkParallelBuilder {
         Ok(builder.build_parallel())
     }
 
-    /// Whether `dir` can only name something below the directory it is read
-    /// from. A relative name that neither starts at the filesystem root nor
-    /// climbs with `..` does, so long as no step of it is a link, which could
-    /// lead anywhere. Answering it this way costs a look at each step rather
-    /// than a resolution of the whole name.
-    fn stays_below(dir: &Path) -> bool {
-        if dir.is_absolute() {
-            return false;
-        }
+    /// Whether `pattern` leads where it reads: the walk answers with names
+    /// built by joining onto it, and `Gitignore` strips the root it was given
+    /// as a string, so an ignore file above a name can only be rooted at one
+    /// the walk's answers begin with. A `.`, a `..` or a link anywhere in a
+    /// name breaks that; a leading `./` does not, since the walker takes one
+    /// off a name it is matching before it looks at the root.
+    fn leads_where_it_reads(pattern: &Path, current_dir: &Path) -> bool {
+        let plain = pattern.strip_prefix(".").unwrap_or(pattern);
 
-        let mut at = PathBuf::new();
-        for component in dir.components() {
-            match component {
-                Component::CurDir => continue,
-                Component::Normal(step) => at.push(step),
-                _ => return false,
-            }
-
-            if at.symlink_metadata().is_ok_and(|step| step.is_symlink()) {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    /// `pattern` with the steps that lead nowhere left out: the `.`s, and the
-    /// `..`s that undo a directory that is one rather than a link to one. A
-    /// walk names what it finds by joining onto the name it was given, so
-    /// `d1/docs/../docs` has it answering about `d1/docs/../docs/a.md`, and no
-    /// ignore file above it can be rooted at a name that lines that up.
-    fn without_idle_steps(pattern: &Path) -> PathBuf {
-        let mut kept: Vec<Component<'_>> = vec![];
-        for component in pattern.components() {
-            // A `..` after a link undoes where the link led, not the name
-            // before it, so only a directory of its own can be dropped here.
-            let undoes_a_directory = component == Component::ParentDir
-                && matches!(kept.last(), Some(Component::Normal(_)))
-                && kept
-                    .iter()
-                    .collect::<PathBuf>()
-                    .symlink_metadata()
-                    .is_ok_and(|at| at.is_dir());
-
-            if undoes_a_directory {
-                kept.pop();
-            } else {
-                kept.push(component);
-            }
-        }
-
-        // A name that undoes itself, such as `docs/..`, names the directory
-        // mado was started in, and the walk has to be given one to open.
-        Self::named(&kept.iter().collect::<PathBuf>())
+        pattern
+            .canonicalize()
+            .is_ok_and(|at| at.as_os_str() == current_dir.join(plain).as_os_str())
     }
 
     /// One walker per set of patterns that need the same ignore files handed
@@ -392,13 +324,9 @@ impl WalkParallelBuilder {
             .ancestors()
             .skip(1)
             .any(Self::is_repository_root);
-        let patterns: Vec<PathBuf> = patterns
-            .iter()
-            .map(|p| Self::without_idle_steps(p))
-            .collect();
         let mut seen = vec![];
         let mut groups: Vec<(Option<Vec<PathBuf>>, Vec<&PathBuf>)> = vec![];
-        for pattern in &patterns {
+        for pattern in patterns {
             let files = Self::ignore_files_for(
                 pattern,
                 current_dir,
@@ -773,8 +701,11 @@ mod tests {
     #[test]
     fn gitignore_when_the_boundary_cannot_be_named() -> miette::Result<()> {
         let tmp_dir = TempDir::new().into_diagnostic()?;
-        write(&tmp_dir.path().join(".gitignore"), "keep.md\n")?;
-        let root = tmp_dir.path().join("project");
+        // Canonical, so the name leads where it reads and the walk up is the
+        // thing that runs out rather than the reading of the name.
+        let at = tmp_dir.path().canonicalize().into_diagnostic()?;
+        write(&at.join(".gitignore"), "keep.md\n")?;
+        let root = at.join("project");
         write_tree(&root)?;
 
         // With no directory to measure against, every path bounds itself, so

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -128,7 +128,11 @@ impl WalkParallelBuilder {
                     return None;
                 }
                 dirs.reverse();
-                return Self::ignore_files_in(&dirs, respect_ignore, respect_gitignore);
+                return Some(Self::ignore_files_in(
+                    &dirs,
+                    respect_ignore,
+                    respect_gitignore,
+                ));
             }
         }
 
@@ -147,23 +151,33 @@ impl WalkParallelBuilder {
         fs::read_to_string(path).is_ok_and(|text| text.lines().any(|line| line.starts_with('!')))
     }
 
+    /// Whether an `.ignore` over `pattern` takes something back that a
+    /// `.gitignore` under it could be excluding. Reading these files for
+    /// `pattern` -- or leaving them unread, which comes to the same -- puts
+    /// them under every file the walk finds for itself, so the walk would drop
+    /// what it should keep, quietly, and where a clone of the same tree keeps
+    /// it. The walker's own arrangement is left to answer instead, which keeps
+    /// what it should and reports more besides.
+    fn taken_back_over(pattern: &Path) -> bool {
+        pattern.canonicalize().is_ok_and(|at| {
+            at.ancestors()
+                .skip(1)
+                .map(|over| over.join(".ignore"))
+                .any(|file| file.is_file() && Self::takes_something_back(&file))
+        })
+    }
+
     /// The ignore files `dirs` hold, in the order to hand them over. Every
     /// `.gitignore` goes in before any `.ignore` so the kinds stay ranked, and
     /// each kind outermost first so the nearer file wins within a kind:
     /// `WalkBuilder` takes the last file handed to it as the one that wins.
     ///
-    /// `None` where an `.ignore` over the path takes something back that a
-    /// `.gitignore` under it could be excluding. Handing these files back puts
-    /// them below every file the walk finds for itself, so the walk would drop
-    /// what it should keep -- quietly, and where a clone of the same tree
-    /// keeps it. The walker's own arrangement is left to answer instead, which
-    /// keeps what it should and reports more besides.
     fn ignore_files_in(
         dirs: &[PathBuf],
         respect_ignore: bool,
         respect_gitignore: bool,
-    ) -> Option<Vec<PathBuf>> {
-        let files: Vec<PathBuf> = [
+    ) -> Vec<PathBuf> {
+        [
             (".gitignore", respect_gitignore),
             (".ignore", respect_ignore),
         ]
@@ -171,14 +185,7 @@ impl WalkParallelBuilder {
         .filter(|&(_, wanted)| wanted)
         .flat_map(|(name, _)| dirs.iter().map(move |dir| dir.join(name)))
         .filter(|path| path.is_file())
-        .collect();
-
-        let takes_back = respect_gitignore
-            && files
-                .iter()
-                .any(|file| file.ends_with(".ignore") && Self::takes_something_back(file));
-
-        (!takes_back).then_some(files)
+        .collect()
     }
 
     /// `ignore_files_of` for the directory `pattern` sits in, remembering
@@ -199,6 +206,12 @@ impl WalkParallelBuilder {
             return Some(vec![]);
         }
 
+        // Whatever mado does with the files over this one, they end up under
+        // what the walk finds for itself, and one of them taking something
+        // back is one the walk would then drop.
+        if respect_gitignore && Self::taken_back_over(pattern) {
+            return None;
+        }
         // A name that does not lead where it reads bounds itself: nothing
         // above it can be rooted at a name the walk's answers begin with.
         if !Self::leads_where_it_reads(pattern) {

--- a/tests/archive_and_clone.rs
+++ b/tests/archive_and_clone.rs
@@ -1,0 +1,211 @@
+//! A tree that has lost its Git metadata, and a clone of the same tree, are
+//! linted by walks that reach their ignore files by different routes: the
+//! walker finds them for a clone, and mado hands them back for an archive.
+//! What the two must never do is disagree in the direction that hides
+//! something -- an archive dropping a file its clone reports.
+//!
+//! The trees here are generated rather than written out, because the shapes
+//! that have broken this are the ones nobody thought to write: an ignore file
+//! two levels up taking back what one below it excludes, a pattern anchored to
+//! a directory the walk names another way.
+
+extern crate alloc;
+
+use alloc::collections::BTreeSet;
+use std::fs::{create_dir_all, remove_dir_all, remove_file, write};
+use std::path::Path;
+
+use assert_cmd::Command;
+use assert_cmd::cargo_bin;
+use miette::{IntoDiagnostic as _, Result};
+use tempfile::tempdir;
+
+/// Directories the trees are built out of.
+const DIRS: &[&str] = &["", "docs", "docs/sub", "d1", "d1/docs"];
+
+/// Where the ignore file under the boundary goes.
+const HOLDER: &str = "docs";
+
+/// The two kinds, which the walker ranks against each other by kind rather
+/// than by where they sit.
+const KINDS: &[&str] = &[".gitignore", ".ignore"];
+
+/// Lines to fill an ignore file out with, beside the one that decides the
+/// shape: anchored and not, naming a directory and naming a file.
+const LINES: &[&str] = &[
+    "a.md",
+    "/docs/a.md",
+    "/d1/",
+    "docs/",
+    "*.md",
+    "/docs/sub/a.md",
+    "**/a.md",
+];
+
+/// The names the walk is pointed at, and whether each leads where it reads.
+/// The ones that do not are their own boundary, which reports more; the ones
+/// that do have nothing to excuse a difference.
+const NAMES: &[(&str, bool)] = &[(".", true), ("docs", true), ("docs/.", false)];
+
+const CONFIGS: &[Option<&str>] = &[
+    None,
+    Some("[lint]\nrespect-gitignore = false\n"),
+    Some("[lint]\nrespect-ignore = false\n"),
+];
+
+/// A generator whose trees do not move when a dependency does, so that a case
+/// named by a failure goes on naming the same tree.
+struct Seeded(u64);
+
+impl Seeded {
+    #[expect(
+        clippy::integer_division_remainder_used,
+        reason = "picking one of a list out of a number is what a remainder is for"
+    )]
+    const fn below(&mut self, end: usize) -> usize {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+
+        ((self.0 >> 33) % end as u64) as usize
+    }
+
+    const fn one_in(&mut self, chance: usize) -> bool {
+        self.below(chance) == 0
+    }
+}
+
+/// One ignore file at the boundary and one under it, which is the pair the
+/// walk and mado reach by different routes. `above` and `below` name their
+/// kinds, and `takes_back` has the one at the boundary take `ignored.md` back
+/// from the one under it -- the shape where handing a file back ranks it under
+/// what the walk finds, and drops what a clone keeps.
+struct Shape {
+    above: &'static str,
+    below: &'static str,
+    takes_back: bool,
+}
+
+fn shapes() -> Vec<Shape> {
+    let mut all = vec![];
+    for above in KINDS {
+        for below in KINDS {
+            for takes_back in [false, true] {
+                all.push(Shape {
+                    above,
+                    below,
+                    takes_back,
+                });
+            }
+        }
+    }
+
+    all
+}
+
+/// A tree of Markdown under `at`, carrying `shape`'s pair of ignore files.
+fn write_tree(at: &Path, shape: &Shape, seed: u64) -> Result<()> {
+    let mut rng = Seeded(seed);
+    for dir in DIRS {
+        create_dir_all(at.join(dir)).into_diagnostic()?;
+        for name in ["a.md", "b.md"] {
+            let text = if rng.one_in(4) { "# Fine\n" } else { "#Hello." };
+            write(at.join(dir).join(name), text).into_diagnostic()?;
+        }
+        // The one the pair of ignore files disagrees about always has
+        // something to report, so that a case cannot go quiet by chance.
+        write(at.join(dir).join("ignored.md"), "#Hello.").into_diagnostic()?;
+    }
+
+    // The filler goes in first and the line that decides the shape last: an
+    // ignore file is read to the end, and the last line to match is the one
+    // that says what happens.
+    let mut above = String::new();
+    let mut below = String::new();
+    for lines in [&mut above, &mut below] {
+        for _ in 0..=rng.below(2) {
+            lines.push_str(LINES[rng.below(LINES.len())]);
+            lines.push('\n');
+        }
+    }
+    if shape.takes_back {
+        above.push_str("!ignored.md\n");
+    }
+    below.push_str("ignored.md\n");
+
+    write(at.join(shape.above), above).into_diagnostic()?;
+    write(at.join(HOLDER).join(shape.below), below).into_diagnostic()
+}
+
+/// The files `mado check name` reports on, named the way it named them.
+fn reported(at: &Path, name: &str) -> Result<BTreeSet<String>> {
+    let output = Command::new(cargo_bin!("mado"))
+        .current_dir(at)
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
+        .args(["check", name])
+        .output()
+        .into_diagnostic()?;
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split(':').next())
+        .filter(|head| Path::new(head).extension().is_some_and(|kind| kind == "md"))
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+#[test]
+fn an_archive_reports_everything_a_clone_of_it_does() -> Result<()> {
+    for (at, shape) in shapes().iter().enumerate() {
+        let tmp_dir = tempdir().into_diagnostic()?;
+        let proj = tmp_dir.path().join("proj");
+        write_tree(&proj, shape, at as u64)?;
+
+        for config in CONFIGS {
+            let settings = proj.join("mado.toml");
+            match *config {
+                Some(text) => write(&settings, text).into_diagnostic()?,
+                None if settings.exists() => remove_file(&settings).into_diagnostic()?,
+                None => {}
+            }
+
+            for &(name, leads_where_it_reads) in NAMES {
+                let git = proj.join(".git");
+                let archive = reported(&proj, name)?;
+                create_dir_all(&git).into_diagnostic()?;
+                let clone = reported(&proj, name)?;
+                remove_dir_all(&git).into_diagnostic()?;
+
+                let case = format!(
+                    "{} over {HOLDER}/{}{}, {config:?}, {name:?}",
+                    shape.above,
+                    shape.below,
+                    if shape.takes_back {
+                        ", taking back"
+                    } else {
+                        ""
+                    },
+                );
+                let dropped: Vec<&String> = clone.difference(&archive).collect();
+                assert!(
+                    dropped.is_empty(),
+                    "{case}: the archive dropped {dropped:?}"
+                );
+
+                // Nothing excuses a difference where both files are
+                // `.gitignore` and the name leads where it reads.
+                let all_gitignore = shape.above == ".gitignore" && shape.below == ".gitignore";
+                if all_gitignore && leads_where_it_reads {
+                    let extra: Vec<&String> = archive.difference(&clone).collect();
+                    assert!(extra.is_empty(), "{case}: the archive reported {extra:?}");
+                }
+            }
+        }
+
+        tmp_dir.close().into_diagnostic()?;
+    }
+
+    Ok(())
+}

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -500,6 +500,28 @@ fn check_reads_an_anchored_parent_pattern_for_a_path_spelled_with_a_step_back() 
     )
 }
 
+#[test]
+fn check_walks_the_directory_a_name_that_undoes_itself_lands_in() -> Result<()> {
+    with_tree(
+        &[("docs/bad.md", "#Hello."), ("top.md", "#Hello.")],
+        |root| {
+            // `docs/..` is the directory mado was started in, not nothing at all.
+            let assert = check_in(root, &["docs/.."]).assert();
+            assert.failure().stdout(indoc! {"
+            ./docs/bad.md:1:1: MD018 No space after hash on atx style header
+            ./docs/bad.md:1:1: MD041 First line in file should be a top level header
+            ./docs/bad.md:1:1: MD047 File should end with a single newline character
+            ./top.md:1:1: MD018 No space after hash on atx style header
+            ./top.md:1:1: MD041 First line in file should be a top level header
+            ./top.md:1:1: MD047 File should end with a single newline character
+
+            Found 6 errors.
+        "});
+            Ok(())
+        },
+    )
+}
+
 #[cfg(unix)]
 #[test]
 fn check_does_not_read_the_boundary_gitignore_for_a_tree_a_link_leads_out_to() -> Result<()> {

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -484,6 +484,17 @@ fn check_reads_an_anchored_parent_pattern_for_a_name_that_leads_where_it_reads()
 }
 
 #[test]
+fn check_reads_an_anchored_parent_pattern_for_a_name_that_ends_in_a_separator() -> Result<()> {
+    with_tree(ANCHORED_BELOW_A_SUBDIRECTORY, |root| {
+        // A separator on the end is not a step: joining onto the name takes
+        // it, which is what the walk does to answer.
+        let assert = check_in(&root.join("proj"), &["docs/"]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
 fn check_bounds_a_name_that_does_not_lead_where_it_reads() -> Result<()> {
     with_tree(ANCHORED_BELOW_A_SUBDIRECTORY, |root| {
         // `docs/.` has the walk answering about `docs/./ignored.md`, which no

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -495,6 +495,32 @@ fn check_reads_an_anchored_parent_pattern_for_a_name_that_ends_in_a_separator() 
 }
 
 #[test]
+fn check_bounds_a_name_with_a_separator_run_in_the_middle_of_it() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/.gitignore", "ignored.md\n"),
+            ("proj/docs/ignored.md", "#Hello."),
+            ("proj/docs/keep.md", "# Fine\n"),
+        ],
+        |root| {
+            // A run of separators is dropped the way a `.` is, and leaves the
+            // same gap between the name and the answers the walk builds from
+            // it: read against the file above, `.//docs/ignored.md` arrives
+            // with a leading separator and matches a pattern it should not.
+            let assert = check_in(&root.join("proj"), &[".//docs"]).assert();
+            assert.failure().stdout(indoc! {"
+                .//docs/ignored.md:1:1: MD018 No space after hash on atx style header
+                .//docs/ignored.md:1:1: MD041 First line in file should be a top level header
+                .//docs/ignored.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
+}
+
+#[test]
 fn check_bounds_a_name_that_does_not_lead_where_it_reads() -> Result<()> {
     with_tree(ANCHORED_BELOW_A_SUBDIRECTORY, |root| {
         // `docs/.` has the walk answering about `docs/./ignored.md`, which no

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -549,6 +549,32 @@ fn check_does_not_read_the_boundary_gitignore_for_a_tree_a_link_leads_out_to() -
 
 #[cfg(unix)]
 #[test]
+fn check_does_not_read_the_boundary_gitignore_for_a_link_named_on_its_own() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/.gitignore", "ignored.md\n"),
+            ("outside/ignored.md", "#Hello."),
+        ],
+        |root| {
+            symlink(root.join("outside"), root.join("proj/link")).into_diagnostic()?;
+
+            // The walk descends into the name it was given, so where that name
+            // leads counts as much as where the ones above it lead.
+            let assert = check_in(&root.join("proj"), &["link"]).assert();
+            assert.failure().stdout(indoc! {"
+                link/ignored.md:1:1: MD018 No space after hash on atx style header
+                link/ignored.md:1:1: MD041 First line in file should be a top level header
+                link/ignored.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
+}
+
+#[cfg(unix)]
+#[test]
 fn check_keeps_a_step_back_that_follows_a_link() -> Result<()> {
     with_tree(
         &[

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::fs::create_dir_all;
+use std::fs::read_to_string;
 use std::fs::write;
 use std::io::Write as _;
 #[cfg(unix)]
@@ -15,6 +16,7 @@ use mado::Config;
 use miette::Context as _;
 use miette::IntoDiagnostic as _;
 use miette::Result;
+use miette::miette;
 use tempfile::tempdir;
 
 fn with_tmp_file<F>(name: &str, content: &str, f: F) -> Result<()>
@@ -266,12 +268,34 @@ fn check_exclusion_default_target_with_dot_slash_prefix() -> Result<()> {
 
 /// Lays out a tree of files under a temporary directory. A path ending in `/`
 /// is created as an empty directory.
+/// Fails where an `.ignore` above `root` takes a path back with a `!` line.
+/// mado reads every parent directory looking for one, so a file like that on
+/// the machine running the tests changes what these trees report, and the
+/// failure would be nothing to do with the tree under test.
+fn nothing_above_takes_a_path_back(root: &Path) -> Result<()> {
+    let at = root.canonicalize().into_diagnostic()?;
+    for over in at.ancestors().skip(1) {
+        let file = over.join(".ignore");
+        let takes_back =
+            read_to_string(&file).is_ok_and(|text| text.lines().any(|line| line.starts_with('!')));
+        if takes_back {
+            return Err(miette!(
+                "{} takes a path back, and these tests need no such file over them",
+                file.display()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn with_tree<F>(entries: &[(&str, &str)], f: F) -> Result<()>
 where
     F: FnOnce(&Path) -> Result<()>,
 {
     let tmp_dir = tempdir().into_diagnostic()?;
     let root = tmp_dir.path();
+    nothing_above_takes_a_path_back(root)?;
     for (path, content) in entries {
         let path = root.join(path);
         if let Some(dir) = path.parent() {

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -684,14 +684,8 @@ fn check_reports_a_broken_glob_in_a_parent_ignore_file() -> Result<()> {
 fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
     with_tree(
         &[
-            ("proj/.ignore", "{a\n"),
-            // An ignore file of its own is what puts a directory in a walk of
-            // its own, and the two walks share the broken file above them.
-            ("proj/d1/.ignore", "x\n"),
+            ("proj/d1/.ignore", "{a\n"),
             ("proj/d1/docs/a.md", "# Fine\n"),
-            ("proj/d2/.ignore", "x\n"),
-            ("proj/d2/docs/a.md", "# Fine\n"),
-            ("proj/sub/keep.md", "# Fine\n"),
         ],
         |root| {
             let proj = root.join("proj");
@@ -701,9 +695,10 @@ fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
             )
             .into_diagnostic()?;
 
-            // The third names the same broken file as the first, by another
-            // route, and it is still one file with one thing wrong with it.
-            let output = check_in(&proj, &["d1/docs", "d2/docs", "sub/../d1/docs"])
+            // Two names for one directory are two walks, each handed the file
+            // above it under the name it walks by, and it is still one file
+            // with one thing wrong with it.
+            let output = check_in(&proj, &["./d1/docs", "d1/docs"])
                 .output()
                 .into_diagnostic()?;
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -712,6 +707,22 @@ fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
                 .filter(|line| line.contains("error parsing glob"))
                 .count();
             assert_eq!(complaints, 1);
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_reports_a_broken_glob_in_the_ignore_file_at_the_path_it_was_given() -> Result<()> {
+    with_tree(
+        &[(".gitignore", "{a\n"), ("docs/a.md", "# Fine\n")],
+        |root| {
+            // The walk reads what is over a root, not what is at one, so mado is
+            // the only reader of this file left to say what it could not parse.
+            let assert = check_in(root, &["."]).assert();
+            assert.success().stderr(indoc! {"
+            ./.gitignore: line 1: error parsing glob '{a': unclosed alternate group; missing '}' (maybe escape '{' with '[{]'?)
+        "});
             Ok(())
         },
     )

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -479,6 +479,33 @@ fn check_reads_gitignore_over_an_ignore_file_it_does_not_respect() -> Result<()>
 }
 
 #[test]
+fn check_reports_a_broken_glob_two_groups_read_once() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/d1/.gitignore", "{a\n"),
+            ("proj/d1/docs/.gitignore", "nothing.md\n"),
+            ("proj/d1/docs/a.md", "# Fine\n"),
+            ("proj/d1/docs/deep/b.md", "# Fine\n"),
+        ],
+        |root| {
+            // The two names need different files handed back, so they walk as
+            // two groups, and the file both are handed is one file with one
+            // thing wrong with it.
+            let output = check_in(&root.join("proj"), &["d1/docs", "d1/docs/deep"])
+                .output()
+                .into_diagnostic()?;
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let complaints = stderr
+                .lines()
+                .filter(|line| line.contains("error parsing glob"))
+                .count();
+            assert_eq!(complaints, 1);
+            Ok(())
+        },
+    )
+}
+
+#[test]
 fn check_keeps_ignore_ahead_of_gitignore_without_git_metadata() -> Result<()> {
     with_tree(CONFLICTING_KINDS, |root| {
         let assert = check_in(&root.join("proj"), &["docs/sub"]).assert();

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -1,4 +1,6 @@
 use std::fs::File;
+use std::fs::create_dir;
+use std::fs::write;
 use std::io::Write as _;
 use std::path::PathBuf;
 
@@ -255,6 +257,59 @@ fn check_exclusion_default_target_with_dot_slash_prefix() -> Result<()> {
             .args(["check", "--exclude", "./test.md"])
             .assert();
         assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+/// Lays out a tree with a `.gitignore` excluding a directory that holds a
+/// Markdown file mado reports on, and no Git metadata anywhere.
+fn with_gitignored_tree<F>(f: F) -> Result<()>
+where
+    F: FnOnce(&PathBuf) -> Result<()>,
+{
+    let tmp_dir = tempdir().into_diagnostic()?;
+    let root = tmp_dir.path().to_path_buf();
+    create_dir(root.join("target")).into_diagnostic()?;
+    write(root.join(".gitignore"), "target/\n").into_diagnostic()?;
+    write(root.join("target/generated.md"), "#Hello.").into_diagnostic()?;
+
+    f(&root)?;
+
+    tmp_dir.close().into_diagnostic()
+}
+
+#[test]
+fn check_respects_gitignore_without_git_metadata() -> Result<()> {
+    with_gitignored_tree(|root| {
+        let mut cmd = Command::new(cargo_bin!("mado"));
+        let assert = cmd.current_dir(root).args(["check", "."]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_without_respect_gitignore_walks_ignored_files() -> Result<()> {
+    with_gitignored_tree(|root| {
+        write(
+            root.join("mado.toml"),
+            "[lint]\nrespect-gitignore = false\n",
+        )
+        .into_diagnostic()?;
+        let mut cmd = Command::new(cargo_bin!("mado"));
+        let assert = cmd
+            .current_dir(root)
+            .env_remove("CLICOLOR_FORCE")
+            .env("NO_COLOR", "1")
+            .args(["check", "."])
+            .assert();
+        assert.failure().stdout(indoc! {"
+            ./target/generated.md:1:1: MD018 No space after hash on atx style header
+            ./target/generated.md:1:1: MD041 First line in file should be a top level header
+            ./target/generated.md:1:1: MD047 File should end with a single newline character
+
+            Found 3 errors.
+        "});
         Ok(())
     })
 }

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -527,6 +527,7 @@ fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
             ("proj/d1/docs/a.md", "# Fine\n"),
             ("proj/d2/.ignore", "x\n"),
             ("proj/d2/docs/a.md", "# Fine\n"),
+            ("proj/sub/keep.md", "# Fine\n"),
         ],
         |root| {
             let proj = root.join("proj");
@@ -536,7 +537,9 @@ fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
             )
             .into_diagnostic()?;
 
-            let output = check_in(&proj, &["d1/docs", "d2/docs"])
+            // The third names the same broken file as the first, by another
+            // route, and it is still one file with one thing wrong with it.
+            let output = check_in(&proj, &["d1/docs", "d2/docs", "sub/../d1/docs"])
                 .output()
                 .into_diagnostic()?;
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -422,6 +422,48 @@ const CONFLICTING_KINDS: &[(&str, &str)] = &[
     ("proj/docs/sub/conflict.md", "#Hello."),
 ];
 
+/// An `.ignore` above the path taking back what a `.gitignore` under it
+/// excludes. The walker ranks the `.ignore` over the `.gitignore` wherever the
+/// two sit; a file handed back to it ranks under both.
+const TAKEN_BACK_FROM_ABOVE: &[(&str, &str)] = &[
+    ("proj/.ignore", "!ignored.md\n"),
+    ("proj/docs/.gitignore", "ignored.md\n"),
+    ("proj/docs/ignored.md", "#Hello."),
+];
+
+#[test]
+fn check_keeps_what_an_ignore_file_above_the_path_takes_back() -> Result<()> {
+    with_tree(TAKEN_BACK_FROM_ABOVE, |root| {
+        // Handing the `.ignore` back would rank it under the `.gitignore` and
+        // drop this file, quietly, where a clone of the same tree keeps it.
+        let assert = check_in(&root.join("proj"), &["docs"]).assert();
+        assert.failure().stdout(indoc! {"
+            docs/ignored.md:1:1: MD018 No space after hash on atx style header
+            docs/ignored.md:1:1: MD041 First line in file should be a top level header
+            docs/ignored.md:1:1: MD047 File should end with a single newline character
+
+            Found 3 errors.
+        "});
+        Ok(())
+    })
+}
+
+#[test]
+fn check_keeps_what_an_ignore_file_above_the_path_takes_back_in_a_repository() -> Result<()> {
+    with_tree(TAKEN_BACK_FROM_ABOVE, |root| {
+        create_dir_all(root.join("proj/.git")).into_diagnostic()?;
+        let assert = check_in(&root.join("proj"), &["docs"]).assert();
+        assert.failure().stdout(indoc! {"
+            docs/ignored.md:1:1: MD018 No space after hash on atx style header
+            docs/ignored.md:1:1: MD041 First line in file should be a top level header
+            docs/ignored.md:1:1: MD047 File should end with a single newline character
+
+            Found 3 errors.
+        "});
+        Ok(())
+    })
+}
+
 #[test]
 fn check_keeps_ignore_ahead_of_gitignore_without_git_metadata() -> Result<()> {
     with_tree(CONFLICTING_KINDS, |root| {

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -465,6 +465,20 @@ fn check_keeps_what_an_ignore_file_above_the_path_takes_back_in_a_repository() -
 }
 
 #[test]
+fn check_reads_gitignore_over_an_ignore_file_it_does_not_respect() -> Result<()> {
+    with_tree(TAKEN_BACK_FROM_ABOVE, |root| {
+        let proj = root.join("proj");
+        write(proj.join("mado.toml"), "[lint]\nrespect-ignore = false\n").into_diagnostic()?;
+
+        // Neither the walk nor mado reads the `.ignore`, so nothing of its
+        // stands over what the walk finds and the `.gitignore` is left to say.
+        let assert = check_in(&proj, &["docs"]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
 fn check_keeps_ignore_ahead_of_gitignore_without_git_metadata() -> Result<()> {
     with_tree(CONFLICTING_KINDS, |root| {
         let assert = check_in(&root.join("proj"), &["docs/sub"]).assert();

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -479,6 +479,21 @@ fn check_reads_gitignore_over_an_ignore_file_it_does_not_respect() -> Result<()>
 }
 
 #[test]
+fn check_reports_every_file_it_cannot_read() -> Result<()> {
+    with_tree(&[], |root| {
+        // Two files with nothing to tell them apart in what the reader says
+        // about them, and each of them is still a file of its own.
+        write(root.join("a.md"), b"\xff\xfe").into_diagnostic()?;
+        write(root.join("b.md"), b"\xff\xfe").into_diagnostic()?;
+
+        let output = check_in(root, &["."]).output().into_diagnostic()?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(stderr.lines().count(), 2);
+        Ok(())
+    })
+}
+
+#[test]
 fn check_reports_a_broken_glob_two_groups_read_once() -> Result<()> {
     with_tree(
         &[

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -490,6 +490,49 @@ fn check_respect_ignore_does_not_depend_on_respect_gitignore() -> Result<()> {
     )
 }
 
+/// A parent `.ignore` whose only pattern the glob parser rejects, alongside a
+/// clean file to lint, and `respect-gitignore` turned off.
+const BROKEN_PARENT_IGNORE: &[(&str, &str)] =
+    &[("proj/.ignore", "{a\n"), ("proj/docs/a.md", "# Fine\n")];
+
+#[test]
+fn check_reports_a_broken_glob_in_a_parent_ignore_file() -> Result<()> {
+    with_tree(BROKEN_PARENT_IGNORE, |root| {
+        let proj = root.join("proj");
+        write(
+            proj.join("mado.toml"),
+            "[lint]\nrespect-gitignore = false\n",
+        )
+        .into_diagnostic()?;
+
+        // With no `.gitignore` to look for, the walk never reads the
+        // directories above the one it was given, so mado is the only reader
+        // left to say what it could not parse.
+        let assert = check_in(&proj, &["docs"]).assert();
+        assert.success().stderr(indoc! {"
+            ./.ignore: line 1: error parsing glob '{a': unclosed alternate group; missing '}' (maybe escape '{' with '[{]'?)
+        "});
+        Ok(())
+    })
+}
+
+#[test]
+fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
+    with_tree(BROKEN_PARENT_IGNORE, |root| {
+        // Here the walk does read them, so saying it again would say it twice.
+        let output = check_in(&root.join("proj"), &["docs"])
+            .output()
+            .into_diagnostic()?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let complaints = stderr
+            .lines()
+            .filter(|line| line.contains("error parsing glob"))
+            .count();
+        assert_eq!(complaints, 1);
+        Ok(())
+    })
+}
+
 #[test]
 fn check_does_not_read_the_current_directory_gitignore_for_a_path_above_it() -> Result<()> {
     with_tree(

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -521,6 +521,33 @@ fn check_reports_a_broken_glob_two_groups_read_once() -> Result<()> {
 }
 
 #[test]
+fn check_says_which_ignore_file_sent_gitignore_back_to_git() -> Result<()> {
+    with_tree(TAKEN_BACK_FROM_ABOVE, |root| {
+        // Two names under the one `.ignore`, and a reader who cannot see why
+        // `.gitignore` stopped applying is told once which file it was.
+        let output = check_in(&root.join("proj"), &["docs", "docs"])
+            .output()
+            .into_diagnostic()?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(stderr.lines().count(), 1);
+        assert!(stderr.contains(".ignore: takes a path back"));
+        Ok(())
+    })
+}
+
+#[test]
+fn check_says_nothing_where_no_ignore_file_is_read() -> Result<()> {
+    with_tree(TAKEN_BACK_FROM_ABOVE, |root| {
+        let proj = root.join("proj");
+        write(proj.join("mado.toml"), "[lint]\nrespect-ignore = false\n").into_diagnostic()?;
+
+        let assert = check_in(&proj, &["docs"]).assert();
+        assert.success().stderr("");
+        Ok(())
+    })
+}
+
+#[test]
 fn check_keeps_ignore_ahead_of_gitignore_without_git_metadata() -> Result<()> {
     with_tree(CONFLICTING_KINDS, |root| {
         let assert = check_in(&root.join("proj"), &["docs/sub"]).assert();

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -637,6 +637,19 @@ fn check_bounds_a_name_that_does_not_lead_where_it_reads() -> Result<()> {
 }
 
 #[test]
+fn check_does_not_bound_a_name_that_does_not_lead_where_it_reads_in_a_repository() -> Result<()> {
+    with_tree(ANCHORED_BELOW_A_SUBDIRECTORY, |root| {
+        create_dir_all(root.join("proj/.git")).into_diagnostic()?;
+
+        // Nothing is handed back in a repository, so nothing rests on how the
+        // name is spelled: the walk finds the files above `docs` itself.
+        let assert = check_in(&root.join("proj"), &["docs/."]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
 fn check_walks_the_directory_a_name_that_undoes_itself_lands_in() -> Result<()> {
     with_tree(
         &[("docs/bad.md", "#Hello."), ("top.md", "#Hello.")],

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -2,6 +2,8 @@ use std::fs::File;
 use std::fs::create_dir_all;
 use std::fs::write;
 use std::io::Write as _;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -474,6 +476,77 @@ fn check_reads_an_anchored_parent_pattern_for_a_path_spelled_with_a_dot() -> Res
             // file above it can be rooted at.
             let assert = check_in(&root.join("proj"), &["docs/."]).assert();
             assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_reads_an_anchored_parent_pattern_for_a_path_spelled_with_a_step_back() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/.gitignore", "/d1/docs/ignored.md\n"),
+            ("proj/d1/docs/ignored.md", "#Hello."),
+            ("proj/d1/docs/keep.md", "# Fine\n"),
+        ],
+        |root| {
+            // Climbing by adding a `..` names a directory the walk's own
+            // answers do not begin with, so the file above has to be rooted at
+            // the name with the step taken out.
+            let assert = check_in(&root.join("proj"), &["d1/docs/../docs"]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[cfg(unix)]
+#[test]
+fn check_does_not_read_the_boundary_gitignore_for_a_tree_a_link_leads_out_to() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/.gitignore", "ignored.md\n"),
+            ("outside/docs/ignored.md", "#Hello."),
+        ],
+        |root| {
+            symlink(root.join("outside"), root.join("proj/link")).into_diagnostic()?;
+
+            // `link/docs` reads as a name under `proj` and is not one.
+            let assert = check_in(&root.join("proj"), &["link/docs"]).assert();
+            assert.failure().stdout(indoc! {"
+                link/docs/ignored.md:1:1: MD018 No space after hash on atx style header
+                link/docs/ignored.md:1:1: MD041 First line in file should be a top level header
+                link/docs/ignored.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
+}
+
+#[cfg(unix)]
+#[test]
+fn check_keeps_a_step_back_that_follows_a_link() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/real/docs/keep.md", "# Fine\n"),
+            ("proj/other/bad.md", "#Hello."),
+        ],
+        |root| {
+            let proj = root.join("proj");
+            symlink("real/docs", proj.join("link")).into_diagnostic()?;
+
+            // `link/..` is where the link led, not `proj`, so the step cannot
+            // be taken out and the name keeps it.
+            let assert = check_in(&proj, &["link/../../other"]).assert();
+            assert.failure().stdout(indoc! {"
+                link/../../other/bad.md:1:1: MD018 No space after hash on atx style header
+                link/../../other/bad.md:1:1: MD041 First line in file should be a top level header
+                link/../../other/bad.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
             Ok(())
         },
     )

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -461,6 +461,40 @@ fn check_keeps_each_spelling_of_a_directory_anchored_to_itself() -> Result<()> {
 }
 
 #[test]
+fn check_reads_an_anchored_parent_pattern_for_a_path_spelled_with_a_dot() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/.gitignore", "/docs/ignored.md\n"),
+            ("proj/docs/ignored.md", "#Hello."),
+            ("proj/docs/keep.md", "# Fine\n"),
+        ],
+        |root| {
+            // A walk names what it finds by joining onto the name it was
+            // given, so a `.` left in the middle of that is a name no ignore
+            // file above it can be rooted at.
+            let assert = check_in(&root.join("proj"), &["docs/."]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_names_a_file_without_the_dots_that_said_nothing() -> Result<()> {
+    with_tree(&[("docs/bad.md", "#Hello.")], |root| {
+        let assert = check_in(root, &["docs/./."]).assert();
+        assert.failure().stdout(indoc! {"
+            docs/bad.md:1:1: MD018 No space after hash on atx style header
+            docs/bad.md:1:1: MD041 First line in file should be a top level header
+            docs/bad.md:1:1: MD047 File should end with a single newline character
+
+            Found 3 errors.
+        "});
+        Ok(())
+    })
+}
+
+#[test]
 fn check_reads_each_root_gitignore_when_only_one_is_in_a_repository() -> Result<()> {
     with_tree(
         &[

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -491,6 +491,50 @@ fn check_respect_ignore_does_not_depend_on_respect_gitignore() -> Result<()> {
 }
 
 #[test]
+fn check_does_not_read_the_current_directory_gitignore_for_a_path_above_it() -> Result<()> {
+    with_tree(
+        &[
+            ("outer/above.md", "#Hello."),
+            ("outer/proj/.gitignore", "above.md\n"),
+            ("outer/proj/keep.md", "# Fine\n"),
+        ],
+        |root| {
+            // `..` climbs out of the directory mado was started in, so that
+            // directory's `.gitignore` has nothing to say about what is there.
+            let assert = check_in(&root.join("outer/proj"), &[".."]).assert();
+            assert.failure().stdout(indoc! {"
+                ../above.md:1:1: MD018 No space after hash on atx style header
+                ../above.md:1:1: MD041 First line in file should be a top level header
+                ../above.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_lints_a_file_it_is_handed_though_gitignore_lists_it() -> Result<()> {
+    with_tree(
+        &[(".gitignore", "ignored.md\n"), ("ignored.md", "#Hello.")],
+        |root| {
+            // Naming a file is asking for it, and the walk hands one back
+            // without asking any ignore file about it.
+            let assert = check_in(root, &["ignored.md"]).assert();
+            assert.failure().stdout(indoc! {"
+                ignored.md:1:1: MD018 No space after hash on atx style header
+                ignored.md:1:1: MD041 First line in file should be a top level header
+                ignored.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
+}
+
+#[test]
 fn check_does_not_read_a_gitignore_above_the_current_directory() -> Result<()> {
     with_tree(
         &[(".gitignore", "leaked.md\n"), ("proj/leaked.md", "#Hello.")],

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -266,8 +266,6 @@ fn check_exclusion_default_target_with_dot_slash_prefix() -> Result<()> {
     })
 }
 
-/// Lays out a tree of files under a temporary directory. A path ending in `/`
-/// is created as an empty directory.
 /// Fails where an `.ignore` above `root` takes a path back with a `!` line.
 /// mado reads every parent directory looking for one, so a file like that on
 /// the machine running the tests changes what these trees report, and the
@@ -289,6 +287,8 @@ fn nothing_above_takes_a_path_back(root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Lays out a tree of files under a temporary directory. A path ending in `/`
+/// is created as an empty directory.
 fn with_tree<F>(entries: &[(&str, &str)], f: F) -> Result<()>
 where
     F: FnOnce(&Path) -> Result<()>,
@@ -558,6 +558,20 @@ fn check_says_which_ignore_file_sent_gitignore_back_to_git() -> Result<()> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert_eq!(stderr.lines().count(), 1);
         assert!(stderr.contains(".ignore: takes a path back"));
+        Ok(())
+    })
+}
+
+#[test]
+fn check_says_nothing_about_a_path_that_is_not_a_directory() -> Result<()> {
+    with_tree(TAKEN_BACK_FROM_ABOVE, |root| {
+        let proj = root.join("proj");
+        write(proj.join("loose.md"), "# Fine\n").into_diagnostic()?;
+
+        // The walk hands a file back without asking any ignore file about it,
+        // so which files mado would have handed over changes nothing for it.
+        let assert = check_in(&proj, &["loose.md"]).assert();
+        assert.success().stderr("");
         Ok(())
     })
 }

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -1,7 +1,8 @@
 use std::fs::File;
-use std::fs::create_dir;
+use std::fs::create_dir_all;
 use std::fs::write;
 use std::io::Write as _;
+use std::path::Path;
 use std::path::PathBuf;
 
 use assert_cmd::Command;
@@ -261,28 +262,54 @@ fn check_exclusion_default_target_with_dot_slash_prefix() -> Result<()> {
     })
 }
 
-/// Lays out a tree with a `.gitignore` excluding a directory that holds a
-/// Markdown file mado reports on, and no Git metadata anywhere.
-fn with_gitignored_tree<F>(f: F) -> Result<()>
+/// Lays out a tree of files under a temporary directory. A path ending in `/`
+/// is created as an empty directory.
+fn with_tree<F>(entries: &[(&str, &str)], f: F) -> Result<()>
 where
-    F: FnOnce(&PathBuf) -> Result<()>,
+    F: FnOnce(&Path) -> Result<()>,
 {
     let tmp_dir = tempdir().into_diagnostic()?;
-    let root = tmp_dir.path().to_path_buf();
-    create_dir(root.join("target")).into_diagnostic()?;
-    write(root.join(".gitignore"), "target/\n").into_diagnostic()?;
-    write(root.join("target/generated.md"), "#Hello.").into_diagnostic()?;
+    let root = tmp_dir.path();
+    for (path, content) in entries {
+        let path = root.join(path);
+        if let Some(dir) = path.parent() {
+            create_dir_all(dir).into_diagnostic()?;
+        }
+        if content.is_empty() && path.to_string_lossy().ends_with('/') {
+            create_dir_all(&path).into_diagnostic()?;
+        } else {
+            write(&path, content).into_diagnostic()?;
+        }
+    }
 
-    f(&root)?;
+    f(root)?;
 
     tmp_dir.close().into_diagnostic()
 }
 
+/// A `mado check` run rooted in `dir`, with colour out of the way.
+fn check_in(dir: &Path, args: &[&str]) -> Command {
+    let mut cmd = Command::new(cargo_bin!("mado"));
+    cmd.current_dir(dir)
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
+        .arg("check")
+        .args(args);
+    cmd
+}
+
+/// A tree whose `.gitignore` lists a directory mado would otherwise report on,
+/// with no Git metadata anywhere: what a source archive or a Docker context
+/// copied without `.git` looks like.
+const IGNORED_BUILD_OUTPUT: &[(&str, &str)] = &[
+    (".gitignore", "target/\n"),
+    ("target/generated.md", "#Hello."),
+];
+
 #[test]
 fn check_respects_gitignore_without_git_metadata() -> Result<()> {
-    with_gitignored_tree(|root| {
-        let mut cmd = Command::new(cargo_bin!("mado"));
-        let assert = cmd.current_dir(root).args(["check", "."]).assert();
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
+        let assert = check_in(root, &["."]).assert();
         assert.success().stdout("All checks passed!\n");
         Ok(())
     })
@@ -290,19 +317,13 @@ fn check_respects_gitignore_without_git_metadata() -> Result<()> {
 
 #[test]
 fn check_without_respect_gitignore_walks_ignored_files() -> Result<()> {
-    with_gitignored_tree(|root| {
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
         write(
             root.join("mado.toml"),
             "[lint]\nrespect-gitignore = false\n",
         )
         .into_diagnostic()?;
-        let mut cmd = Command::new(cargo_bin!("mado"));
-        let assert = cmd
-            .current_dir(root)
-            .env_remove("CLICOLOR_FORCE")
-            .env("NO_COLOR", "1")
-            .args(["check", "."])
-            .assert();
+        let assert = check_in(root, &["."]).assert();
         assert.failure().stdout(indoc! {"
             ./target/generated.md:1:1: MD018 No space after hash on atx style header
             ./target/generated.md:1:1: MD041 First line in file should be a top level header
@@ -312,4 +333,175 @@ fn check_without_respect_gitignore_walks_ignored_files() -> Result<()> {
         "});
         Ok(())
     })
+}
+
+/// A project whose root `.gitignore` excludes a file in a subdirectory, linted
+/// by naming that subdirectory rather than the root.
+const IGNORED_BELOW_A_SUBDIRECTORY: &[(&str, &str)] = &[
+    ("proj/.gitignore", "docs/generated.md\n"),
+    ("proj/docs/generated.md", "#Hello."),
+    ("proj/docs/keep.md", "# Fine\n"),
+];
+
+#[test]
+fn check_subdirectory_reads_the_project_root_gitignore_without_git_metadata() -> Result<()> {
+    with_tree(IGNORED_BELOW_A_SUBDIRECTORY, |root| {
+        let assert = check_in(&root.join("proj"), &["docs"]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_subdirectory_reads_the_project_root_gitignore_with_git_metadata() -> Result<()> {
+    with_tree(IGNORED_BELOW_A_SUBDIRECTORY, |root| {
+        create_dir_all(root.join("proj/.git")).into_diagnostic()?;
+        let assert = check_in(&root.join("proj"), &["docs"]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_subdirectory_reads_the_project_root_gitignore_with_jj_metadata() -> Result<()> {
+    with_tree(IGNORED_BELOW_A_SUBDIRECTORY, |root| {
+        create_dir_all(root.join("proj/.jj")).into_diagnostic()?;
+        let assert = check_in(&root.join("proj"), &["docs"]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+/// Two `.gitignore` files whose patterns are anchored to their own directory,
+/// so a pattern read against the wrong root matches the wrong file.
+const ANCHORED_AT_TWO_LEVELS: &[(&str, &str)] = &[
+    ("proj/.gitignore", "/only-at-top.md\n"),
+    ("proj/docs/.gitignore", "/sub/only-in-sub.md\n"),
+    ("proj/docs/sub/only-at-top.md", "#Hello."),
+    ("proj/docs/sub/only-in-sub.md", "#Hello."),
+    ("proj/docs/sub/keep.md", "# Fine\n"),
+];
+
+/// Only `only-in-sub.md` is anchored at a directory that contains it, so it is
+/// the only one of the two the walk drops.
+const ANCHORED_AT_TWO_LEVELS_REPORT: &str = indoc! {"
+    docs/sub/only-at-top.md:1:1: MD018 No space after hash on atx style header
+    docs/sub/only-at-top.md:1:1: MD041 First line in file should be a top level header
+    docs/sub/only-at-top.md:1:1: MD047 File should end with a single newline character
+
+    Found 3 errors.
+"};
+
+#[test]
+fn check_keeps_gitignore_anchoring_per_directory_without_git_metadata() -> Result<()> {
+    with_tree(ANCHORED_AT_TWO_LEVELS, |root| {
+        let assert = check_in(&root.join("proj"), &["docs/sub"]).assert();
+        assert.failure().stdout(ANCHORED_AT_TWO_LEVELS_REPORT);
+        Ok(())
+    })
+}
+
+#[test]
+fn check_keeps_gitignore_anchoring_per_directory_with_git_metadata() -> Result<()> {
+    with_tree(ANCHORED_AT_TWO_LEVELS, |root| {
+        create_dir_all(root.join("proj/.git")).into_diagnostic()?;
+        let assert = check_in(&root.join("proj"), &["docs/sub"]).assert();
+        assert.failure().stdout(ANCHORED_AT_TWO_LEVELS_REPORT);
+        Ok(())
+    })
+}
+
+#[test]
+fn check_reads_each_root_gitignore_when_only_one_is_in_a_repository() -> Result<()> {
+    with_tree(
+        &[
+            ("repo/.git/HEAD", "ref: refs/heads/main\n"),
+            ("repo/.gitignore", "ignored.md\n"),
+            ("repo/ignored.md", "#Hello."),
+            ("archive/.gitignore", "ignored.md\n"),
+            ("archive/ignored.md", "#Hello."),
+        ],
+        |root| {
+            let assert = check_in(root, &["repo", "archive"]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_respect_ignore_does_not_depend_on_respect_gitignore() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/.ignore", "skipped.md\n"),
+            ("proj/docs/skipped.md", "#Hello."),
+        ],
+        |root| {
+            let proj = root.join("proj");
+            for respect_ignore in [true, false] {
+                for respect_gitignore in [true, false] {
+                    let config = formatdoc! {"
+                        [lint]
+                        respect-ignore = {respect_ignore}
+                        respect-gitignore = {respect_gitignore}
+                    "};
+                    write(proj.join("mado.toml"), config).into_diagnostic()?;
+
+                    // `.ignore` decides this on its own: `respect-gitignore`
+                    // must not move the directories `.ignore` is read from.
+                    let assert = check_in(&proj, &["docs"]).assert();
+                    if respect_ignore {
+                        assert.success();
+                    } else {
+                        assert.failure();
+                    }
+                }
+            }
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_does_not_read_a_gitignore_above_the_current_directory() -> Result<()> {
+    with_tree(
+        &[(".gitignore", "leaked.md\n"), ("proj/leaked.md", "#Hello.")],
+        |root| {
+            let assert = check_in(&root.join("proj"), &["."]).assert();
+            assert.failure().stdout(indoc! {"
+                ./leaked.md:1:1: MD018 No space after hash on atx style header
+                ./leaked.md:1:1: MD041 First line in file should be a top level header
+                ./leaked.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_does_not_read_the_global_git_ignore_file() -> Result<()> {
+    with_tree(
+        &[
+            ("home/.config/git/ignore", "globally-ignored.md\n"),
+            ("proj/globally-ignored.md", "#Hello."),
+        ],
+        |root| {
+            let home = root.join("home");
+            let mut cmd = check_in(&root.join("proj"), &["."]);
+            let assert = cmd
+                .env("HOME", &home)
+                .env("XDG_CONFIG_HOME", home.join(".config"))
+                .assert();
+            assert.failure().stdout(indoc! {"
+                ./globally-ignored.md:1:1: MD018 No space after hash on atx style header
+                ./globally-ignored.md:1:1: MD041 First line in file should be a top level header
+                ./globally-ignored.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
 }

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -518,19 +518,36 @@ fn check_reports_a_broken_glob_in_a_parent_ignore_file() -> Result<()> {
 
 #[test]
 fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
-    with_tree(BROKEN_PARENT_IGNORE, |root| {
-        // Here the walk does read them, so saying it again would say it twice.
-        let output = check_in(&root.join("proj"), &["docs"])
-            .output()
+    with_tree(
+        &[
+            ("proj/.ignore", "{a\n"),
+            // An ignore file of its own is what puts a directory in a walk of
+            // its own, and the two walks share the broken file above them.
+            ("proj/d1/.ignore", "x\n"),
+            ("proj/d1/docs/a.md", "# Fine\n"),
+            ("proj/d2/.ignore", "x\n"),
+            ("proj/d2/docs/a.md", "# Fine\n"),
+        ],
+        |root| {
+            let proj = root.join("proj");
+            write(
+                proj.join("mado.toml"),
+                "[lint]\nrespect-gitignore = false\n",
+            )
             .into_diagnostic()?;
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let complaints = stderr
-            .lines()
-            .filter(|line| line.contains("error parsing glob"))
-            .count();
-        assert_eq!(complaints, 1);
-        Ok(())
-    })
+
+            let output = check_in(&proj, &["d1/docs", "d2/docs"])
+                .output()
+                .into_diagnostic()?;
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let complaints = stderr
+                .lines()
+                .filter(|line| line.contains("error parsing glob"))
+                .count();
+            assert_eq!(complaints, 1);
+            Ok(())
+        },
+    )
 }
 
 #[test]

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -707,6 +707,21 @@ fn check_reports_a_broken_glob_in_a_parent_ignore_file() -> Result<()> {
 }
 
 #[test]
+fn check_leaves_a_broken_glob_the_walk_reads_to_the_walk() -> Result<()> {
+    with_tree(
+        &[(".gitignore", "{a\n"), ("docs/a.md", "# Fine\n")],
+        |root| {
+            // What the walk reads it reports for itself, and what it makes of a
+            // file at a root rather than over one it keeps to itself. mado says
+            // neither of those over again.
+            let assert = check_in(root, &["."]).assert();
+            assert.success().stderr("");
+            Ok(())
+        },
+    )
+}
+
+#[test]
 fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
     with_tree(
         &[
@@ -733,22 +748,6 @@ fn check_reports_a_broken_glob_in_a_parent_ignore_file_once() -> Result<()> {
                 .filter(|line| line.contains("error parsing glob"))
                 .count();
             assert_eq!(complaints, 1);
-            Ok(())
-        },
-    )
-}
-
-#[test]
-fn check_reports_a_broken_glob_in_the_ignore_file_at_the_path_it_was_given() -> Result<()> {
-    with_tree(
-        &[(".gitignore", "{a\n"), ("docs/a.md", "# Fine\n")],
-        |root| {
-            // The walk reads what is over a root, not what is at one, so mado is
-            // the only reader of this file left to say what it could not parse.
-            let assert = check_in(root, &["."]).assert();
-            assert.success().stderr(indoc! {"
-            ./.gitignore: line 1: error parsing glob '{a': unclosed alternate group; missing '}' (maybe escape '{' with '[{]'?)
-        "});
             Ok(())
         },
     )

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -452,8 +452,11 @@ fn check_keeps_what_an_ignore_file_above_the_path_takes_back() -> Result<()> {
 fn check_keeps_what_an_ignore_file_above_the_path_takes_back_in_a_repository() -> Result<()> {
     with_tree(TAKEN_BACK_FROM_ABOVE, |root| {
         create_dir_all(root.join("proj/.git")).into_diagnostic()?;
+
+        // The walker finds these files itself here, so there is nothing for
+        // mado to arrange and nothing to say about having left it alone.
         let assert = check_in(&root.join("proj"), &["docs"]).assert();
-        assert.failure().stdout(indoc! {"
+        assert.failure().stderr("").stdout(indoc! {"
             docs/ignored.md:1:1: MD018 No space after hash on atx style header
             docs/ignored.md:1:1: MD041 First line in file should be a top level header
             docs/ignored.md:1:1: MD047 File should end with a single newline character

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -451,53 +451,54 @@ fn check_keeps_each_spelling_of_a_directory_anchored_to_itself() -> Result<()> {
             ("proj/sub/keep.md", "# Fine\n"),
         ],
         |root| {
-            // A walk yields paths built from the name its pattern was written
-            // as, so the boundary's `.gitignore` has to be rooted at that name
-            // for an anchored pattern in it to line up. Two names for one
-            // directory need one walk each.
+            // The plain name reads what is above it; the one that steps back
+            // over itself bounds itself, and the walk of each is its own.
             let assert = check_in(&root.join("proj"), &["./d1/docs", "sub/../d1/docs"]).assert();
-            assert.success().stdout("All checks passed!\n");
+            assert.failure().stdout(indoc! {"
+                sub/../d1/docs/ignored.md:1:1: MD018 No space after hash on atx style header
+                sub/../d1/docs/ignored.md:1:1: MD041 First line in file should be a top level header
+                sub/../d1/docs/ignored.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
             Ok(())
         },
     )
 }
 
+/// A project whose root `.gitignore` excludes a file in a subdirectory by a
+/// pattern anchored to that root, which only reaches a name it prefixes.
+const ANCHORED_BELOW_A_SUBDIRECTORY: &[(&str, &str)] = &[
+    ("proj/.gitignore", "/docs/ignored.md\n"),
+    ("proj/docs/ignored.md", "#Hello."),
+    ("proj/docs/keep.md", "# Fine\n"),
+];
+
 #[test]
-fn check_reads_an_anchored_parent_pattern_for_a_path_spelled_with_a_dot() -> Result<()> {
-    with_tree(
-        &[
-            ("proj/.gitignore", "/docs/ignored.md\n"),
-            ("proj/docs/ignored.md", "#Hello."),
-            ("proj/docs/keep.md", "# Fine\n"),
-        ],
-        |root| {
-            // A walk names what it finds by joining onto the name it was
-            // given, so a `.` left in the middle of that is a name no ignore
-            // file above it can be rooted at.
-            let assert = check_in(&root.join("proj"), &["docs/."]).assert();
-            assert.success().stdout("All checks passed!\n");
-            Ok(())
-        },
-    )
+fn check_reads_an_anchored_parent_pattern_for_a_name_that_leads_where_it_reads() -> Result<()> {
+    with_tree(ANCHORED_BELOW_A_SUBDIRECTORY, |root| {
+        let assert = check_in(&root.join("proj"), &["./docs"]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
 }
 
 #[test]
-fn check_reads_an_anchored_parent_pattern_for_a_path_spelled_with_a_step_back() -> Result<()> {
-    with_tree(
-        &[
-            ("proj/.gitignore", "/d1/docs/ignored.md\n"),
-            ("proj/d1/docs/ignored.md", "#Hello."),
-            ("proj/d1/docs/keep.md", "# Fine\n"),
-        ],
-        |root| {
-            // Climbing by adding a `..` names a directory the walk's own
-            // answers do not begin with, so the file above has to be rooted at
-            // the name with the step taken out.
-            let assert = check_in(&root.join("proj"), &["d1/docs/../docs"]).assert();
-            assert.success().stdout("All checks passed!\n");
-            Ok(())
-        },
-    )
+fn check_bounds_a_name_that_does_not_lead_where_it_reads() -> Result<()> {
+    with_tree(ANCHORED_BELOW_A_SUBDIRECTORY, |root| {
+        // `docs/.` has the walk answering about `docs/./ignored.md`, which no
+        // ignore file above `docs` can be rooted at a name for, so the path
+        // bounds itself and what is above it goes unread.
+        let assert = check_in(&root.join("proj"), &["docs/."]).assert();
+        assert.failure().stdout(indoc! {"
+            docs/./ignored.md:1:1: MD018 No space after hash on atx style header
+            docs/./ignored.md:1:1: MD041 First line in file should be a top level header
+            docs/./ignored.md:1:1: MD047 File should end with a single newline character
+
+            Found 3 errors.
+        "});
+        Ok(())
+    })
 }
 
 #[test]
@@ -508,12 +509,12 @@ fn check_walks_the_directory_a_name_that_undoes_itself_lands_in() -> Result<()> 
             // `docs/..` is the directory mado was started in, not nothing at all.
             let assert = check_in(root, &["docs/.."]).assert();
             assert.failure().stdout(indoc! {"
-            ./docs/bad.md:1:1: MD018 No space after hash on atx style header
-            ./docs/bad.md:1:1: MD041 First line in file should be a top level header
-            ./docs/bad.md:1:1: MD047 File should end with a single newline character
-            ./top.md:1:1: MD018 No space after hash on atx style header
-            ./top.md:1:1: MD041 First line in file should be a top level header
-            ./top.md:1:1: MD047 File should end with a single newline character
+            docs/../docs/bad.md:1:1: MD018 No space after hash on atx style header
+            docs/../docs/bad.md:1:1: MD041 First line in file should be a top level header
+            docs/../docs/bad.md:1:1: MD047 File should end with a single newline character
+            docs/../top.md:1:1: MD018 No space after hash on atx style header
+            docs/../top.md:1:1: MD041 First line in file should be a top level header
+            docs/../top.md:1:1: MD047 File should end with a single newline character
 
             Found 6 errors.
         "});
@@ -575,39 +576,15 @@ fn check_does_not_read_the_boundary_gitignore_for_a_link_named_on_its_own() -> R
 
 #[cfg(unix)]
 #[test]
-fn check_keeps_a_step_back_that_follows_a_link() -> Result<()> {
-    with_tree(
-        &[
-            ("proj/real/docs/keep.md", "# Fine\n"),
-            ("proj/other/bad.md", "#Hello."),
-        ],
-        |root| {
-            let proj = root.join("proj");
-            symlink("real/docs", proj.join("link")).into_diagnostic()?;
-
-            // `link/..` is where the link led, not `proj`, so the step cannot
-            // be taken out and the name keeps it.
-            let assert = check_in(&proj, &["link/../../other"]).assert();
-            assert.failure().stdout(indoc! {"
-                link/../../other/bad.md:1:1: MD018 No space after hash on atx style header
-                link/../../other/bad.md:1:1: MD041 First line in file should be a top level header
-                link/../../other/bad.md:1:1: MD047 File should end with a single newline character
-
-                Found 3 errors.
-            "});
-            Ok(())
-        },
-    )
-}
-
-#[test]
-fn check_names_a_file_without_the_dots_that_said_nothing() -> Result<()> {
+fn check_names_a_file_the_way_the_command_named_the_path() -> Result<()> {
     with_tree(&[("docs/bad.md", "#Hello.")], |root| {
+        // What is reported is built by joining onto the name mado was given,
+        // and mado does not rewrite that name.
         let assert = check_in(root, &["docs/./."]).assert();
         assert.failure().stdout(indoc! {"
-            docs/bad.md:1:1: MD018 No space after hash on atx style header
-            docs/bad.md:1:1: MD041 First line in file should be a top level header
-            docs/bad.md:1:1: MD047 File should end with a single newline character
+            docs/././bad.md:1:1: MD018 No space after hash on atx style header
+            docs/././bad.md:1:1: MD041 First line in file should be a top level header
+            docs/././bad.md:1:1: MD047 File should end with a single newline character
 
             Found 3 errors.
         "});

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -562,6 +562,50 @@ fn check_says_which_ignore_file_sent_gitignore_back_to_git() -> Result<()> {
     })
 }
 
+/// A repository below the path being linted, holding a file the `.gitignore`
+/// above the repository names.
+const REPOSITORY_BELOW: &[(&str, &str)] = &[
+    ("proj/.gitignore", "lib/\n"),
+    ("proj/vendor/lib/inner.md", "#Hello."),
+];
+
+#[test]
+fn check_applies_a_gitignore_above_a_repository_inside_it() -> Result<()> {
+    with_tree(REPOSITORY_BELOW, |root| {
+        let proj = root.join("proj");
+        create_dir_all(proj.join("vendor/.git")).into_diagnostic()?;
+
+        // Git would not ignore this file: `proj/.gitignore` is outside the
+        // repository holding it. mado has one flag for two jobs -- reading
+        // `.gitignore` without Git metadata also stops the walker bounding
+        // itself at a repository below -- so the file is excluded here and
+        // `main` reports it. This pins #440 rather than blessing it.
+        let assert = check_in(&proj, &["."]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_applies_a_gitignore_above_a_repository_the_path_is_in() -> Result<()> {
+    with_tree(REPOSITORY_BELOW, |root| {
+        let proj = root.join("proj");
+        create_dir_all(proj.join("vendor/.git")).into_diagnostic()?;
+
+        // Named from inside the repository, the boundary is the repository
+        // root and nothing above it is read, which is what Git does.
+        let assert = check_in(&proj.join("vendor"), &["."]).assert();
+        assert.failure().stdout(indoc! {"
+            ./lib/inner.md:1:1: MD018 No space after hash on atx style header
+            ./lib/inner.md:1:1: MD041 First line in file should be a top level header
+            ./lib/inner.md:1:1: MD047 File should end with a single newline character
+
+            Found 3 errors.
+        "});
+        Ok(())
+    })
+}
+
 #[test]
 fn check_says_nothing_about_a_path_that_is_not_a_directory() -> Result<()> {
     with_tree(TAKEN_BACK_FROM_ABOVE, |root| {

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -440,6 +440,27 @@ fn check_keeps_ignore_ahead_of_gitignore_with_git_metadata() -> Result<()> {
 }
 
 #[test]
+fn check_keeps_each_spelling_of_a_directory_anchored_to_itself() -> Result<()> {
+    with_tree(
+        &[
+            ("proj/.gitignore", "/d1/docs/ignored.md\n"),
+            ("proj/d1/docs/ignored.md", "#Hello."),
+            ("proj/d1/docs/keep.md", "# Fine\n"),
+            ("proj/sub/keep.md", "# Fine\n"),
+        ],
+        |root| {
+            // A walk yields paths built from the name its pattern was written
+            // as, so the boundary's `.gitignore` has to be rooted at that name
+            // for an anchored pattern in it to line up. Two names for one
+            // directory need one walk each.
+            let assert = check_in(&root.join("proj"), &["./d1/docs", "sub/../d1/docs"]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
 fn check_reads_each_root_gitignore_when_only_one_is_in_a_repository() -> Result<()> {
     with_tree(
         &[

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -411,6 +411,34 @@ fn check_keeps_gitignore_anchoring_per_directory_with_git_metadata() -> Result<(
     })
 }
 
+/// An `.ignore` and a `.gitignore` in different parent directories disagreeing
+/// about the same file. `.ignore` wins wherever either sits, so the file is
+/// dropped and mado has nothing to report.
+const CONFLICTING_KINDS: &[(&str, &str)] = &[
+    ("proj/.ignore", "docs/sub/conflict.md\n"),
+    ("proj/docs/.gitignore", "!sub/conflict.md\n"),
+    ("proj/docs/sub/conflict.md", "#Hello."),
+];
+
+#[test]
+fn check_keeps_ignore_ahead_of_gitignore_without_git_metadata() -> Result<()> {
+    with_tree(CONFLICTING_KINDS, |root| {
+        let assert = check_in(&root.join("proj"), &["docs/sub"]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_keeps_ignore_ahead_of_gitignore_with_git_metadata() -> Result<()> {
+    with_tree(CONFLICTING_KINDS, |root| {
+        create_dir_all(root.join("proj/.git")).into_diagnostic()?;
+        let assert = check_in(&root.join("proj"), &["docs/sub"]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
 #[test]
 fn check_reads_each_root_gitignore_when_only_one_is_in_a_repository() -> Result<()> {
     with_tree(

--- a/tests/command_check_without_git_metadata.rs
+++ b/tests/command_check_without_git_metadata.rs
@@ -1,13 +1,15 @@
-//! A tree that has lost its Git metadata, and a clone of the same tree, are
-//! linted by walks that reach their ignore files by different routes: the
-//! walker finds them for a clone, and mado hands them back for an archive.
-//! What the two must never do is disagree in the direction that hides
-//! something -- an archive dropping a file its clone reports.
+//! `mado check` over a tree that has lost its Git metadata -- a source
+//! archive, a Docker context copied without `.git` -- against `mado check`
+//! over a clone of the same tree. The two reach their ignore files by
+//! different routes: the walker finds them for a clone, and mado hands them
+//! back where there is no repository to find them by. What they must never do
+//! is disagree in the direction that hides something: a tree without the
+//! metadata dropping a file its clone reports.
 //!
-//! The trees here are generated rather than written out, because the shapes
-//! that have broken this are the ones nobody thought to write: an ignore file
-//! two levels up taking back what one below it excludes, a pattern anchored to
-//! a directory the walk names another way.
+//! The trees here are laid out by pairing rather than written out one by one,
+//! because the shapes that have broken this are the ones nobody thought to
+//! write: an ignore file two levels up taking back what one below it excludes,
+//! a pattern anchored to a directory the walk names another way.
 
 extern crate alloc;
 

--- a/tests/command_check_without_git_metadata.rs
+++ b/tests/command_check_without_git_metadata.rs
@@ -14,12 +14,12 @@
 extern crate alloc;
 
 use alloc::collections::BTreeSet;
-use std::fs::{create_dir_all, remove_dir_all, remove_file, write};
+use std::fs::{create_dir_all, read_to_string, remove_dir_all, remove_file, write};
 use std::path::Path;
 
 use assert_cmd::Command;
 use assert_cmd::cargo_bin;
-use miette::{IntoDiagnostic as _, Result};
+use miette::{IntoDiagnostic as _, Result, miette};
 use tempfile::tempdir;
 
 /// Directories the trees are built out of.
@@ -158,10 +158,32 @@ fn reported(at: &Path, name: &str) -> Result<BTreeSet<String>> {
         .collect())
 }
 
+/// Fails where an `.ignore` above `root` takes a path back with a `!` line.
+/// mado reads every parent directory looking for one, so a file like that on
+/// the machine running the tests changes what these trees report, and the
+/// failure would be nothing to do with the tree under test.
+fn nothing_above_takes_a_path_back(root: &Path) -> Result<()> {
+    let at = root.canonicalize().into_diagnostic()?;
+    for over in at.ancestors().skip(1) {
+        let file = over.join(".ignore");
+        let takes_back =
+            read_to_string(&file).is_ok_and(|text| text.lines().any(|line| line.starts_with('!')));
+        if takes_back {
+            return Err(miette!(
+                "{} takes a path back, and these tests need no such file over them",
+                file.display()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 #[test]
 fn an_archive_reports_everything_a_clone_of_it_does() -> Result<()> {
     for (at, shape) in shapes().iter().enumerate() {
         let tmp_dir = tempdir().into_diagnostic()?;
+        nothing_above_takes_a_path_back(tmp_dir.path())?;
         let proj = tmp_dir.path().join("proj");
         write_tree(&proj, shape, at as u64)?;
 


### PR DESCRIPTION
Closes #346.

## What this implements

The decision recorded in #346, with the boundary decided **per path given to
`mado check`** rather than once for the whole walk:

| Path being linted | Boundary for its ignore files |
|---|---|
| sits in a repository (`.git` directory, `.git` file, or `.jj`) | the repository root |
| otherwise, below the directory mado was started in | that directory — the one `mado.toml` is looked for in |
| otherwise | the path itself |

`respect-gitignore` was passed straight to `WalkBuilder::git_ignore`. That
builder has a separate `require_git` setting, defaulting to `true`, that mado
never touched: with the option on but no `.git` present, `.gitignore` was
silently not consulted at all. This is one of the two root causes behind #141 —
a build or packaging environment that has the source tree but not `.git` walks
and lints everything `.gitignore` lists.

Inside a repository the walker's own parent search already stops at the
repository root and stays in charge. Outside one, mado turns that search off
and hands the ignore files between the boundary and the path back to the walker
one directory at a time. `WalkBuilder::add_ignore` roots each file it is given
at whatever `current_dir` was last set to, so setting it per directory keeps
every file's patterns anchored where they were written.

## Review rounds

**Round 1** — the boundary was decided once for the whole walk. Roots were
judged together, so one path in a repository decided the answer for every other
one; the bound sat at the traversal root rather than a project root, so
`mado check docs` skipped the project's own `.gitignore`; and the switch that
bounds `.gitignore` bounds `.ignore` too, so `respect-gitignore` moved the
directories `.ignore` was read from. Fixed by deciding per path and putting the
files above it back.

**Round 2** — putting them back through one flat `add_ignore` list lost the
ranking between the two kinds. The walker takes the last file handed to it as
the one that wins, so the nearer file won whichever kind it was, where in a
repository an `.ignore` wins over a `.gitignore` wherever either sits: a tree
with both in different parent directories linted differently with and without
`.git`. And one walker per path meant one thread pool per path.

Fixed by handing every `.gitignore` in before any `.ignore` so the kinds stay
ranked, each outermost first so the nearer file still wins within a kind, and
by grouping paths that agree into one walker.

**Round 3** — that grouping keyed on the *directories* a path reads ignore
files from, so paths under one boundary but in different directories still got
a walker each. A file in each of 200 directories still built 200 walkers.

What a group has to agree on is the ignore files themselves, and a directory
holding none contributes none, so the key is those instead. The walk up looking
for a repository is merged into the walk up collecting directories, and the
directories above the boundary are answered for once, so a path costs a couple
of questions rather than a scan to the filesystem root. Measured against
`main`, five runs each:

| | `main` | this branch |
|---|---|---|
| `mado check ./*/*.md`, 200 files in 200 directories | 0.302s | 0.299s |
| `mado check ./*.md`, 200 files in one directory | 0.099s | 0.077s |
| `mado check .` | 0.090s | 0.085s |

Before this round the first row was 6.35s.

**Round 4** — two more from review, and one rejected.

`Path::parent` drops the last component, which walks the wrong way when that
component is a `..`: the directory `..` sits in came out as the empty path,
which reads as the directory mado was started in, so `mado check ..` put that
directory's `.gitignore` to work on the tree above it. It climbs with a `..` of
its own now, and such a path bounds itself like any other name that leaves the
boundary.

The walker hands back a path that is not a directory without asking any ignore
file about it (`walk.rs`, `Worker::run_one`) — naming a file is asking for it —
so working out which files to read for one, and splitting the walk over the
answer, changed nothing and cost everything. Both are skipped. That closes the
one shape still paying for the reconstruction: a file in each of 200
directories, every one holding a `.gitignore`, went from ~0.96s a run to 0.033s
against `main`'s 0.035s.

Rejected: a report that `drop(builder.add_ignore(file))` hides a broken glob
from the user, on the grounds that the walker reads those files itself and
prints what it cannot parse. Adding a report there printed the same line twice.

**Round 5** — that rejection was half right, and review caught the other half.
The walker only looks above a root while it has a `.gitignore` to look for, so
with `respect-gitignore = false` it never reads a parent `.ignore` at all and
the diagnostic `main` prints was lost. It is printed in that case now, and only
in that case. Both directions have a test.

The same round corrected the comment beside `parents(false)`: it does not stop
the walker looking above a root — that is how the errors arrive — it leaves
what is found there out of the matching.

And it turned up a third gap of the #437/#438 family, tracked as #440. A
repository *below* a path that is not itself in one keeps its own boundary in a
clone and loses it in an archive, because `require_git` decides both whether
`.gitignore` applies outside a repository and whether the walk stops at a
repository it descends into, and this branch needs it off for the first. So
`mado check .` over a tree holding a clone drops files inside that clone which
the clone's own `.git` would have kept. README says so.

**Round 6** — the benchmarks had been measuring the wrong shape. A directory
carrying an ignore file of its own needs a walk of its own, and every earlier
timing named *files*, which since round 4 need nothing read for them and share
one walk. Naming directories splits them: `mado check packages/*/docs` over an
archive of a 200-package monorepo built 200 walks, each starting a thread per
core and reading the table of file types back in for a handful of files, and
took about twenty times `main`.

The table is now built once for the command; a walk gets one thread of its own
where there is more than one walk; and the runner runs a machine's worth of
them at a time. Five runs each:

| | `main` | this branch |
|---|---|---|
| `mado check packages/*/docs`, 200 packages, archive | 0.195s | 0.592s |
| the same, clone | 0.255s | 0.268s |
| `mado check .` over the same tree | 0.204s | 0.187s |
| `mado check .` over this repository | 0.102s | 0.085s |

Before this round the first row was 4.69s. What is left of it is reading two
hundred ignore files, which `main` does not do there — it consults no
`.gitignore` in an archive at all, which is the bug this PR is about. The
clone, where both do the same work, is level.

The same round stopped a broken glob in a parent ignore file being reported
once per walk that needs it, and #441 carries the two the walker still says
itself: its own copy of that word, once per walk, and the words it says over
ignore files above the boundary that it reads but never applies.

**Round 7** — that thread count was a clamp, and review caught what it clamped.
Giving every walk one thread the moment there was more than one of them fixed
the two hundred tiny walks and broke the ordinary case: `mado check docs
README.md` is two groups, since nothing is read for a file and something is for
a directory, and the walk over `docs` lost every thread but one. Over a
directory of 3,000 files, five runs each:

| | `main` | before round 7 | now |
|---|---|---|---|
| `mado check docs` | 0.321s | 0.309s | 0.309s |
| `mado check docs README.md` | 0.381s | 1.120s | 0.382s |

The machine is divided between the walks now rather than handed to one of them,
which is the same thing for two hundred groups and the whole machine for two.

Round 7 also made the boundary-less case say so. `Path::starts_with` holds that
every path is under the empty one, so a mado that could not name the directory
it was started in walked to the filesystem root collecting directories it then
threw away — the right answer by a long road. And it left #442 for the runner
running its walks in batches joined a batch at a time rather than handing them
out as threads free up, which costs something only where the walks differ a lot
in size and outnumber the cores.

**Round 8** — sizing a walk by hand meant it stopped asking the walker how big
to be, and the walker's own answer stops at twelve threads however many cores
it is run on. This machine has ten, so no benchmark here could show it: a
hundred groups on a sixty-four core machine would have taken sixty-four threads
and sixty-four linters where one walk takes twelve. The walks now share out
what the walker would have spent rather than what the machine has, and the
runner runs as many alongside each other as that pays for. The arithmetic takes
the budget as an argument so a test can hold it to a machine it is not running
on.

Two more from the same round. A file two groups name two ways — `./d1` from one
and `sub/../d1` from another — is one file, so the note about a glob in it that
will not parse is kept to one by where the file is rather than by what it was
called. And the changelog was missing that `respect-ignore` narrowed too: an
`.ignore` above the directory mado was started in is no longer read outside a
repository, which is a `vendor/` that used to be skipped and now gets linted.
That entry is in `Changed` now, beside the two that were already there.

**Round 9** — the batching loop moves on only while the batch is at least one,
and what kept it at least one was a `.max(1)` in another module. Nothing
reachable puts a zero there, but the way it would fail is a loop turning
without moving rather than anything that says so, so it asks for one a batch
itself now.

**Round 10** — the thread budget was divided by how many walks there are,
which gave each of thirteen one thread on a ten-thread budget. A directory of
2,700 files linted alongside twelve holding one file apiece took over three
times what it takes alone, because the walk that holds the tree was sized like
the ones that hold nothing. It is divided by how many *rounds* of walks the
budget makes now — thirteen over ten is two rounds, so five threads each and
two walks at a time. Three runs each:

| | `main` | before round 10 | now |
|---|---|---|---|
| `mado check big` (2,700 files) | 0.202s | 0.213s | 0.213s |
| `mado check big d1/docs … d12/docs` | 0.202s | 0.794s | 0.319s |
| `mado check packages/*/docs`, 200 packages | 0.138s | 0.352s | 0.352s |

Which walk holds the tree is not knowable before walking it, so a build-time
count is the best a decision made there can do, and this is the third round
spent on it. #444 carries the way out — lint from a pool the walks feed, so how
many walks there are stops mattering — and #442 would fall out of it too. The
batch and the visitors handed to it now come from one number as well, so a walk
cannot reach a batch with no visitor for it and be dropped unwalked.

Round 10 also turned up #445: an ignore file mado cannot read is passed over in
silence, so violations appear in files the user meant to exclude with nothing
said about why. That is what the walker does — `Ignore::add_child` says "all
I/O errors are completely ignored" — and `main` is silent on the same tree, so
it is inherited rather than introduced, and worth deciding rather than keeping
by default.

**Round 11** — a walk names what it finds by joining onto the name it was
given, so `mado check docs/.` has it answering about `docs/./a.md`, and no
ignore file above `docs` can be rooted at a name that lines that up:
`Gitignore` strips a root as a string, and there is no string here to strip. An
anchored pattern in the boundary's `.gitignore` stopped reaching anything named
that way, while a clone of the same tree still honoured it — the walker's own
search above a root rebuilds the path from a canonical base. `docs/.`,
`./docs/.`, `docs/./sub` and `docs/sub/.` all parted company with their clones.

Those dots are taken out of the name before the walk starts now. They say
nothing about which file is meant, and what is reported loses them with them:
`docs/bad.md` where `docs/./bad.md` was printed before, which is a `Changed`
entry of its own.

**Round 12** — the same fault was still in the `..`s, which round 11 said were
safe. They are not: climbing past one names a directory by adding another, so
the boundary above `d1/docs/../docs` came out as `d1/docs/../..`, which the
walk's own answers do not begin with. One step back worked and two did not,
which is why the round-11 sweep missed it and why that round's note here was
wrong. A `..` that undoes a directory is taken out with it now; one that
follows a link undoes where the link led rather than the step before it, so
both are left where they are and `link/../../other` still says so.

**Round 13** — taking a step back out of a name along with the step it undoes
left nothing at all where the name undid the whole of itself. `mado check
docs/..` handed the walk an empty name, it opened nothing under it, and mado
passed every check it never ran — `All checks passed!` and a zero exit over a
tree `main` reported six errors in. `./docs/..` kept the `.` it was written
with and worked, which is why round 12's tests did not catch it. A name that
undoes itself names the directory mado was started in, and says so now.

**Round 15 — the scope was cut.** Fourteen rounds of review split cleanly in
two: rounds 1–5 were about the decision #346 records, and rounds 6–14 were
about one consequence of it — that reconstructing the boundary means naming the
directories above a path the way that path names them, since `add_ignore` roots
a file at the name it is handed. Nine of those rounds found a name that leads
somewhere its spelling does not say (`docs/.`, `docs/./sub`,
`d1/docs/../docs`, `docs/..`, a link in the middle, a link at the end), and
each was met with another step of straightening. Two of them reported nothing
at all and exited zero.

So the question is asked once now, and the straightening is gone: **a name
leads where it reads when resolving it gives back the directory mado was
started in joined with the name itself.** Where it does, the directories above
it are named by cutting the name down, and the walk up is read off the name
with nothing asked of the filesystem. Where it does not, the path is its own
boundary and nothing above it is read.

The cut costs `mado check docs/.` and `mado check d1/docs/../docs` the ignore
files above them — `mado check docs/` keeps them, a separator on the end being
no step at all, where a clone of the same tree still reads them — a
divergence README states. What it buys is that the divergence has one
direction: mado reports what those files would have excluded, rather than
excluding what they would not — round 20 found the one place that did not hold
and closed it. Over-reporting is visible; the two failures this
area produced were not. `without_idle_steps` and the per-step `stays_below` are
gone with it, and the changelog entry about rewriting the names mado prints
goes too — the names are the ones it was given again. `src/service/walker.rs`
is 143 lines lighter.

**Round 16** — the cut asked its question by resolving the name and comparing
the answer with the name joined onto the directory mado was started in, which
put two platforms' spelling rules in the way of a question about steps.
`Path::join` keeps a separator on the end and `canonicalize` takes it off, so
`mado check docs/` — what a shell completes to — lost the files above it while
`./docs/` kept them. And `canonicalize` on Windows answers with a verbatim
`\?\C:\...` path that no join produces, so every absolute name and every
`/`-written one would have lost them there, which no test would have said: CI
runs on Linux and the Windows binaries are built without one.

The question is asked of the steps now and of nothing else.

**Round 17** — round 16 asked it by joining onto the name and onto its own
components, which still went through a name: joining puts the platform's
separator between the steps, so a `/` written on Windows came back a `\` on one
side and stayed a `/` on the other, and every multi-step name written that way
lost the files above it. The same shape as the round before it, one comparison
further in. The steps are counted off the name as written now, splitting on
what the platform calls a separator, which finds a `.` in the middle of a name
without writing anything back out.

The directory mado was started in is the one the operating system gives, too.
`fs::canonicalize` answers on Windows with a `\\?\C:\...` whose prefix is not
the prefix any name climbs to, so no absolute name would have met the boundary
there either. It resolves links on the platforms this can be tried on, which is
all the comparison wanted from it. Neither of these can be held by a test while
CI runs on Linux alone; both are reasoned from the standard library's
documented behaviour rather than observed.

**Round 18** — a name reads as it is written when nothing in it says nothing,
and round 17 counted the `.`s but not the runs of separators. `Path::components`
drops both, so the directories above `.//docs` came out named `.` while the
walk answered about `.//docs/ignored.md`, and the file rooted at `.` was read
against a name with a separator left on the front of it. `ignored.md` in the
boundary's `.gitignore` then matched what it should not, and
`mado check .//docs` passed a tree `main` reports three errors in — the quiet
kind of wrong, one character from `mado check "$DIR/"docs` with `DIR=.`. One
run at either end is not a step, the walk taking the trailing one when it joins
and the leading one being the root, so only a run in the middle counts now.

Round 17 also widened the rule about who reports a glob that will not parse, to
the ignore file at a root as well as the ones over it.

**Round 19** — that widening was wrong three ways, and is gone. Two walks
sharing a file, one with a root under it and one at it, had the walker say it
and mado say it again. Inside a repository mado reads none of these files, so
the same tree said it in an archive and not in a clone. And the changelog
claimed more than held. It is back to the one case nothing else covers — mado
reads these files because the walker will not, which is when
`respect-gitignore` is off — and the counts match `main` everywhere again: one
for a broken glob over a root, none for one at a root, one rather than two
where two walks share the file. Nothing `main` reports is lost.

**Round 20 — a differential run, and the one wrong-way divergence it found.**
Nineteen rounds had not produced a file `main` lints that this branch skips, so
this round went looking with a harness: forty generated trees of nested
`.gitignore` and `.ignore` files, anchored and negating patterns, over twelve
path spellings and every `respect-*` combination — 1,440 comparisons of a clone
against an archive of the same tree.

It found five, all one shape:

```console
$ printf '!ignored.md\n' > proj/.ignore
$ printf 'ignored.md\n' > proj/docs/.gitignore
$ cd proj && mado check docs
```

The walker ranks an `.ignore` over every `.gitignore` wherever the two sit, so
a clone honours the `!` and reports the file, as `main` does. A file handed
back through `add_ignore` ranks under every file the walk finds for itself, so
the archive let `docs/.gitignore` win and dropped it — quietly, which is the
one way of being wrong this branch is not supposed to have.

Narrowing does not reach it: the `.gitignore` under the path is read by the
walk whatever mado hands back, and no rank mado can hand a file back at sits
over it. So where an `.ignore` over the path takes something back,
`.gitignore` files are left unread outside a repository and Git's own rule
answers, as it did before this branch read them without one. That reports more
and drops nothing. After it, the same 1,440 comparisons show no file a clone
reports and an archive does not, and every remaining difference is #438's, in
the direction that reports more. #438 carries the shape and the numbers.

**Round 21 — the harness became a test.** A sweep that only ever ran by hand
proves nothing about the next change, so it is
`tests/command_check_without_git_metadata.rs` now: eight tree shapes -- an
`.ignore` or a `.gitignore` above the path and below it, each of them taking
something back or not -- over three `respect-*` settings and three path
spellings, each built twice, once with `.git` and once without, and the two
runs compared. It holds two claims: an archive reports everything a clone of it
does, always; and the two agree exactly where every ignore file in the tree is
a `.gitignore` and the name leads where it reads. Moving it in caught a shape
the hand-run had not: `mado check docs/.`, which bounds itself, dropped the
same files, so the guard moved from the ignore-file list to the path.

**Round 22 — the fallback fired where nothing could go wrong, and one word was
still said twice.** With `respect-ignore` off neither mado nor the walk reads
an `.ignore`, so nothing stands to rank over a `.gitignore` — and the fallback
fired anyway, costing that tree its `.gitignore` for no reason. It is
conditioned on `respect-ignore` now. Separately, round 19 stopped a broken glob
being said twice with `respect-gitignore` off, but the default leaves that
word to the walker, and a tree walked as several groups has a walker apiece:
`mado check d1/docs d1/docs/deep`, where the two need different files handed
back, said it twice. The visitors share one note of what has been said, so each
thing is said once for the run however many groups meet it.

What the fallback still costs is measured on #438: it asks every parent
directory, however far above the tree, and any `!` line fires it whether or not
it names anything below — it has to, since the walker reads `.ignore` files
from all of them. So one such line anywhere above a tree costs that tree this
PR outside a repository. The direction is the safe one, and deciding #438 does
away with the fallback and its cost together.

**Round 23 — the note round 22 introduced was keeping the wrong words.** It was
put there for an ignore file several walks read and it took every word the
visitor had, including what goes wrong with a file being linted. Two files a
reader cannot make sense of say the same thing about themselves — what
`read_to_string` reports carries no path — so the second went unsaid where
`main` says both. The note is kept for the walk's own words now; a file's
trouble is its own and is said either way. Reading the note also fell the wrong
way where it could not be read: a poisoned lock left the word unsaid, against
the comment beside it, and saying a thing twice is the smaller fault.

The same round corrected the README. A name that does not lead where it reads
is its own boundary because mado hands the files above it back itself, which it
does only where the walker will not. In a repository the walker finds them, and
reads `mado check docs/.` against them exactly as it reads `mado check docs` —
the section said otherwise, and a test pins it now.

**Round 24 — the fallback says why now.** Review asked once more for the
fallback to look only at the files mado hands back, on the grounds that an
`.ignore` above the boundary cannot reach the ranking. It can: the walker reads
`.ignore` files from every parent, above a repository root included, so a clone
honours a `!` there while mado, which never reads it, lets a `.gitignore` below
the path win. Narrowing was built and measured — `outer/.ignore` taking
`kept.md` back over `proj/.gitignore` — and the archive said `All checks
passed!` where the clone reports three, with the sweep failing on two files it
dropped. So the reach stays.

What was wrong with it is that it said nothing. A user who reaches for mado
because it reads `.gitignore` had no way to learn that one line in a home
directory is why it stopped. The `.ignore` responsible is named once for the
run, in a sentence saying what was decided rather than warning about it, and
nothing is said where `respect-ignore` is off and no `.ignore` is read at all.
#438 carries the measurement; deciding it does away with the fallback and the
sentence together.

**Round 25 — the sentence round 24 added was said in the wrong places and
stopped short.** It was said before mado knew whether it was going to hand
anything back, so a repository under an `.ignore` that takes a path back heard
it on every run — and it is not true there: the walker reads `.gitignore`
itself in a repository. The files to hand back are worked out first now, and
only a path that was going to be handed some falls back or is spoken about.
Both markers were checked, `.git` and `.jj`, and the test that covers the
repository case pins the silence.

It also stopped short. Leaving the walker its own arrangement leaves it the
whole of one, so `.ignore` files are read from every parent directory as well,
rather than stopping where the boundary would put them. That matches a clone,
which is the point, but it is a rule the README and the changelog state, so the
sentence says it now and so do they.

The answer is remembered like the ignore files themselves are, since it belongs
to the directory a path sits in: a command naming every directory in one place
was asking the same question once per name.

Review also noted that a `.gitignore` above the boundary can still have a glob
error reported for it. Measured: the file is spoken about and not applied —
`ignored.md` above the boundary is linted, as the boundary says — so what is
reported is the only thing wrong, which is #441, and the measurement is on it.

**Round 26 — the tests were reading the machine they run on.** mado looks for
an `.ignore` that takes a path back in every parent directory, and the trees
these tests build sit under the system temp directory. A machine with such a
file in `/tmp` or `/` therefore has mado leave `.gitignore` to Git's own rule
for every one of them, and the tests fail for a reason that is nothing to do
with the tree under test. The trees cannot be moved out from under it — `/` is
over everything — so `with_tree` and the sweep say plainly which file it was
and that they need none over them. Checked by running the suite under a
`TMPDIR` with one.

Review also arrived a second time at the walker reading further up than the
boundary lets mado apply, which is why a `.gitignore` above the boundary can
still have a glob error reported for it. It is #441, measured there last round,
and the comment beside the guard says so now rather than leaving it to be found
again.

**Round 27 — the sentence was said about paths it could not be about.** The
fallback is reached for every path that was going to be handed ignore files,
and a path that is not a directory is handed an empty list of them: the walk
gives one back to the visitor without asking any ignore file about it. So
`mado check README.md` under an `.ignore` that takes a path back heard that
`.gitignore` files would go unread, where nothing about that file could have
changed either way. Directories only now, and a test pins the silence.

Review left the reach of the fallback unreported this round, as a design
decision recorded in the README and the changelog rather than an oversight.
#438 carries it, with what it costs measured, and deciding it does away with
the fallback altogether.

**Round 28 — the comments were the problem.** Three reviews in a row reached
for narrowing the search for an `.ignore` that takes a path back, each on the
reasoning the comment beside it was written to answer. A comment that has to be
read twice is not carrying its fact, and that one was long, figurative and
split over paragraphs. The fact is two sentences — the walker reads `.ignore`
files from every parent and ranks them over every `.gitignore`, and
`add_ignore` cannot — and the comments around it were cut to what they have to
say.

Review also measured the batching: with more groups than threads the run is
`ceil(groups / budget)` batches one after another. Two hundred groups is a
tenth of a second on ten cores, two thousand is 1.4s; the numbers are on #442,
which carries the decision.

**Round 29 — the last three, and where the cost actually was.** A repository
below the path being linted has a `.gitignore` from above applied inside it,
where Git would not: that is #440, the README says so, and it reports less than
`main` does, which nothing pinned — the sweep never builds a repository under a
walk root. Both sides are tests now, so deciding #440 rewrites a test rather
than changing behaviour quietly.

The tables mado builds while grouping were scanned rather than hashed, and
measuring said the quadratic term was not where the time went: a command naming
two thousand directories, each with a parent of its own, spent most of its
extra on asking what was over each one. Every directory on the way up is
remembered now, not just the one asked after — 0.38s to 0.23s against `main`'s
0.13s, with the tables hashed as well. A command naming files, or one
directory, was never in this: 0.048s against 0.043s for two thousand files.

The note's comment claimed only the walk's own errors reached it; a path the
walk cannot read arrives the same way. Those name the path they are about, so
nothing is lost to the note, and the comment says what is true.

The rounds below are what led here, kept for the record.

**Round 14** — the boundary was worked out from the directory a pattern sits
in and upward, so the pattern's own last step never faced the question the ones
above it did. `mado check link`, where `link` leads out of the directory mado
was started in, was handed that directory's `.gitignore` and dropped everything
it named: `All checks passed!` over a tree `main` and the clone both report six
errors in. `link/docs` was already right, which is why round 12 read as
finished. The rule is stated once now — a name that leaves the boundary
anywhere along its length is bounded by itself — and the pattern's own step is
asked about with the rest.

`build` also says what it expects of the visiting: the walkers come sized to
run alongside each other rather than one at a time, which a caller outside this
crate cannot work out from what it is handed.

Round 12's other finding is the same question asked the other way round.
`stays_below` decided whether a name stayed under the boundary by reading it,
and `link/docs` reads as a name under the directory mado was started in without
being one, so the boundary's `.gitignore` was reaching a tree the boundary does
not hold — the archive stricter than the clone this time, rather than looser.
It asks the filesystem after each step now, and a link ends the reading. Asking
a step at a time rather than resolving the whole name keeps the 200-package
walk about where it was.

The round's other finding goes to #444 rather than into the code. Sizing a walk
by how many walks there are hands the whole budget to one at a time while there
are no more of them than threads — what one big walk among small ones needs,
and what ten small ones do not. Ten directories take 0.230s and eleven take
0.137s, which is the count answering a question only the workload can. That is
the fourth round spent moving this line; #444 is where it stops being moved.

The round-9 finding was that the group key compares the *names* of the ignore
files rather than the directories they resolve to, so one directory named two
ways is two groups and two walks. That one is not an oversight and cannot be
canonicalised away: the walker roots a file it is handed at the name it was
handed, and matches it against paths built from the name the pattern was
written as. Built with a canonical key, `mado check ./d1/docs sub/../d1/docs`
starts reporting a file that `/d1/docs/ignored.md` in the boundary's
`.gitignore` names, because the merged walk's matcher is rooted at `.` and the
second spelling's paths do not begin there. There is a comment on the key and a
test on the behaviour now, and #443 carries the question underneath it —
whether a path already covered by another should reach the walk at all, which
would settle the extra walk and the double reporting that predates this branch
together.

Round 3 also fixes a path written with `..`: it was reconstructed as if it had
not climbed out of the boundary, which rooted an ancestor's patterns at the
wrong directory. Such a path now bounds itself.

## The other two decisions

- **The global Git ignore file and `.git/info/exclude` are switched off.** #346
  asks for these to be decided rather than inherited, and the decision could
  not be deferred: `require_git(false)` would otherwise have turned the global
  ignore file *on* outside a repository, where it was previously off. Neither
  travels with the tree — `~/.config/git/ignore` belongs to the machine and
  `.git/info/exclude` to the clone.
- **`.jj` is kept as a repository marker**, because the walker itself stops at
  it. `ignore` moves from `0.4.25` to `0.4.33` in `Cargo.toml` (the version
  `Cargo.lock` already resolves) since that is the version that reads it.

## Breaking change

`service::walker::WalkParallelBuilder::build` now returns
`Result<Vec<WalkParallel>>` rather than `Result<WalkParallel>`. Where a path's
search for ignore files stops is a property of that path, and the walker's
settings that express it are per-builder, so one walker cannot serve paths that
disagree. It is marked `**Breaking:**` in the changelog under `Changed`, and
the release carrying it should be **0.4.0**.

Whether it is breaking at all is #425's question, not this PR's:
`WalkParallelBuilder` is reachable through `pub mod service` but is not one of
the types `lib.rs` re-exports, and #425 is open on whether the library surface
counts. The entry is written as though it does, which is the safe way round —
drop it if #425 lands the other way.

The commit that makes the change carries it the way Conventional Commits 1.0.0
asks: `fix!:` in the prefix, and a `BREAKING CHANGE:` footer describing it,
since rule 13 hands the job of describing the break to the description only
when the footer is left out, and that commit's description is about the
boundary rather than the signature. This PR's title carries the `!` too,
because the repository squashes and takes the title as the subject. **The
squash body is generated from the commit messages, so the `BREAKING CHANGE:`
footer will land mid-body rather than last** — worth moving to the end when
merging, if you want the merge commit to parse as well as its parts.

## Known gaps

Three places where a clone and an archive of the same tree still differ, two
where stderr says less or more than it should, and three about how the walks
are handed out. All are out of scope here, tracked as decisions of their own —
each starts from whether to act at all, since none has a fix that is free. The
first three are stated in README:

- #437 — **`.ignore` above a repository root.** Inside a repository, `.ignore`
  files above the repository root are still read, since the walker's parent
  search handles that case and does not stop `.ignore` at the root. Outside one
  they stop at the boundary.
- #438 — **A `.gitignore` below the path being linted beats an `.ignore` above
  it, outside a repository.** The files above the path go in through
  `add_ignore`, the only public way to hand the walker a rooted ignore file,
  and it lands them in the lowest precedence slot. Ranking the two kinds
  against each other *above* the path, which is what round 2 caught, is fixed
  here.
- #440 — **A repository below the path being linted does not start a boundary
  of its own, where the path is not in one.** `require_git` is one flag for two
  jobs, and this branch needs it off for the other.
- #441 — **stderr speaks about files mado does not use.** `parents(false)`
  stops the walker *consulting* the directories above a root, not reading them,
  so it reports globs it cannot parse in files the boundary rules out. Saying
  one thing once per walk is fixed here, in both directions round 22 found.
- #442 — **the walks run in batches joined a batch at a time**, so a batch
  waits for its slowest walk before the next starts. It costs something only
  where the walks differ a lot in size and there are more of them than cores.
- #443 — **a path covered by another is walked and reported twice.** The
  reporting predates this branch; the second walk is new, and is what keeps
  each spelling's ignore files anchored to that spelling.
- #444 — **a walk is sized by how many walks there are, not by what it holds.**
  Nothing knows which walk holds the tree before walking it, so linting from a
  pool the walks feed is the way out, and would settle #442 as well. The count
  answering for the workload also makes the curve non-monotonic: ten small
  directories cost more than eleven.
- #445 — **an ignore file that cannot be read is passed over in silence.**
  Inherited from the walker rather than introduced here; `main` is silent on
  the same tree.

The first four would fall out of an upstream boundary that does not depend on
`require_git`.

## Tests

End-to-end in `tests/command_check.rs`, where a child process gets its own
working directory so the relative-path cases run as a user hits them:

- `mado check docs` agreeing with and without `.git`, and with `.jj`
- two `.gitignore` files anchored at different levels, agreeing with and
  without `.git` — this catches a file read against the wrong root
- an `.ignore` and a `.gitignore` in different parent directories disagreeing
  about one file, agreeing with and without `.git` — round 2's finding
- a repository and an archive named in one command, both honoured
- all four `respect-ignore` × `respect-gitignore` combinations over a parent
  `.ignore`, showing the result moves only with `respect-ignore`
- a `.gitignore` above the working directory, not read
- the global ignore file, not read, with `HOME` and `XDG_CONFIG_HOME` isolated
  to the child process
- the #141 scenario: `.gitignore` listing `target/`, no `.git` anywhere

- `mado check ..` reporting the tree above, rather than hiding it behind the
  working directory's `.gitignore`
- `mado check ignored.md` linting a file `.gitignore` lists, which is the
  behaviour the file shortcut rests on
- a broken glob in a parent `.ignore` reported with `respect-gitignore` off,
  reported once rather than once per walk where two walks name one file two
  ways, and left to the walk where the walk reads it
- a broken glob in a `.gitignore` two groups are handed, reported once for the
  run under the default settings, where the walker is the one saying it
- a `.gitignore` still read where an `.ignore` above the path takes something
  back and `respect-ignore` is off
- two files a reader cannot make sense of, reported one apiece, as `main`
  reports them
- `mado check docs/.` inside a repository, read against the files above `docs`
  like any other spelling
- the `.ignore` that sent `.gitignore` back to Git's own rule, named once for
  two names under it, nothing said where `respect-ignore` is off, nothing said
  in a repository, where the walker finds the files itself, and nothing said
  for a path that is not a directory
- a `.gitignore` above a repository below the path, applied inside it, and the
  same tree named from inside the repository, where it is not -- #440 pinned
  from both sides

`tests/command_check_without_git_metadata.rs` runs the round-20 sweep as a
test: eight tree shapes over three `respect-*` settings and three path
spellings, each built with `.git` and without, asserting that an archive
reports everything a clone of it does and that the two agree exactly where the
tree's ignore files are all `.gitignore`.

`src/service/walker.rs` keeps unit coverage for the walk itself, including
`.git/info/exclude`, both `.git` markers, a repository above the directory mado
was started in, a path that is not there, and a boundary that cannot be named.
Grouping is covered on both sides: eight directories under one boundary build
one walker, one of them holding an ignore file of its own splits that one off
and no more, and eight files spread over the same directories build one walker
whatever any of them holds.

Every test covering a review finding was confirmed to fail against the
implementation it was written against and pass against this one.

## Docs

The precondition was undocumented, which #346 also flags. README's "Ignore
files" section states the boundary rule, which kind wins where both name a
path, and both known gaps. It no longer claims a clone and an archive lint the
same files outright: that holds for a tree whose ignore files are all
`.gitignore`, and the section says so before describing the two differences.
`pkg/json-schema/mado.json` says what each option covers and that the two are
independent. `Changed` in the changelog carries everything a user can see change: the
global Git ignore file and `.git/info/exclude`, the parent `.ignore` files
outside a repository, and the Rust API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV




























