### PR TITLE
feat!: take a policy for when .gitignore files are read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,17 @@ parsed and therefore what gets reported.
   | `respect-gitignore = true` | `respect-gitignore = "repository-only"` |
   | — | `respect-gitignore = "always"` |
 
-  `"repository-only"` is the default and lints what 0.3.x lints: `.gitignore`
-  applies inside a Git repository, as Git does. `"always"` applies it whether or
-  not the tree carries Git metadata, so a source archive or a Docker context
-  copied without `.git` lints like a clone of the same tree — on the `ignore`
-  crate's terms, the same ones `rg --no-require-git` has: `.gitignore` files
-  apply from every parent directory, and a repository below the path being
-  linted does not bound the search. The boolean spelling is not accepted; a
-  configuration that still carries it fails to load rather than being guessed at
+  `"repository-only"` is the default and is what a boolean `true` did:
+  `.gitignore` applies inside a repository, as Git does. Note the entry below,
+  which changes what a repository lints in every mode. `"always"` stops mado looking
+  for a repository at all, for every tree rather than only those without one, so
+  a source archive or a Docker context copied without `.git` lints the files a
+  clone of it does. It comes on the `ignore` crate's terms, the same ones
+  `rg --no-require-git` has: `.gitignore` files apply from every parent
+  directory, above a clone's own repository root included, and a repository
+  below the path being linted does not bound the search. The boolean spelling is
+  not accepted; a configuration that still carries it fails to load rather than
+  being guessed at
 - The global Git ignore file and `.git/info/exclude` are no longer read. mado
   had been reading both by inheriting the walker's defaults; neither travels
   with the tree being linted, so reading them had one source lint differently on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ parsed and therefore what gets reported.
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `respect-gitignore` takes a policy rather than a boolean, since
+  there are three behaviours to name rather than two (#436):
+
+  | 0.3.x | 0.4.0 |
+  |---|---|
+  | `respect-gitignore = false` | `respect-gitignore = "never"` |
+  | `respect-gitignore = true` | `respect-gitignore = "repository-only"` |
+  | — | `respect-gitignore = "always"` |
+
+  `"repository-only"` is the default and lints what 0.3.x lints: `.gitignore`
+  applies inside a Git repository, as Git does. `"always"` applies it whether or
+  not the tree carries Git metadata, so a source archive or a Docker context
+  copied without `.git` lints like a clone of the same tree — on the `ignore`
+  crate's terms, the same ones `rg --no-require-git` has: `.gitignore` files
+  apply from every parent directory, and a repository below the path being
+  linted does not bound the search. The boolean spelling is not accepted; a
+  configuration that still carries it fails to load rather than being guessed at
+- The global Git ignore file and `.git/info/exclude` are no longer read. mado
+  had been reading both by inheriting the walker's defaults; neither travels
+  with the tree being linted, so reading them had one source lint differently on
+  another machine (#436)
+- **Breaking:** `config::lint::Lint::respect_gitignore` is a
+  `config::lint::GitignorePolicy` rather than a `bool`, and
+  `service::walker::WalkParallelBuilder::build` takes one (#436)
+
 ## [0.3.2] - 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -150,6 +150,28 @@ For more details,
 see [the example `mado.toml`](https://github.com/akiomik/mado/blob/main/mado.toml)
 and [the JSON Schema for `mado.toml`](https://github.com/akiomik/mado/blob/main/pkg/json-schema/mado.json).
 
+### Ignore files
+
+`respect-ignore` decides whether `.ignore` files exclude what they list.
+`respect-gitignore` decides when `.gitignore` files do:
+
+| value | `.gitignore` files are read |
+|---|---|
+| `"never"` | not at all |
+| `"repository-only"` (default) | inside a Git repository, as Git does |
+| `"always"` | whether or not the tree carries Git metadata |
+
+`"always"` suits a tree that arrives without its Git metadata — a source
+archive, or a Docker context copied without `.git` — and comes on the
+[ignore](https://docs.rs/ignore) crate's terms, the same ones
+`rg --no-require-git` has: `.gitignore` files apply from every parent
+directory, and a repository below the path being linted does not bound the
+search.
+
+The global Git ignore file and `.git/info/exclude` are never read. Neither
+travels with the tree being linted, so reading them would have one source lint
+differently on another machine.
+
 ## GitHub Actions
 
 Mado is compatible with GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -161,12 +161,17 @@ and [the JSON Schema for `mado.toml`](https://github.com/akiomik/mado/blob/main/
 | `"repository-only"` (default) | inside a Git repository, as Git does |
 | `"always"` | whether or not the tree carries Git metadata |
 
+A repository here is a `.git` directory, the `.git` file a worktree or a
+submodule carries, or a `.jj` directory, which the ignore crate stops at as
+well.
+
 `"always"` suits a tree that arrives without its Git metadata — a source
-archive, or a Docker context copied without `.git` — and comes on the
-[ignore](https://docs.rs/ignore) crate's terms, the same ones
-`rg --no-require-git` has: `.gitignore` files apply from every parent
-directory, and a repository below the path being linted does not bound the
-search.
+archive, or a Docker context copied without `.git`. It stops mado looking for a
+repository at all, for every tree rather than only those without one, which is
+what the [ignore](https://docs.rs/ignore) crate offers and what
+`rg --no-require-git` does. So `.gitignore` files apply from every parent
+directory, above a clone's own repository root included, and a repository below
+the path being linted does not bound the search.
 
 The global Git ignore file and `.git/info/exclude` are never read. Neither
 travels with the tree being linted, so reading them would have one source lint

--- a/mado.toml
+++ b/mado.toml
@@ -1,6 +1,6 @@
 [lint]
 respect-ignore = true
-respect-gitignore = true
+respect-gitignore = "repository-only"
 output-format = "concise"
 quiet = false
 exclude = []

--- a/mado.toml
+++ b/mado.toml
@@ -1,6 +1,5 @@
 [lint]
 respect-ignore = true
-respect-gitignore = "repository-only"
 output-format = "concise"
 quiet = false
 exclude = []

--- a/pkg/json-schema/mado.json
+++ b/pkg/json-schema/mado.json
@@ -16,9 +16,10 @@
           "default": true
         },
         "respect-gitignore": {
-          "description": "Exclude files that are ignored by .gitignore",
-          "type": "boolean",
-          "default": true
+          "description": "When .gitignore files are read: never, only inside a Git repository as Git does, or always, whether or not the tree carries Git metadata. With \"always\", .gitignore files apply from every parent directory and a repository below the path being linted does not bound the search",
+          "type": "string",
+          "enum": ["never", "repository-only", "always"],
+          "default": "repository-only"
         },
         "output-format": {
           "description": "Output format for violations",

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 pub mod lint;
 
-pub use lint::Lint;
+pub use lint::{GitignorePolicy, Lint};
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/src/config/lint.rs
+++ b/src/config/lint.rs
@@ -36,12 +36,34 @@ pub use md036::MD036;
 pub use md041::MD041;
 pub use md046::MD046;
 
+/// When `.gitignore` files are read.
+///
+/// Git itself only applies them inside a repository, and the `ignore` crate
+/// follows it. A tree that arrives without its Git metadata -- a source
+/// archive, a Docker context copied without `.git` -- therefore lints
+/// differently from a clone of the same tree unless asked otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum GitignorePolicy {
+    /// Never, whatever the tree carries.
+    Never,
+    /// Inside a repository, as Git does.
+    #[default]
+    RepositoryOnly,
+    /// Whether or not the tree carries Git metadata. Without a repository to
+    /// stop at, `.gitignore` files apply from every parent directory, and a
+    /// repository below the path being linted does not bound the search --
+    /// the same terms `rg --no-require-git` has.
+    Always,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 #[allow(clippy::exhaustive_structs)]
 pub struct Lint {
     pub respect_ignore: bool,
-    pub respect_gitignore: bool,
+    pub respect_gitignore: GitignorePolicy,
     pub output_format: Format,
     pub quiet: bool,
     pub exclude: Vec<Glob>,
@@ -263,7 +285,7 @@ impl Default for Lint {
     fn default() -> Self {
         Self {
             respect_ignore: true,
-            respect_gitignore: true,
+            respect_gitignore: GitignorePolicy::default(),
             output_format: Format::Concise,
             quiet: false,
             exclude: vec![],

--- a/src/config/lint.rs
+++ b/src/config/lint.rs
@@ -1,6 +1,9 @@
+use core::fmt;
+
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use miette::{IntoDiagnostic as _, Result};
-use serde::{Deserialize, Serialize};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{output::Format, rule, rule::Rule};
 
@@ -42,7 +45,7 @@ pub use md046::MD046;
 /// follows it. A tree that arrives without its Git metadata -- a source
 /// archive, a Docker context copied without `.git` -- therefore lints
 /// differently from a clone of the same tree unless asked otherwise.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum GitignorePolicy {
@@ -56,6 +59,43 @@ pub enum GitignorePolicy {
     /// repository below the path being linted does not bound the search --
     /// the same terms `rg --no-require-git` has.
     Always,
+}
+
+const POLICIES: &[&str] = &["never", "repository-only", "always"];
+
+struct GitignorePolicyVisitor;
+
+impl Visitor<'_> for GitignorePolicyVisitor {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("`never`, `repository-only` or `always`")
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        match value {
+            "never" => Ok(GitignorePolicy::Never),
+            "repository-only" => Ok(GitignorePolicy::RepositoryOnly),
+            "always" => Ok(GitignorePolicy::Always),
+            other => Err(E::unknown_variant(other, POLICIES)),
+        }
+    }
+
+    /// 0.3.x wrote this as a boolean, so say which policy the one written
+    /// means rather than leaving a reader of the error to guess.
+    fn visit_bool<E: de::Error>(self, value: bool) -> Result<Self::Value, E> {
+        let meant = if value { "repository-only" } else { "never" };
+        Err(E::custom(format_args!(
+            "no longer a boolean: write \"{meant}\" for what `{value}` meant"
+        )))
+    }
+
+    type Value = GitignorePolicy;
+}
+
+impl<'de> Deserialize<'de> for GitignorePolicy {
+    #[inline]
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(GitignorePolicyVisitor)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -405,6 +445,36 @@ mod tests {
     use rule::Tag;
 
     use super::*;
+
+    #[test]
+    fn gitignore_policy_round_trips_through_toml() -> Result<()> {
+        // Serialize is derived and Deserialize is written by hand, so the two
+        // have to be held to the same spellings.
+        for policy in [
+            GitignorePolicy::Never,
+            GitignorePolicy::RepositoryOnly,
+            GitignorePolicy::Always,
+        ] {
+            let written = toml::to_string(&Lint {
+                respect_gitignore: policy,
+                ..Lint::default()
+            })
+            .into_diagnostic()?;
+            let read: Lint = toml::from_str(&written).into_diagnostic()?;
+
+            assert_eq!(read.respect_gitignore, policy);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn gitignore_policy_says_what_a_boolean_meant() {
+        let read = toml::from_str::<Lint>("respect-gitignore = true");
+        let message = read.err().map(|err| err.to_string()).unwrap_or_default();
+
+        assert!(message.contains("repository-only"), "{message}");
+    }
 
     #[test]
     fn exclude_set() -> Result<()> {

--- a/src/config/lint.rs
+++ b/src/config/lint.rs
@@ -469,6 +469,23 @@ mod tests {
     }
 
     #[test]
+    fn gitignore_policy_names_the_values_it_takes() {
+        let unknown = toml::from_str::<Lint>("respect-gitignore = \"repo-only\"")
+            .err()
+            .map(|err| err.to_string())
+            .unwrap_or_default();
+        assert!(unknown.contains("repository-only"), "{unknown}");
+
+        // Anything that is neither a string nor the boolean 0.3.x wrote is
+        // answered by what the visitor says it expects.
+        let wrong_kind = toml::from_str::<Lint>("respect-gitignore = 1")
+            .err()
+            .map(|err| err.to_string())
+            .unwrap_or_default();
+        assert!(wrong_kind.contains("repository-only"), "{wrong_kind}");
+    }
+
+    #[test]
     fn gitignore_policy_says_what_a_boolean_meant() {
         let read = toml::from_str::<Lint>("respect-gitignore = true");
         let message = read.err().map(|err| err.to_string()).unwrap_or_default();

--- a/src/service/walker.rs
+++ b/src/service/walker.rs
@@ -7,6 +7,8 @@ use miette::IntoDiagnostic as _;
 use miette::Result;
 use miette::miette;
 
+use crate::config::GitignorePolicy;
+
 #[non_exhaustive]
 pub struct WalkParallelBuilder;
 
@@ -15,7 +17,7 @@ impl WalkParallelBuilder {
     pub fn build(
         patterns: &[PathBuf],
         respect_ignore: bool,
-        respect_gitignore: bool,
+        respect_gitignore: GitignorePolicy,
     ) -> Result<WalkParallel> {
         let (head_pattern, tail_patterns) = patterns
             .split_first()
@@ -26,7 +28,16 @@ impl WalkParallelBuilder {
         }
 
         builder.ignore(respect_ignore);
-        builder.git_ignore(respect_gitignore);
+        builder.git_ignore(respect_gitignore != GitignorePolicy::Never);
+        // `require_git` decides whether a repository has to be there for a
+        // `.gitignore` to apply at all. It also decides whether a repository
+        // marker bounds the search upward, which is why `Always` reads
+        // `.gitignore` files from every parent directory.
+        builder.require_git(respect_gitignore != GitignorePolicy::Always);
+        // Neither of these travels with the tree being linted, so reading them
+        // makes the same source lint differently on different machines.
+        builder.git_global(false);
+        builder.git_exclude(false);
 
         // NOTE: Expect performance improvements with pre-filtering
         let types = TypesBuilder::new()
@@ -44,6 +55,7 @@ impl WalkParallelBuilder {
 mod tests {
     extern crate alloc;
 
+    use crate::config::GitignorePolicy;
     use alloc::sync::Arc;
     use miette::{Context as _, IntoDiagnostic as _};
     use std::{
@@ -94,7 +106,7 @@ mod tests {
             Path::new("mado.toml").to_path_buf(),
             Path::new("README.md").to_path_buf(),
         ];
-        let builder = WalkParallelBuilder::build(&paths, true, true)?;
+        let builder = WalkParallelBuilder::build(&paths, true, GitignorePolicy::default())?;
         let collector = PathCollector::new();
 
         builder.run(|| Box::new(collector.gen_visitor()));
@@ -113,7 +125,7 @@ mod tests {
 
     #[test]
     fn build_empty_patterns() {
-        let result = WalkParallelBuilder::build(&[], true, true);
+        let result = WalkParallelBuilder::build(&[], true, GitignorePolicy::default());
         assert!(result.is_err());
     }
 }

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -142,6 +142,19 @@ fn check_reads_a_git_file_marker_as_a_repository() -> Result<()> {
 }
 
 #[test]
+fn check_reads_a_jj_directory_as_a_repository() -> Result<()> {
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
+        // The ignore crate stops at `.jj` as well as `.git`, so a Jujutsu
+        // repository is a repository for this setting too.
+        create_dir_all(root.join(".jj")).into_diagnostic()?;
+
+        let assert = check_in(root, &["."]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
 fn check_reads_a_nested_gitignore_where_it_sits() -> Result<()> {
     with_tree(
         &[
@@ -175,6 +188,28 @@ fn check_reads_a_gitignore_above_the_tree_when_told_always() -> Result<()> {
             // Without a repository to stop at there is nothing to stop at:
             // `.gitignore` files apply however far above the tree they sit.
             // This is the `ignore` crate's rule, and `always` says so.
+            let assert = check_in(&proj, &["."]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_reads_a_gitignore_above_a_repository_when_told_always() -> Result<()> {
+    with_tree(
+        &[
+            (".gitignore", "generated.md\n"),
+            ("proj/generated.md", "#Hello."),
+        ],
+        |root| {
+            let proj = root.join("proj");
+            create_dir_all(proj.join(".git")).into_diagnostic()?;
+            policy(&proj, "always")?;
+
+            // `always` stops mado looking for a repository at all, so the
+            // boundary Git keeps at a repository root is not kept here either.
+            // This tree has one, and the file above it still applies.
             let assert = check_in(&proj, &["."]).assert();
             assert.success().stdout("All checks passed!\n");
             Ok(())
@@ -273,12 +308,14 @@ fn check_rejects_the_boolean_spelling_of_the_policy() -> Result<()> {
     with_tree(IGNORED_BUILD_OUTPUT, |root| {
         write(root.join("mado.toml"), "[lint]\nrespect-gitignore = true\n").into_diagnostic()?;
 
-        // 0.3.x wrote this as a boolean. Failing to parse is the migration
-        // notice: `true` would have to mean one of two things now.
+        // 0.3.x wrote this as a boolean. Failing to load is the migration
+        // notice, and it says which policy the boolean written meant rather
+        // than leaving that to be looked up.
         let output = check_in(root, &["."]).output().into_diagnostic()?;
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(!output.status.success());
         assert!(stderr.contains("respect-gitignore"), "{stderr}");
+        assert!(stderr.contains("repository-only"), "{stderr}");
         Ok(())
     })
 }

--- a/tests/command_check.rs
+++ b/tests/command_check.rs
@@ -1,5 +1,8 @@
 use std::fs::File;
+use std::fs::create_dir_all;
+use std::fs::write;
 use std::io::Write as _;
+use std::path::Path;
 use std::path::PathBuf;
 
 use assert_cmd::Command;
@@ -24,6 +27,260 @@ where
     f(path)?;
 
     tmp_dir.close().into_diagnostic()
+}
+
+fn with_tree<F>(entries: &[(&str, &str)], f: F) -> Result<()>
+where
+    F: FnOnce(&Path) -> Result<()>,
+{
+    let tmp_dir = tempdir().into_diagnostic()?;
+    let root = tmp_dir.path();
+    for (path, content) in entries {
+        let path = root.join(path);
+        if let Some(dir) = path.parent() {
+            create_dir_all(dir).into_diagnostic()?;
+        }
+        write(&path, content).into_diagnostic()?;
+    }
+
+    f(root)?;
+
+    tmp_dir.close().into_diagnostic()
+}
+
+fn check_in(dir: &Path, args: &[&str]) -> Command {
+    let mut cmd = Command::new(cargo_bin!("mado"));
+    cmd.current_dir(dir)
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
+        .arg("check")
+        .args(args);
+    cmd
+}
+
+fn policy(root: &Path, value: &str) -> Result<()> {
+    write(
+        root.join("mado.toml"),
+        formatdoc! {"
+            [lint]
+            respect-gitignore = \"{value}\"
+        "},
+    )
+    .into_diagnostic()
+}
+
+/// A tree whose `.gitignore` lists a directory mado would otherwise report on:
+/// what #141 ran into when the same tree arrived without its Git metadata.
+const IGNORED_BUILD_OUTPUT: &[(&str, &str)] = &[
+    (".gitignore", "target/\n"),
+    ("target/generated.md", "#Hello."),
+];
+
+const REPORTED: &str = indoc! {"
+    ./target/generated.md:1:1: MD018 No space after hash on atx style header
+    ./target/generated.md:1:1: MD041 First line in file should be a top level header
+    ./target/generated.md:1:1: MD047 File should end with a single newline character
+
+    Found 3 errors.
+"};
+
+#[test]
+fn check_reads_gitignore_in_a_repository() -> Result<()> {
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
+        create_dir_all(root.join(".git")).into_diagnostic()?;
+
+        let assert = check_in(root, &["."]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_does_not_read_gitignore_without_git_metadata() -> Result<()> {
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
+        // The default is what Git does, and Git does nothing here.
+        let assert = check_in(root, &["."]).assert();
+        assert.failure().stdout(REPORTED);
+        Ok(())
+    })
+}
+
+#[test]
+fn check_reads_gitignore_without_git_metadata_when_asked() -> Result<()> {
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
+        policy(root, "always")?;
+
+        let assert = check_in(root, &["."]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_reads_no_gitignore_when_told_never() -> Result<()> {
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
+        create_dir_all(root.join(".git")).into_diagnostic()?;
+        policy(root, "never")?;
+
+        let assert = check_in(root, &["."]).assert();
+        assert.failure().stdout(REPORTED);
+        Ok(())
+    })
+}
+
+#[test]
+fn check_reads_a_git_file_marker_as_a_repository() -> Result<()> {
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
+        // A worktree and a submodule carry `.git` as a file naming the real
+        // directory, and it marks a repository just as the directory does.
+        write(root.join(".git"), "gitdir: /elsewhere/.git/worktrees/w\n").into_diagnostic()?;
+
+        let assert = check_in(root, &["."]).assert();
+        assert.success().stdout("All checks passed!\n");
+        Ok(())
+    })
+}
+
+#[test]
+fn check_reads_a_nested_gitignore_where_it_sits() -> Result<()> {
+    with_tree(
+        &[
+            (".gitignore", "root-ignored.md\n"),
+            ("docs/.gitignore", "nested-ignored.md\n"),
+            ("root-ignored.md", "#Hello."),
+            ("docs/nested-ignored.md", "#Hello."),
+            ("docs/kept.md", "# Kept\n"),
+        ],
+        |root| {
+            policy(root, "always")?;
+
+            let assert = check_in(root, &["."]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_reads_a_gitignore_above_the_tree_when_told_always() -> Result<()> {
+    with_tree(
+        &[
+            (".gitignore", "generated.md\n"),
+            ("proj/generated.md", "#Hello."),
+        ],
+        |root| {
+            let proj = root.join("proj");
+            policy(&proj, "always")?;
+
+            // Without a repository to stop at there is nothing to stop at:
+            // `.gitignore` files apply however far above the tree they sit.
+            // This is the `ignore` crate's rule, and `always` says so.
+            let assert = check_in(&proj, &["."]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_does_not_stop_at_a_repository_below_the_path_when_told_always() -> Result<()> {
+    with_tree(
+        &[(".gitignore", "lib/\n"), ("vendor/lib/inner.md", "#Hello.")],
+        |root| {
+            create_dir_all(root.join("vendor/.git")).into_diagnostic()?;
+            policy(root, "always")?;
+
+            // Git would apply nothing from outside the repository holding this
+            // file. `always` turns the marker off for the whole walk, so the
+            // file is excluded here. See #440.
+            let assert = check_in(root, &["."]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_does_not_read_the_global_git_ignore_file() -> Result<()> {
+    with_tree(
+        &[
+            ("home/.config/git/ignore", "globally-ignored.md\n"),
+            ("proj/globally-ignored.md", "#Hello."),
+        ],
+        |root| {
+            let proj = root.join("proj");
+            create_dir_all(proj.join(".git")).into_diagnostic()?;
+
+            // It does not travel with the tree, so reading it would have the
+            // same source lint differently on a different machine.
+            let assert = check_in(&proj, &["."])
+                .env("HOME", root.join("home"))
+                .env("XDG_CONFIG_HOME", root.join("home/.config"))
+                .assert();
+            assert.failure().stdout(indoc! {"
+                ./globally-ignored.md:1:1: MD018 No space after hash on atx style header
+                ./globally-ignored.md:1:1: MD041 First line in file should be a top level header
+                ./globally-ignored.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_does_not_read_the_repository_exclude_file() -> Result<()> {
+    with_tree(
+        &[
+            (".git/info/exclude", "locally-ignored.md\n"),
+            ("locally-ignored.md", "#Hello."),
+        ],
+        |root| {
+            // It lives in the Git metadata rather than the tree, so it does not
+            // travel with a source archive either.
+            let assert = check_in(root, &["."]).assert();
+            assert.failure().stdout(indoc! {"
+                ./locally-ignored.md:1:1: MD018 No space after hash on atx style header
+                ./locally-ignored.md:1:1: MD041 First line in file should be a top level header
+                ./locally-ignored.md:1:1: MD047 File should end with a single newline character
+
+                Found 3 errors.
+            "});
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_respects_ignore_files_whatever_gitignore_is_told() -> Result<()> {
+    with_tree(
+        &[(".ignore", "ignored.md\n"), ("ignored.md", "#Hello.")],
+        |root| {
+            policy(root, "never")?;
+
+            // The two options are independent: `.ignore` is mado's own, and
+            // nothing about `.gitignore` decides whether it is read.
+            let assert = check_in(root, &["."]).assert();
+            assert.success().stdout("All checks passed!\n");
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn check_rejects_the_boolean_spelling_of_the_policy() -> Result<()> {
+    with_tree(IGNORED_BUILD_OUTPUT, |root| {
+        write(root.join("mado.toml"), "[lint]\nrespect-gitignore = true\n").into_diagnostic()?;
+
+        // 0.3.x wrote this as a boolean. Failing to parse is the migration
+        // notice: `true` would have to mean one of two things now.
+        let output = check_in(root, &["."]).output().into_diagnostic()?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success());
+        assert!(stderr.contains("respect-gitignore"), "{stderr}");
+        Ok(())
+    })
 }
 
 #[test]


### PR DESCRIPTION
Closes #346. Supersedes #436.

## What this does

`respect-gitignore` becomes a policy rather than a boolean, and mado passes it
to the walker rather than arranging anything itself:

| value | walker |
|---|---|
| `"never"` | `git_ignore(false)` |
| `"repository-only"` (default) | `git_ignore(true)`, `require_git(true)` |
| `"always"` | `git_ignore(true)`, `require_git(false)` |

`"repository-only"` is what a boolean `true` did. `"always"` stops mado looking
for a repository at all, for every tree rather than only those without one,
which is what #141 ran into: a source archive or a Docker context copied without
`.git` walked everything `.gitignore` listed. It also means a `.gitignore` above
a clone's own repository root applies, which `"repository-only"` does not.

Neither mode lints exactly what 0.3.x lints, because of the entry below: the
global Git ignore file and `.git/info/exclude` go unread, so a repository whose
ignore rules lived there reports more than it did.

The global Git ignore file and `.git/info/exclude` go unread in every mode.
mado had been reading both by inheriting the walker's defaults, and neither
travels with the tree being linted.

## Why a setting rather than the default

#346's recorded decision was to honour `.gitignore` unconditionally, with mado
establishing its own logical boundary when no repository is present so that a
host-level ancestor `.gitignore` could not change the lint result. #436
implemented that and ran to 465 lines of walker, 41 commits and seven issues.
[The revision on #346](https://github.com/akiomik/mado/issues/346) has the
detail; the short version is that five properties were wanted at once and the
`ignore` crate cannot deliver them together:

- `add_ignore` is the only way to hand the walker a file rooted at a chosen
  directory, and it lands in the lowest precedence slot, so a reconstructed
  ancestor cannot outrank a `.gitignore` below the path
- `require_git` gates both "does `.gitignore` apply" and "does a repository
  marker bound the search", so turning it off loses the second
- `parents(false)` stops the walker consulting the directories above a root but
  not reading them, and it stops `.ignore` and `.gitignore` together, while the
  walker ranks `.ignore` above `.gitignore` and reads it from every parent

#436 compensated for the third with a fallback, and the fallback broke the very
property the boundary was for: one `!` line in an `.ignore` anywhere above a
tree left `.gitignore` unread for that tree, silently, whether or not the line
named anything below it.

Delegating gives up bounded-unconditional behaviour and says so. A bounded
`always` needs the dependency to separate "apply below this directory" from
"require a repository", which is an upstream question rather than something to
approximate here.

## What `always` costs

Documented in the README and the changelog rather than worked around:

- `.gitignore` files apply from every parent directory, there being no
  repository to stop at
- a repository below the path being linted does not bound the search, so a
  `.gitignore` from above it applies inside it where Git would not

Both are the `ignore` crate's terms, the same ones `rg --no-require-git` has.

## Tests

`tests/command_check.rs`, each running a child process in its own directory:

- the same tree with and without `.git`, under each of the three values
- a `.git` file, as a worktree or submodule carries, read as a repository
- nested `.gitignore` files, each applying where it sits
- a `.gitignore` above the tree under `"always"`, applied — the documented cost
- a repository below the path under `"always"`, not bounding the search — #440
- the global ignore file, not read, with `HOME` and `XDG_CONFIG_HOME` isolated
- `.git/info/exclude`, not read
- `.ignore` still read with `respect-gitignore = "never"`, the two being
  independent
- the boolean spelling, failing to load

## The example config

`mado.toml` loses its `respect-gitignore` line for now. The `Download` and
`Test Action` jobs fetch the released mado and run it over this repository, so
the file has to be loadable by 0.3.2 as well as by this branch, and no spelling
satisfies both. The value it named is the default either way, and the example
can carry the new spelling once 0.4.0 ships. #448 carries the constraint.

## Size

48 lines of production code against #436's 465, and no walker rewrite: one
walker, no grouping, no thread arithmetic, no path-spelling rules, no fallback.
#438, #441, #442 and #444 go with #436, being questions about machinery that no
longer exists. #440 becomes a documented limit of `"always"` and does not arise
under the default. #437 becomes the crate's answer rather than mado's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV


