### PR TITLE
docs: say how a configuration key changes shape without breaking CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,32 @@ fails inside that build rather than in anything the change touched. `just test`
 does not need a C++ one, for the `false`s in `fuzz/Cargo.toml`, and neither does
 CI's coverage job. CI's Clippy job installs `g++` on a runner that has none.
 
+## Changing a configuration key's shape
+
+`mado.toml` here is read by two mado binaries: the one built from the branch,
+and the newest published release, which the `Download` job in
+`.github/workflows/ci-action.yml` runs over this checkout through the action.
+That job is also the Markdown quality gate for this repository — nothing else
+lints these documents — so it cannot be pointed at a fixture instead.
+
+Adding a key is safe, and so is removing or renaming one: the release ignores
+keys it does not know and gives absent ones their defaults. What it cannot read
+is an existing key whose type has changed, or a value it has never heard of,
+such as a variant added to an enum. It fails to load the file, and the job fails
+before it lints anything.
+
+A change of that kind therefore lands in two steps:
+
+1. In the pull request that changes the key, take it out of `mado.toml`. Say in
+   the changelog what a configuration carrying the old spelling has to do.
+1. After the release that carries the change is published, restore the key with
+   its new spelling. Step 4 of [Releasing](#releasing) is where the rest of the
+   after-the-release work lives, and this belongs in the same pull request.
+
+The action's `version` input met the same constraint from the other side: it
+defaults to the release it was published with, which does not exist yet at the
+moment of a version bump, so the job names the newest published release instead.
+
 ## Changelog
 
 `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
@@ -64,10 +90,12 @@ Mark a breaking change with a `**Breaking:**` prefix under `Changed`.
    leaves it behind runs the previous version's binary. CI checks that these
    agree with `Cargo.toml`, so forgetting one fails before the tag.
 1. Tag the merged commit `vx.y.z` and push the tag. That starts CD.
-1. Once CD has published the release, set `version` / `prev_version` in the
-   `justfile`, refresh the package manifests with `just update-homebrew`,
-   `just update-scoop`, `just update-winget` and `just update-flake`, and open a
-   pull request for them. Every one of these recipes downloads assets of the
+1. Once CD has published the release, restore anything
+   [a configuration change](#changing-a-configuration-keys-shape) had to take
+   out of `mado.toml`, set `version` / `prev_version` in the `justfile`, refresh
+   the package manifests with `just update-homebrew`, `just update-scoop`,
+   `just update-winget` and `just update-flake`, and open a pull request for
+   them. Every one of these recipes downloads assets of the
    release being packaged, so none of them can run any earlier. This is also why
    `flake.nix` and the manifests under `pkg/` still name the previous version at
    the moment the tag is pushed, and why `nix run github:akiomik/mado/vx.y.z`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,10 @@ before it lints anything.
 
 A change of that kind therefore lands in two steps:
 
-1. In the pull request that changes the key, take it out of `mado.toml`. Say in
-   the changelog what a configuration carrying the old spelling has to do.
+1. In the pull request that changes the key, take it out of `mado.toml`, and
+   open an issue for putting it back. Nothing fails while the key is missing, so
+   the second step has to be somewhere that is looked at rather than remembered.
+   Say in the changelog what a configuration carrying the old spelling has to do.
 1. After the release that carries the change is published, restore the key with
    its new spelling. Step 4 of [Releasing](#releasing) is where the rest of the
    after-the-release work lives, and this belongs in the same pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,11 @@ CI's coverage job. CI's Clippy job installs `g++` on a runner that has none.
 
 ## Changing a configuration key's shape
 
-`mado.toml` here is read by two mado binaries: the one built from the branch,
-and the newest published release, which the `Download` job in
-`.github/workflows/ci-action.yml` runs over this checkout through the action.
-That job is also the Markdown quality gate for this repository — nothing else
-lints these documents — so it cannot be pointed at a fixture instead.
+`mado.toml` here is read by two mado binaries. `cargo test` runs the one built
+from the branch over this repository, and the `Download` job in
+`.github/workflows/ci-action.yml` runs the newest published release over it,
+through the action and with the action's own default arguments. So the file has
+to be readable by the release before this one as well as by the branch.
 
 Adding a key is safe, and so is removing or renaming one: the release ignores
 keys it does not know and gives absent ones their defaults. What it cannot read
@@ -41,6 +41,9 @@ A change of that kind therefore lands in two steps:
    open an issue for putting it back. Nothing fails while the key is missing, so
    the second step has to be somewhere that is looked at rather than remembered.
    Say in the changelog what a configuration carrying the old spelling has to do.
+   Run `mado check .` here with the key out before you settle on this: the
+   repository lints with that key's default until it comes back, and for some of
+   them that is a very different set of files.
 1. After the release that carries the change is published, restore the key with
    its new spelling. Step 4 of [Releasing](#releasing) is where the rest of the
    after-the-release work lives, and this belongs in the same pull request.


### PR DESCRIPTION
Closes #448.

## What this documents

`mado.toml` in this repository is read by two mado binaries: the one built from
the branch, and the newest published release, which the `Download` job in
`.github/workflows/ci-action.yml` runs over this checkout through the action.
That job is also the Markdown quality gate here — nothing else lints these
documents — so it cannot be pointed at a fixture to break the tie.

Measured, against 0.3.2 and the branch that became #447:

| change to `mado.toml` | the published release |
|---|---|
| a key added | fine — unknown keys are ignored |
| a key removed | fine — absent keys take their defaults |
| a key renamed | fine — the old name is absent, the new one unknown |
| an existing key's type changed | fails to load the file |
| a value the release does not know | fails to load the file |

So the narrow case — a key changing shape — lands in two steps: take it out of
`mado.toml` in the pull request that changes it and open an issue for putting it
back, then restore it after the release that carries the change is published.
The issue is the part that matters: nothing fails while the key is missing, so
the restore is the half that can be lost quietly. #451 is the one outstanding. #447 did the first half; the
second is now listed with the rest of the after-the-release work in
[Releasing](https://github.com/akiomik/mado/blob/main/CONTRIBUTING.md#releasing),
which is where it will be looked for.

## What this does not do

It does not put the rule in front of anyone before they need it. A contributor
changing a key's type meets the constraint as a red `Download` job, reads
`invalid type: string "repository-only", expected a boolean` against a file
their branch says otherwise about, and finds this section by searching
`CONTRIBUTING.md` for `mado.toml`. Making it findable earlier would mean a note
in `mado.toml` itself, which is the example configuration the README points at
and not the place for CI commentary, or a hint printed by the job, which is
machinery for something that happens about once in a project's life. The
failure is loud, fast and names the file and line, so this seemed the right
trade rather than an oversight.

## Why not decouple the job

#448 has the reasoning. In short, the job is two things at once and both are
wanted: it tests the action's own download path on each runner, and it is the
Markdown gate. A fixture directory would free `mado.toml` and take the gate
away.

While deciding it, one thing turned up that is worth its own question rather
than this change: nothing lints this repository with the mado built from the
branch, so a rule added or fixed on `main` reaches these documents only at the
next release. That is #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xqGos7Q8MiBm6G59sh4FV


