### PR TITLE
fix: measure MD027's quoted paragraph lines from the line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,10 @@ parsed and therefore what gets reported.
   is, the two spaces after its marker having gone unread. A line below the one a
   nested quote starts at is measured at each of that quote's own markers rather
   than at the innermost alone, so `>  >  >  text` written there is reported once
-  per marker. A reported line names the content after the marker through to the
-  end of the line, where it named the first inline on the line (#439)
+  per marker, and a line carrying no marker at all is left alone rather than
+  measured at the first inline on it. A reported line names the content after the
+  marker through to the end of the line, where it named the first inline on the
+  line (#439)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,7 @@ parsed and therefore what gets reported.
   nested quote starts at is measured at each of that quote's own markers rather
   than at the innermost alone, so `>  >  >  text` written there is reported once
   per marker, and a line carrying no marker at all is left alone rather than
-  measured at the first inline on it. A reported line names the content after the
-  marker through to the end of the line, where it named the first inline on the
-  line (#439)
+  measured at the first inline on it (#439)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,11 @@ parsed and therefore what gets reported.
   move in both directions: `> **bold` followed by `> span.** tail here` was
   reported at the text after the strong and is not any more, one space following
   both markers, while `> **bold` followed by `>  span**` went unreported and now
-  is, the two spaces after its marker having gone unread. A reported line names
-  the content after the marker through to the end of the line, where it named the
-  first inline on the line (#439)
+  is, the two spaces after its marker having gone unread. A line below the one a
+  nested quote starts at is measured at each of that quote's own markers rather
+  than at the innermost alone, so `>  >  >  text` written there is reported once
+  per marker. A reported line names the content after the marker through to the
+  end of the line, where it named the first inline on the line (#439)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,13 @@ parsed and therefore what gets reported.
   nested quote starts at is measured at each of that quote's own markers rather
   than at the innermost alone, so `>  >  >  text` written there is reported once
   per marker, and a line carrying no marker at all is left alone rather than
-  measured at the first inline on it, as is a line that reaches its quote through
-  a list item, which the second line of `> - >  first` does and which is reported
-  no longer (#439, #456)
+  measured at the first inline on it. Two shapes change answer the other way: a
+  line reaching its quote through a list item's indentation goes unreported
+  (#456), and one whose `>` is indented far enough for `CommonMark` to read it as
+  text is reported for the spaces after it (#455). The position a violation
+  carries runs from the content after the marker to the end of the line, where it
+  ran to the end of the first inline on it; no output format prints that, so it is
+  for a library caller reading `Violation::position()` (#439)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ parsed and therefore what gets reported.
   nested quote starts at is measured at each of that quote's own markers rather
   than at the innermost alone, so `>  >  >  text` written there is reported once
   per marker, and a line carrying no marker at all is left alone rather than
-  measured at the first inline on it (#439)
+  measured at the first inline on it, as is a line that reaches its quote through
+  a list item, which the second line of `> - >  first` does and which is reported
+  no longer (#439, #456)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ parsed and therefore what gets reported.
   `config::lint::GitignorePolicy` rather than a `bool`, and
   `service::walker::WalkParallelBuilder::build` takes one (#436)
 
+### Fixed
+
+- MD027: measure a quoted paragraph's line from the line itself rather than from
+  the first inline reported on it, so a line whose content begins where an inline
+  that opened on the line before closed — `> **bold` followed by
+  `> span.** tail here` — is no longer reported when one space follows its
+  marker. A line that is reported now names the content after the marker through
+  to the end of the line, where it named the first inline on the line before
+  (#439)
+
 ## [0.3.2] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ parsed and therefore what gets reported.
   per marker, and a line carrying no marker at all is left alone rather than
   measured at the first inline on it. Two shapes change answer the other way: a
   line reaching its quote through a list item's indentation goes unreported
-  (#456), and one whose `>` is indented far enough for `CommonMark` to read it as
+  (#456), and one whose `>` is indented far enough for CommonMark to read it as
   text is reported for the spaces after it (#455). The position a violation
   carries runs from the content after the marker to the end of the line, where it
   ran to the end of the first inline on it; no output format prints that, so it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,14 @@ parsed and therefore what gets reported.
 ### Fixed
 
 - MD027: measure a quoted paragraph's line from the line itself rather than from
-  the first inline reported on it, so a line whose content begins where an inline
-  that opened on the line before closed — `> **bold` followed by
-  `> span.** tail here` — is no longer reported when one space follows its
-  marker. A line that is reported now names the content after the marker through
-  to the end of the line, where it named the first inline on the line before
-  (#439)
+  the first inline reported on it, which an inline spanning two lines leaves
+  beginning where it closed rather than where the line's content does. Reports
+  move in both directions: `> **bold` followed by `> span.** tail here` was
+  reported at the text after the strong and is not any more, one space following
+  both markers, while `> **bold` followed by `>  span**` went unreported and now
+  is, the two spaces after its marker having gone unread. A reported line names
+  the content after the marker through to the end of the line, where it named the
+  first inline on the line (#439)
 
 ## [0.3.2] - 2026-09-07
 

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -45,13 +45,13 @@ impl MD027 {
     /// item's to answer for rather than either quote's.
     ///
     /// A line that carries fewer markers than the quote stops being measured
-    /// there, and what follows the last marker it does carry is measured as that
-    /// marker's content: a lazy continuation line of `> - >  first` is
-    /// `  >    second`, and the four spaces are the quote's however few markers
-    /// follow them. A line carrying no marker at all is left alone, text that
-    /// happens to hold a `>` included. Spaces before the first marker are read as
-    /// the prefix they look like, however many; a tab there is not, which leaves a
-    /// quote a list item indents with one unmeasured on that line.
+    /// there, with what follows the last marker it carries measured as that
+    /// marker's content if the quote owns that marker: `> > Quoted` followed by
+    /// `>   lazy` is three spaces after the outer marker. A line carrying no
+    /// marker at all is left alone, text that happens to hold a `>` included.
+    /// Spaces before the first marker are read as the prefix they look like,
+    /// however many; a tab there is not, which leaves a quote a list item indents
+    /// with one unmeasured on that line.
     ///
     /// `None` for a line `lines` does not hold, and for one the `offset` is not
     /// within. The caller reports nothing for either.
@@ -77,7 +77,7 @@ impl MD027 {
             let spaces = rest.len() - at_marker.len();
 
             let Some(after_marker) = at_marker.strip_prefix('>') else {
-                if marker > 0 && spaces > 1 && !at_marker.is_empty() {
+                if marker + own_markers > markers && spaces > 1 && !at_marker.is_empty() {
                     positions.push(content_position(prefix_len + spaces + 1));
                 }
 
@@ -330,8 +330,8 @@ mod tests {
     #[test]
     fn check_errors_paragraph_in_list_item_with_nested_block_quote() -> Result<()> {
         let text = indoc! {"
-            > - >  Indented text
-              >    More indented
+            > -   >  Indented text
+            >     Not indented
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();
@@ -339,10 +339,7 @@ mod tests {
         let doc = Document::new(&arena, path.clone(), text)?;
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
-        let expected = vec![
-            rule.to_violation(path.clone(), Sourcepos::from((1, 8, 1, 20))),
-            rule.to_violation(path, Sourcepos::from((2, 8, 2, 20))),
-        ];
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 10, 1, 22)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -24,9 +24,10 @@ impl MD027 {
     }
 
     /// The content of line `lineno` from where it begins to the end of the line,
-    /// when more than one space separates it from the innermost of the `depth`
-    /// blockquote markers the line is quoted by. One space after a marker belongs
-    /// to the prefix, per `CommonMark`, and the rest is what this rule reports.
+    /// when more than one space or tab separates it from the innermost of the
+    /// `depth` blockquote markers that follow byte `offset`. One of those spaces
+    /// belongs to the marker, per `CommonMark`, and the rest is what this rule
+    /// reports.
     ///
     /// The line is read rather than the inlines on it, since an inline that
     /// opened on an earlier line leaves the first inline of this one beginning
@@ -35,27 +36,31 @@ impl MD027 {
     /// The markers are counted off the line itself rather than taken from the
     /// column the quote started at, which is a column the same nesting can be
     /// written at differently from one line to the next, as `>>` and `> >` are.
+    /// `offset` is for the line the quote starts at, where what precedes the
+    /// marker is a list item's own, and comrak has already said which column the
+    /// marker is at.
     ///
     /// `None` for a line with nothing to report, and for one that does not carry
-    /// `depth` markers at all: a lazy continuation line carries none, and its
-    /// text is not a prefix however much like one it reads.
+    /// `depth` markers after `offset`: a lazy continuation line carries none, and
+    /// its text is not a prefix however much like one it reads.
     fn indented_content_position(
         lines: &[String],
         lineno: usize,
         depth: usize,
+        offset: usize,
     ) -> Option<Sourcepos> {
         let line = lines.get(lineno.checked_sub(1)?)?;
-        let mut after_markers = line.as_str();
-        let mut prefix_len = 0;
+        let mut after_markers = line.get(offset..)?;
+        let mut prefix_len = offset;
 
         for _ in 0..depth {
-            let at_marker = after_markers.trim_start_matches(' ');
+            let at_marker = after_markers.trim_start_matches([' ', '\t']);
             let spaces = after_markers.len() - at_marker.len();
             after_markers = at_marker.strip_prefix('>')?;
             prefix_len += spaces + 1;
         }
 
-        let content = after_markers.trim_start_matches(' ');
+        let content = after_markers.trim_start_matches([' ', '\t']);
         let spaces = after_markers.len() - content.len();
 
         if spaces < 2 || content.trim().is_empty() {
@@ -91,11 +96,21 @@ impl RuleLike for MD027 {
             {
                 match &child_node.data.borrow().value {
                     NodeValue::Paragraph => {
+                        let block_quote_position = node.data.borrow().sourcepos;
                         let depth = Self::block_quote_depth(node);
                         let paragraph_position = child_node.data.borrow().sourcepos;
                         for lineno in paragraph_position.start.line..=paragraph_position.end.line {
+                            // The quote's own marker on the line it starts at, and
+                            // the whole prefix on every line after, where nothing
+                            // but the quote's markers can precede the content.
+                            let (markers, offset) = if lineno == block_quote_position.start.line {
+                                (1, block_quote_position.start.column.saturating_sub(1))
+                            } else {
+                                (depth, 0)
+                            };
+
                             if let Some(position) =
-                                Self::indented_content_position(&doc.lines, lineno, depth)
+                                Self::indented_content_position(&doc.lines, lineno, markers, offset)
                             {
                                 let violation = self.to_violation(doc.path.clone(), position);
                                 violations.push(violation);
@@ -207,6 +222,42 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((3, 6, 3, 18)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_paragraph_in_list_item() -> Result<()> {
+        let text = indoc! {"
+            - >  Indented text
+              >  More indented
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((1, 6, 1, 18))),
+            rule.to_violation(path, Sourcepos::from((2, 6, 2, 18))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_paragraph_with_tab() -> Result<()> {
+        let text = indoc! {"
+            > \tIndented text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 4, 1, 16)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -44,10 +44,14 @@ impl MD027 {
     /// between two quotes indents the inner one, and that indentation is the
     /// item's to answer for rather than either quote's.
     ///
-    /// `None` for a line that does not carry `markers` markers after `offset`,
-    /// which is how a lazy continuation line is left alone. Text that happens to
-    /// hold a `>` is not a prefix, though indentation before one is read as the
-    /// prefix it looks like.
+    /// A line stops being measured where it stops carrying markers, with what it
+    /// carried of them measured: a lazy continuation line carries none, and text
+    /// that happens to hold a `>` is not a prefix. Spaces before one are, though,
+    /// so a line indented past what `CommonMark` allows before a marker is read as
+    /// the prefix it looks like. A tab at the start of a line is not, which leaves
+    /// a quote a list item indents with one unmeasured on that line.
+    ///
+    /// `None` only for a line the `offset` is not within.
     fn indented_content_positions(
         lines: &[String],
         lineno: usize,
@@ -61,7 +65,11 @@ impl MD027 {
         let mut positions = vec![];
 
         for marker in 0..markers {
-            let at_marker = rest.trim_start_matches([' ', '\t']);
+            let at_marker = if marker == 0 {
+                rest.trim_start_matches(' ')
+            } else {
+                rest.trim_start_matches([' ', '\t'])
+            };
             let spaces = rest.len() - at_marker.len();
 
             if marker + own_markers > markers && spaces > 1 {
@@ -69,7 +77,11 @@ impl MD027 {
                 positions.push(Sourcepos::from((lineno, column, lineno, line.len())));
             }
 
-            rest = at_marker.strip_prefix('>')?;
+            let Some(after_marker) = at_marker.strip_prefix('>') else {
+                return Some(positions);
+            };
+
+            rest = after_marker;
             prefix_len += spaces + 1;
         }
 
@@ -119,19 +131,18 @@ impl RuleLike for MD027 {
                     NodeValue::Paragraph => {
                         let block_quote_position = node.data.borrow().sourcepos;
                         let paragraph_position = child_node.data.borrow().sourcepos;
+                        let depth = Self::block_quote_depth(node);
+                        let nested = Self::nested_block_quotes(node);
                         for lineno in paragraph_position.start.line..=paragraph_position.end.line {
-                            // The quote's own marker on the line it starts at, and
-                            // the whole prefix on every line after, where nothing
-                            // but the quote's markers can precede the content.
+                            // The quote's own marker on the line it starts at,
+                            // where comrak has already said which column it is at
+                            // and a list item's marker can precede it. Every line
+                            // after carries the prefix and is read from its start.
                             let (markers, own_markers, offset) =
                                 if lineno == block_quote_position.start.line {
                                     (1, 1, block_quote_position.start.column.saturating_sub(1))
                                 } else {
-                                    (
-                                        Self::block_quote_depth(node),
-                                        Self::nested_block_quotes(node),
-                                        0,
-                                    )
+                                    (depth, nested, 0)
                                 };
 
                             let positions = Self::indented_content_positions(
@@ -465,6 +476,23 @@ mod tests {
     }
 
     #[test]
+    fn check_errors_with_nested_block_quotes5() -> Result<()> {
+        let text = indoc! {"
+            > > Quoted text
+            >   More quoted text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 5, 2, 20)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
     fn check_no_errors_paragraph() -> Result<()> {
         let text = indoc! {"
             > Text
@@ -522,6 +550,25 @@ mod tests {
         let text = indoc! {"
             > > Quoted text
             ab>  more text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: A tab is four columns of indentation, more than `CommonMark` allows
+    // before a marker, so the `>` on line 2 is text.
+    #[test]
+    fn check_no_errors_paragraph_with_tab_indented_continuation() -> Result<()> {
+        let text = indoc! {"
+            > Quoted text
+            \t>  More text
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -102,8 +102,10 @@ impl MD027 {
         Some(positions)
     }
 
-    /// How wide `text` is, written at column `from`, with each tab taking the
-    /// columns up to the next stop of four as `CommonMark` expands them.
+    /// How wide `text` is, starting `from` columns into the line, with each tab
+    /// taking the columns up to the next stop of four as `CommonMark` expands them.
+    /// `from` is a width rather than a column: the first column of a line is 0 of
+    /// them.
     fn expanded_width(text: &str, from: usize) -> usize {
         text.chars().fold(0, |width, character| {
             width

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -23,35 +23,24 @@ impl MD027 {
         Self {}
     }
 
-    /// What line `lineno` carries more than one space or tab of, after each of
-    /// the `own_markers` innermost of the `markers` blockquote markers that follow
-    /// byte `offset`. One space after a marker belongs to it, per `CommonMark`,
-    /// and the rest is what this rule reports: from where what follows it begins
-    /// to the end of the line.
+    /// Where line `lineno` carries more than one space or tab after a blockquote
+    /// marker the quote owns, from what follows the spaces to the end of the line.
+    /// One space after a marker belongs to it, per `CommonMark`.
     ///
-    /// The line is read rather than the inlines on it, since an inline that
-    /// opened on an earlier line leaves the first inline of this one beginning
-    /// wherever that inline closed.
+    /// The line is read rather than the inlines on it, since an inline that opened
+    /// on an earlier line leaves the first inline of this one beginning wherever
+    /// that inline closed. Its markers are read off it too, the same nesting being
+    /// written at different columns from one line to the next, as `>>` and `> >`
+    /// are. `offset` skips to the marker comrak measured on the line the quote
+    /// starts at, the one line a list item's marker can precede.
     ///
-    /// The markers are counted off the line itself rather than taken from the
-    /// column the quote started at, which is a column the same nesting can be
-    /// written at differently from one line to the next, as `>>` and `> >` are.
-    /// `offset` is for the line the quote starts at, where what precedes the
-    /// marker is a list item's own, and comrak has already said which column the
-    /// marker is at.
+    /// The quote owns the innermost `own_markers` of the `markers` quoting the
+    /// line, and the spaces before an outer one are the indentation of whatever
+    /// holds it rather than any quote's. A line carrying fewer markers than that
+    /// is measured for as many as it carries, and one carrying none is left alone.
     ///
-    /// `markers` beyond `own_markers` are read and not measured: a list item
-    /// between two quotes indents the inner one, and that indentation is the
-    /// item's to answer for rather than either quote's.
-    ///
-    /// A line that carries fewer markers than the quote stops being measured
-    /// there, with what follows the last marker it carries measured as that
-    /// marker's content if the quote owns that marker: `> > Quoted` followed by
-    /// `>   lazy` is three spaces after the outer marker. A line carrying no
-    /// marker at all is left alone, text that happens to hold a `>` included.
-    /// Spaces before the first marker are read as the prefix they look like,
-    /// however many; a tab there is not, which leaves a quote a list item indents
-    /// with one unmeasured on that line.
+    /// What this reads as a prefix and `CommonMark` does not is #455, and what it
+    /// cannot tell from a list item's indentation is #456.
     ///
     /// `None` for a line `lines` does not hold, and for one the `offset` is not
     /// within. The caller reports nothing for either.
@@ -143,7 +132,8 @@ impl RuleLike for MD027 {
                             // The quote's own marker on the line it starts at,
                             // where comrak has already said which column it is at
                             // and a list item's marker can precede it. Every line
-                            // after carries the prefix and is read from its start.
+                            // after is read from its start, for the markers it
+                            // carries of the ones quoting it.
                             let (markers, own_markers, offset) =
                                 if lineno == block_quote_position.start.line {
                                     (1, 1, block_quote_position.start.column.saturating_sub(1))

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -1,4 +1,4 @@
-use comrak::nodes::{NodeValue, Sourcepos};
+use comrak::nodes::{AstNode, NodeValue, Sourcepos};
 use miette::Result;
 
 use crate::{Document, violation::Violation};
@@ -24,36 +24,54 @@ impl MD027 {
     }
 
     /// The content of line `lineno` from where it begins to the end of the line,
-    /// when more than one space separates it from the blockquote marker at
-    /// `marker_column`. One space after the marker belongs to the prefix, per
-    /// `CommonMark`, and the rest is what this rule reports.
+    /// when more than one space separates it from the innermost of the `depth`
+    /// blockquote markers the line is quoted by. One space after a marker belongs
+    /// to the prefix, per `CommonMark`, and the rest is what this rule reports.
     ///
     /// The line is read rather than the inlines on it, since an inline that
     /// opened on an earlier line leaves the first inline of this one beginning
     /// wherever that inline closed.
     ///
-    /// `None` for a line with nothing to report, a line the marker cannot be
-    /// read at included: a lazy continuation line carries no marker, and a
-    /// nested quote's markers move between lines that spell the nesting with
-    /// different widths.
+    /// The markers are counted off the line itself rather than taken from the
+    /// column the quote started at, which is a column the same nesting can be
+    /// written at differently from one line to the next, as `>>` and `> >` are.
+    ///
+    /// `None` for a line with nothing to report, and for one that does not carry
+    /// `depth` markers at all: a lazy continuation line carries none, and its
+    /// text is not a prefix however much like one it reads.
     fn indented_content_position(
         lines: &[String],
         lineno: usize,
-        marker_column: usize,
+        depth: usize,
     ) -> Option<Sourcepos> {
         let line = lines.get(lineno.checked_sub(1)?)?;
-        let after_marker = line
-            .get(marker_column.checked_sub(1)?..)?
-            .strip_prefix('>')?;
-        let content = after_marker.trim_start_matches(' ');
-        let spaces = after_marker.len() - content.len();
+        let mut after_markers = line.as_str();
+        let mut prefix_len = 0;
+
+        for _ in 0..depth {
+            let at_marker = after_markers.trim_start_matches(' ');
+            let spaces = after_markers.len() - at_marker.len();
+            after_markers = at_marker.strip_prefix('>')?;
+            prefix_len += spaces + 1;
+        }
+
+        let content = after_markers.trim_start_matches(' ');
+        let spaces = after_markers.len() - content.len();
 
         if spaces < 2 || content.trim().is_empty() {
             return None;
         }
 
-        let column = marker_column + spaces + 1;
+        let column = prefix_len + spaces + 1;
         Some(Sourcepos::from((lineno, column, lineno, line.len())))
+    }
+
+    /// How many blockquotes `node`, itself a blockquote, is quoted by, itself
+    /// included.
+    fn block_quote_depth<'a>(node: &'a AstNode<'a>) -> usize {
+        node.ancestors()
+            .filter(|ancestor| ancestor.data.borrow().value == NodeValue::BlockQuote)
+            .count()
     }
 }
 
@@ -73,11 +91,11 @@ impl RuleLike for MD027 {
             {
                 match &child_node.data.borrow().value {
                     NodeValue::Paragraph => {
-                        let marker_column = node.data.borrow().sourcepos.start.column;
+                        let depth = Self::block_quote_depth(node);
                         let paragraph_position = child_node.data.borrow().sourcepos;
                         for lineno in paragraph_position.start.line..=paragraph_position.end.line {
                             if let Some(position) =
-                                Self::indented_content_position(&doc.lines, lineno, marker_column)
+                                Self::indented_content_position(&doc.lines, lineno, depth)
                             {
                                 let violation = self.to_violation(doc.path.clone(), position);
                                 violations.push(violation);
@@ -157,6 +175,9 @@ mod tests {
         let text = indoc! {"
             > **bold
             >  span.** tail here
+
+            > **bold
+            >  span**
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();
@@ -164,7 +185,10 @@ mod tests {
         let doc = Document::new(&arena, path.clone(), text)?;
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
-        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 4, 2, 20)))];
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((2, 4, 2, 20))),
+            rule.to_violation(path, Sourcepos::from((5, 4, 5, 9))),
+        ];
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -328,6 +352,23 @@ mod tests {
     }
 
     #[test]
+    fn check_errors_with_nested_block_quotes3() -> Result<()> {
+        let text = indoc! {"
+            >> Original
+            > >  Reply
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 6, 2, 10)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
     fn check_no_errors_paragraph() -> Result<()> {
         let text = indoc! {"
             > Text
@@ -365,6 +406,26 @@ mod tests {
 
             > `code
             > span` tail here
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: Line 2 is a lazy continuation line. It carries no marker, and the
+    // `>` in its text is not one however much the column it sits at looks like
+    // the quote's.
+    #[test]
+    fn check_no_errors_paragraph_with_lazy_continuation() -> Result<()> {
+        let text = indoc! {"
+            > > Quoted text
+            ab>  more text
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -51,7 +51,8 @@ impl MD027 {
     /// the prefix it looks like. A tab at the start of a line is not, which leaves
     /// a quote a list item indents with one unmeasured on that line.
     ///
-    /// `None` only for a line the `offset` is not within.
+    /// `None` for a line `lines` does not hold, and for one the `offset` is not
+    /// within. The caller reports nothing for either.
     fn indented_content_positions(
         lines: &[String],
         lineno: usize,
@@ -88,7 +89,7 @@ impl MD027 {
         let content = rest.trim_start_matches([' ', '\t']);
         let spaces = rest.len() - content.len();
 
-        if spaces > 1 && !content.trim().is_empty() {
+        if spaces > 1 && !content.is_empty() {
             let column = prefix_len + spaces + 1;
             positions.push(Sourcepos::from((lineno, column, lineno, line.len())));
         }
@@ -263,6 +264,24 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((3, 6, 3, 18)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: A line of whitespace CommonMark does not end a line with is content,
+    // and the content of this one begins two spaces after the marker.
+    #[test]
+    fn check_errors_paragraph_with_unicode_whitespace() -> Result<()> {
+        let text = indoc! {"
+            >  \u{a0}
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 4, 1, 5)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -44,12 +44,14 @@ impl MD027 {
     /// between two quotes indents the inner one, and that indentation is the
     /// item's to answer for rather than either quote's.
     ///
-    /// A line stops being measured where it stops carrying markers, with what it
-    /// carried of them measured: a lazy continuation line carries none, and text
-    /// that happens to hold a `>` is not a prefix. Spaces before one are, though,
-    /// so a line indented past what `CommonMark` allows before a marker is read as
-    /// the prefix it looks like. A tab at the start of a line is not, which leaves
-    /// a quote a list item indents with one unmeasured on that line.
+    /// A line that carries fewer markers than the quote stops being measured
+    /// there, and what follows the last marker it does carry is measured as that
+    /// marker's content: a lazy continuation line of `> - >  first` is
+    /// `  >    second`, and the four spaces are the quote's however few markers
+    /// follow them. A line carrying no marker at all is left alone, text that
+    /// happens to hold a `>` included. Spaces before the first marker are read as
+    /// the prefix they look like, however many; a tab there is not, which leaves a
+    /// quote a list item indents with one unmeasured on that line.
     ///
     /// `None` for a line `lines` does not hold, and for one the `offset` is not
     /// within. The caller reports nothing for either.
@@ -64,6 +66,7 @@ impl MD027 {
         let mut rest = line.get(offset..)?;
         let mut prefix_len = offset;
         let mut positions = vec![];
+        let content_position = |column| Sourcepos::from((lineno, column, lineno, line.len()));
 
         for marker in 0..markers {
             let at_marker = if marker == 0 {
@@ -73,14 +76,17 @@ impl MD027 {
             };
             let spaces = rest.len() - at_marker.len();
 
-            if marker + own_markers > markers && spaces > 1 {
-                let column = prefix_len + spaces + 1;
-                positions.push(Sourcepos::from((lineno, column, lineno, line.len())));
-            }
-
             let Some(after_marker) = at_marker.strip_prefix('>') else {
+                if marker > 0 && spaces > 1 && !at_marker.is_empty() {
+                    positions.push(content_position(prefix_len + spaces + 1));
+                }
+
                 return Some(positions);
             };
+
+            if marker + own_markers > markers && spaces > 1 {
+                positions.push(content_position(prefix_len + spaces + 1));
+            }
 
             rest = after_marker;
             prefix_len += spaces + 1;
@@ -90,8 +96,7 @@ impl MD027 {
         let spaces = rest.len() - content.len();
 
         if spaces > 1 && !content.is_empty() {
-            let column = prefix_len + spaces + 1;
-            positions.push(Sourcepos::from((lineno, column, lineno, line.len())));
+            positions.push(content_position(prefix_len + spaces + 1));
         }
 
         Some(positions)
@@ -318,6 +323,26 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((1, 4, 1, 16)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_paragraph_in_list_item_with_nested_block_quote() -> Result<()> {
+        let text = indoc! {"
+            > - >  Indented text
+              >    More indented
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((1, 8, 1, 20))),
+            rule.to_violation(path, Sourcepos::from((2, 8, 2, 20))),
+        ];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -23,11 +23,11 @@ impl MD027 {
         Self {}
     }
 
-    /// The content of line `lineno` from where it begins to the end of the line,
-    /// when more than one space or tab separates it from the innermost of the
-    /// `depth` blockquote markers that follow byte `offset`. One of those spaces
-    /// belongs to the marker, per `CommonMark`, and the rest is what this rule
-    /// reports.
+    /// What line `lineno` carries more than one space or tab of, after each of
+    /// the `own_markers` innermost of the `markers` blockquote markers that follow
+    /// byte `offset`. One space after a marker belongs to it, per `CommonMark`,
+    /// and the rest is what this rule reports: from where what follows it begins
+    /// to the end of the line.
     ///
     /// The line is read rather than the inlines on it, since an inline that
     /// opened on an earlier line leaves the first inline of this one beginning
@@ -40,35 +40,48 @@ impl MD027 {
     /// marker is a list item's own, and comrak has already said which column the
     /// marker is at.
     ///
-    /// `None` for a line with nothing to report, and for one that does not carry
-    /// `depth` markers after `offset`: a lazy continuation line carries none, and
-    /// its text is not a prefix however much like one it reads.
-    fn indented_content_position(
+    /// `markers` beyond `own_markers` are read and not measured: a list item
+    /// between two quotes indents the inner one, and that indentation is the
+    /// item's to answer for rather than either quote's.
+    ///
+    /// `None` for a line that does not carry `markers` markers after `offset`,
+    /// which is how a lazy continuation line is left alone. Text that happens to
+    /// hold a `>` is not a prefix, though indentation before one is read as the
+    /// prefix it looks like.
+    fn indented_content_positions(
         lines: &[String],
         lineno: usize,
-        depth: usize,
+        markers: usize,
+        own_markers: usize,
         offset: usize,
-    ) -> Option<Sourcepos> {
+    ) -> Option<Vec<Sourcepos>> {
         let line = lines.get(lineno.checked_sub(1)?)?;
-        let mut after_markers = line.get(offset..)?;
+        let mut rest = line.get(offset..)?;
         let mut prefix_len = offset;
+        let mut positions = vec![];
 
-        for _ in 0..depth {
-            let at_marker = after_markers.trim_start_matches([' ', '\t']);
-            let spaces = after_markers.len() - at_marker.len();
-            after_markers = at_marker.strip_prefix('>')?;
+        for marker in 0..markers {
+            let at_marker = rest.trim_start_matches([' ', '\t']);
+            let spaces = rest.len() - at_marker.len();
+
+            if marker + own_markers > markers && spaces > 1 {
+                let column = prefix_len + spaces + 1;
+                positions.push(Sourcepos::from((lineno, column, lineno, line.len())));
+            }
+
+            rest = at_marker.strip_prefix('>')?;
             prefix_len += spaces + 1;
         }
 
-        let content = after_markers.trim_start_matches([' ', '\t']);
-        let spaces = after_markers.len() - content.len();
+        let content = rest.trim_start_matches([' ', '\t']);
+        let spaces = rest.len() - content.len();
 
-        if spaces < 2 || content.trim().is_empty() {
-            return None;
+        if spaces > 1 && !content.trim().is_empty() {
+            let column = prefix_len + spaces + 1;
+            positions.push(Sourcepos::from((lineno, column, lineno, line.len())));
         }
 
-        let column = prefix_len + spaces + 1;
-        Some(Sourcepos::from((lineno, column, lineno, line.len())))
+        Some(positions)
     }
 
     /// How many blockquotes `node`, itself a blockquote, is quoted by, itself
@@ -76,6 +89,14 @@ impl MD027 {
     fn block_quote_depth<'a>(node: &'a AstNode<'a>) -> usize {
         node.ancestors()
             .filter(|ancestor| ancestor.data.borrow().value == NodeValue::BlockQuote)
+            .count()
+    }
+
+    /// How many blockquotes `node`, itself a blockquote, is quoted by with nothing
+    /// but another blockquote in between, itself included.
+    fn nested_block_quotes<'a>(node: &'a AstNode<'a>) -> usize {
+        node.ancestors()
+            .take_while(|ancestor| ancestor.data.borrow().value == NodeValue::BlockQuote)
             .count()
     }
 }
@@ -97,21 +118,30 @@ impl RuleLike for MD027 {
                 match &child_node.data.borrow().value {
                     NodeValue::Paragraph => {
                         let block_quote_position = node.data.borrow().sourcepos;
-                        let depth = Self::block_quote_depth(node);
                         let paragraph_position = child_node.data.borrow().sourcepos;
                         for lineno in paragraph_position.start.line..=paragraph_position.end.line {
                             // The quote's own marker on the line it starts at, and
                             // the whole prefix on every line after, where nothing
                             // but the quote's markers can precede the content.
-                            let (markers, offset) = if lineno == block_quote_position.start.line {
-                                (1, block_quote_position.start.column.saturating_sub(1))
-                            } else {
-                                (depth, 0)
-                            };
+                            let (markers, own_markers, offset) =
+                                if lineno == block_quote_position.start.line {
+                                    (1, 1, block_quote_position.start.column.saturating_sub(1))
+                                } else {
+                                    (
+                                        Self::block_quote_depth(node),
+                                        Self::nested_block_quotes(node),
+                                        0,
+                                    )
+                                };
 
-                            if let Some(position) =
-                                Self::indented_content_position(&doc.lines, lineno, markers, offset)
-                            {
+                            let positions = Self::indented_content_positions(
+                                &doc.lines,
+                                lineno,
+                                markers,
+                                own_markers,
+                                offset,
+                            );
+                            for position in positions.into_iter().flatten() {
                                 let violation = self.to_violation(doc.path.clone(), position);
                                 violations.push(violation);
                             }
@@ -389,14 +419,12 @@ mod tests {
             rule.to_violation(path.clone(), Sourcepos::from((1, 4, 3, 55))),
             rule.to_violation(path.clone(), Sourcepos::from((1, 7, 3, 55))),
             rule.to_violation(path.clone(), Sourcepos::from((1, 10, 1, 58))),
+            rule.to_violation(path.clone(), Sourcepos::from((3, 4, 3, 55))),
+            rule.to_violation(path.clone(), Sourcepos::from((3, 7, 3, 55))),
             rule.to_violation(path, Sourcepos::from((3, 10, 3, 55))),
-            // TODO: This results are expected
+            // TODO: The outer two are expected to name line 1 alone
             // rule.to_violation(path.clone(), Sourcepos::from((1, 4, 1, 58))),
             // rule.to_violation(path.clone(), Sourcepos::from((1, 7, 1, 58))),
-            // rule.to_violation(path.clone(), Sourcepos::from((1, 10, 1, 58))),
-            // rule.to_violation(path.clone(), Sourcepos::from((3, 4, 3, 55))),
-            // rule.to_violation(path.clone(), Sourcepos::from((3, 7, 3, 55))),
-            // rule.to_violation(path, Sourcepos::from((3, 10, 3, 55))),
         ];
         assert_eq!(actual, expected);
         Ok(())
@@ -415,6 +443,23 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((2, 6, 2, 10)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_with_nested_block_quotes4() -> Result<()> {
+        let text = indoc! {"
+            > > Quoted text
+            >  > More quoted text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 4, 2, 21)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -54,6 +54,7 @@ impl MD027 {
         let line = lines.get(lineno.checked_sub(1)?)?;
         let mut rest = line.get(offset..)?;
         let mut prefix_len = offset;
+        let mut prefix_width = Self::expanded_width(line.get(..offset)?, 0);
         let mut positions = vec![];
         let content_position = |column| Sourcepos::from((lineno, column, lineno, line.len()));
 
@@ -67,13 +68,12 @@ impl MD027 {
             let owned = marker + own_markers > markers;
 
             // A marker takes one space of its own and three of indentation, per
-            // `CommonMark`, and a tab stands for four columns of the latter. Past
-            // that the `>` is text, and the spaces are the previous marker's
-            // content rather than indentation. Only a gap this quote answers for is
-            // held to it: one a list item indents is the item's, and as wide as the
-            // item is.
-            let columns = spaces + 3 * rest.get(..spaces)?.matches('\t').count();
-            let marker_here = at_marker.starts_with('>') && !(owned && columns > 4);
+            // `CommonMark`. Past that the `>` is text, and the spaces are the
+            // previous marker's content rather than indentation. Only a gap this
+            // quote answers for is held to it: one a list item indents is the
+            // item's, and as wide as the item is.
+            let width = Self::expanded_width(rest.get(..spaces)?, prefix_width);
+            let marker_here = at_marker.starts_with('>') && !(owned && width > 4);
 
             if !marker_here {
                 if owned && spaces > 1 && !at_marker.is_empty() {
@@ -89,6 +89,7 @@ impl MD027 {
 
             rest = at_marker.get(1..)?;
             prefix_len += spaces + 1;
+            prefix_width += width + 1;
         }
 
         let content = rest.trim_start_matches([' ', '\t']);
@@ -99,6 +100,21 @@ impl MD027 {
         }
 
         Some(positions)
+    }
+
+    /// How wide `text` is, written at column `from`, with each tab taking the
+    /// columns up to the next stop of four as `CommonMark` expands them.
+    fn expanded_width(text: &str, from: usize) -> usize {
+        text.chars().fold(0, |width, character| {
+            width
+                + if character == '\t' {
+                    // The columns up to the next stop, which is every fourth and
+                    // so is what the low two bits count off.
+                    4 - ((from + width) & 3)
+                } else {
+                    1
+                }
+        })
     }
 
     /// How many blockquotes `node`, itself a blockquote, is quoted by, itself
@@ -359,6 +375,28 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((2, 7, 2, 18)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: The tab on line 2 takes the two columns up to the next stop, which
+    // leaves the `>` after it within a marker's reach.
+    #[test]
+    fn check_errors_paragraph_with_tab_between_markers() -> Result<()> {
+        let text = indoc! {"
+            > > Quoted text
+            > \t>  More text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((2, 4, 2, 15))),
+            rule.to_violation(path, Sourcepos::from((2, 7, 2, 15))),
+        ];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -35,12 +35,15 @@ impl MD027 {
     /// starts at, the one line a list item's marker can precede.
     ///
     /// The quote owns the innermost `own_markers` of the `markers` quoting the
-    /// line, and the spaces before an outer one are the indentation of whatever
-    /// holds it rather than any quote's. A line carrying fewer markers than that
-    /// is measured for as many as it carries, and one carrying none is left alone.
+    /// line. The spaces before the outermost it owns are the indentation of
+    /// whatever holds that marker rather than any quote's, and go unmeasured; the
+    /// ones after it are the quote's. A line carrying fewer markers than it is
+    /// quoted by is measured for as many as it carries, and one carrying none is
+    /// left alone.
     ///
-    /// What this reads as a prefix and `CommonMark` does not is #455, and what it
-    /// cannot tell from a list item's indentation is #456.
+    /// What this reads as a prefix and `CommonMark` does not is #455, what it
+    /// cannot tell from a list item's indentation is #456, and the tab it counts
+    /// as one space here and as its own width above is #458.
     ///
     /// `None` for a line `lines` does not hold, and for one the `offset` is not
     /// within. The caller reports nothing for either.
@@ -291,8 +294,8 @@ mod tests {
         Ok(())
     }
 
-    // NOTE: A line of whitespace CommonMark does not end a line with is content,
-    // and the content of this one begins two spaces after the marker.
+    // NOTE: A line of whitespace `CommonMark` does not end a line with is
+    // content, and the content of this one begins two spaces after the marker.
     #[test]
     fn check_errors_paragraph_with_unicode_whitespace() -> Result<()> {
         let text = indoc! {"

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -64,20 +64,30 @@ impl MD027 {
                 rest.trim_start_matches([' ', '\t'])
             };
             let spaces = rest.len() - at_marker.len();
+            let owned = marker + own_markers > markers;
 
-            let Some(after_marker) = at_marker.strip_prefix('>') else {
-                if marker + own_markers > markers && spaces > 1 && !at_marker.is_empty() {
+            // A marker takes one space of its own and three of indentation, per
+            // `CommonMark`, and a tab stands for four columns of the latter. Past
+            // that the `>` is text, and the spaces are the previous marker's
+            // content rather than indentation. Only a gap this quote answers for is
+            // held to it: one a list item indents is the item's, and as wide as the
+            // item is.
+            let columns = spaces + 3 * rest.get(..spaces)?.matches('\t').count();
+            let marker_here = at_marker.starts_with('>') && !(owned && columns > 4);
+
+            if !marker_here {
+                if owned && spaces > 1 && !at_marker.is_empty() {
                     positions.push(content_position(prefix_len + spaces + 1));
                 }
 
                 return Some(positions);
-            };
+            }
 
-            if marker + own_markers > markers && spaces > 1 {
+            if owned && spaces > 1 {
                 positions.push(content_position(prefix_len + spaces + 1));
             }
 
-            rest = after_marker;
+            rest = at_marker.get(1..)?;
             prefix_len += spaces + 1;
         }
 
@@ -330,6 +340,25 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((1, 10, 1, 22)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: The `>` on line 2 is five columns in, past the four a marker takes,
+    // so it is text and the spaces before it are the outer marker's content.
+    #[test]
+    fn check_errors_paragraph_with_over_indented_marker() -> Result<()> {
+        let text = indoc! {"
+            > > Quoted text
+            >     >  More text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 7, 2, 18)))];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -1,6 +1,5 @@
-use comrak::nodes::NodeValue;
+use comrak::nodes::{NodeValue, Sourcepos};
 use miette::Result;
-use rustc_hash::FxHashSet;
 
 use crate::{Document, violation::Violation};
 
@@ -23,6 +22,39 @@ impl MD027 {
     pub const fn new() -> Self {
         Self {}
     }
+
+    /// The content of line `lineno` from where it begins to the end of the line,
+    /// when more than one space separates it from the blockquote marker at
+    /// `marker_column`. One space after the marker belongs to the prefix, per
+    /// `CommonMark`, and the rest is what this rule reports.
+    ///
+    /// The line is read rather than the inlines on it, since an inline that
+    /// opened on an earlier line leaves the first inline of this one beginning
+    /// wherever that inline closed.
+    ///
+    /// `None` for a line with nothing to report, a line the marker cannot be
+    /// read at included: a lazy continuation line carries no marker, and a
+    /// nested quote's markers move between lines that spell the nesting with
+    /// different widths.
+    fn indented_content_position(
+        lines: &[String],
+        lineno: usize,
+        marker_column: usize,
+    ) -> Option<Sourcepos> {
+        let line = lines.get(lineno.checked_sub(1)?)?;
+        let after_marker = line
+            .get(marker_column.checked_sub(1)?..)?
+            .strip_prefix('>')?;
+        let content = after_marker.trim_start_matches(' ');
+        let spaces = after_marker.len() - content.len();
+
+        if spaces < 2 || content.trim().is_empty() {
+            return None;
+        }
+
+        let column = marker_column + spaces + 1;
+        Some(Sourcepos::from((lineno, column, lineno, line.len())))
+    }
 }
 
 impl RuleLike for MD027 {
@@ -41,22 +73,15 @@ impl RuleLike for MD027 {
             {
                 match &child_node.data.borrow().value {
                     NodeValue::Paragraph => {
-                        let mut lines = FxHashSet::default();
-                        for inline_node in child_node.children() {
-                            let block_quote_position = node.data.borrow().sourcepos;
-                            let inline_position = inline_node.data.borrow().sourcepos;
-                            let lineno = inline_position.start.line;
-                            let expected_column = block_quote_position.start.column + 2;
-
-                            if inline_position.start.column > expected_column
-                                && !lines.contains(&lineno)
+                        let marker_column = node.data.borrow().sourcepos.start.column;
+                        let paragraph_position = child_node.data.borrow().sourcepos;
+                        for lineno in paragraph_position.start.line..=paragraph_position.end.line {
+                            if let Some(position) =
+                                Self::indented_content_position(&doc.lines, lineno, marker_column)
                             {
-                                let violation =
-                                    self.to_violation(doc.path.clone(), inline_position);
+                                let violation = self.to_violation(doc.path.clone(), position);
                                 violations.push(violation);
                             }
-
-                            lines.insert(lineno);
                         }
                     }
                     NodeValue::List(_) => {
@@ -118,11 +143,46 @@ mod tests {
         let expected = vec![
             rule.to_violation(path.clone(), Sourcepos::from((1, 4, 1, 16))),
             rule.to_violation(path.clone(), Sourcepos::from((2, 4, 2, 16))),
-            rule.to_violation(path.clone(), Sourcepos::from((4, 4, 4, 9))),
-            rule.to_violation(path.clone(), Sourcepos::from((5, 4, 5, 13))),
-            rule.to_violation(path.clone(), Sourcepos::from((6, 4, 6, 9))),
-            rule.to_violation(path, Sourcepos::from((7, 4, 7, 30))),
+            rule.to_violation(path.clone(), Sourcepos::from((4, 4, 4, 18))),
+            rule.to_violation(path.clone(), Sourcepos::from((5, 4, 5, 22))),
+            rule.to_violation(path.clone(), Sourcepos::from((6, 4, 6, 18))),
+            rule.to_violation(path, Sourcepos::from((7, 4, 7, 39))),
         ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_paragraph_with_multiple_line_inline() -> Result<()> {
+        let text = indoc! {"
+            > **bold
+            >  span.** tail here
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 4, 2, 20)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_paragraph_with_indented_block_quote() -> Result<()> {
+        let text = indoc! {"
+            Text
+
+              >  Indented text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 6, 3, 18)))];
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -276,6 +336,35 @@ mod tests {
             > **Strong** and text
             > `code` and text
             > [link](https://example.com) and text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: One space follows every marker here. The inline that spans both
+    // lines leaves the first inline of the second line beginning where it
+    // closed, which is not where the line's content begins.
+    #[test]
+    fn check_no_errors_paragraph_with_multiple_line_inline() -> Result<()> {
+        let text = indoc! {"
+            > **bold
+            > span.** tail here
+
+            > _em
+            > span._ tail here
+
+            > [link
+            > text](https://example.com) tail here
+
+            > `code
+            > span` tail here
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();


### PR DESCRIPTION
Closes #439.

## What this does

MD027's paragraph branch reads the source line instead of the inlines on it.
For every line of a quoted paragraph, `indented_content_positions` finds the
quote's markers on that line and reports, after each marker the quote owns, the
content through to the end of the line when more than one space is there.

That is what #439 needed. The branch used to suppress inlines by the line they
started on, so an inline spanning two lines never registered the second, and the
text after its close was read as the first thing on that line:

| document | before | after | mdl 0.17.0 |
|---|---|---|---|
| `> **bold` / `> span.** tail here` | `4:10` | none | none |
| `> _em` / `> span._ tail here` | `4:9` | none | none |
| `> [link` / `> text](http://e.com) tail here` | `4:22` | none | none |
| `` > `code `` / `` > span` tail here `` | `4:8` | none | none |
| `> **bold` / `>  span.** tail here` | `4:11` | `4:4` | reported |
| `>  **bold` / `> span.** tail here` | `3:4`, `4:10` | `3:4` | reported |
| `> **bold` / `>  span**` | none | `2:4` | reported |

The fifth row is why recording the lines an inline spans, which #439 suggested
and which is three lines, was not the fix: it takes the four false positives
away and the genuine finding on row five with them. Row five also shows the
column this branch got wrong whenever it did report the right line, and row
seven a line whose own indentation the old bookkeeping never read.

## How a line's markers are found

Two lines of one quote are not written the same way, so neither is read the same
way. Each case below is a regression test here.

On the line the quote starts at, comrak says which column its marker is at, and
that is the only line where something other than the quote's own markers can
precede the content:

- `- >  quoted text`, and `> - >  nested in list`. The bullet is not part of any
  quote's prefix. Reading the line from its start finds a `-` where a marker
  should be and reports nothing.

Every line after carries the whole prefix and nothing else, so it is counted
from the start of the line:

- `>> Original` / `> >  Reply`. The same nesting, two widths. Taking the marker's
  column from the first line finds a space where the inner marker is on the
  second, and the two spaces after that marker go unreported.
- `> > Quoted text` / `ab>  more text`. The second line is a lazy continuation
  line carrying no marker at all, and its text has a `>` at the column the
  quote's inner marker sits at above. Taking the column from the first line
  reports a line that is prose.

Each marker the quote owns is measured, not the innermost alone, since the spaces
after an outer marker are as much the quote's: `> > a` / `>  > b` is two spaces
after the outer marker on line 2, and the `_ =>` branch cannot answer for it
because it measures the line the quotes start at. A quote owns every marker up to
the first ancestor that is not a blockquote, so the gap a list item's indentation
accounts for is read and not measured: `- >  first` / `  >  second` is the item's
two spaces and then the quote's.

A marker of the quote's own takes one space and three of indentation, per
CommonMark, and a `>` indented past that is text: `> > a` / `>     >  b` is one
report at `2:7`, for the five spaces after the outer marker, rather than that and
a second inside the text behind it. A tab takes the columns up to the next stop of
four from wherever it sits while the bound is measured, so the `>` after the tab
in `> > a` / `> \t>  b` is two columns along and is a marker, where counting the
tab as four flat made it text. A gap a list item indents is held to the item's
width instead of the bound, so `> 10. >  x` / `>      >  y` reports where it did.

A line that carries fewer markers than the quote is measured at the last one it
does carry, if the quote owns that marker: `> > Quoted` / `>   lazy` is three
spaces after the outer marker, reported at `2:5` now and by mdl, and by nothing in
0.3.2. A line carrying none of the quote's markers is left alone, which drops the
reports 0.3.2 made at the first inline on such a line: `> Quoted text` /
`     prose` was `2:6` and is nothing, as it is nothing to mdl.

A line is content when anything at all follows the spaces, Unicode whitespace
included: `>  \u{a0}` is reported, as 0.3.2 and mdl report it, and a line that
ends after the spaces is MD009's.

Tabs count as one space's worth of whitespace after a marker, so
`> \tIndented text` is two characters and reported, as it was before this branch,
and `>\tIndented text` is one and is not, as it was not. A tab is not read as
indentation *before* a marker: it is four columns, more than CommonMark allows
there, so `> Quoted` / `\t>  More` is text and left alone, as 0.3.2 and mdl leave
it. Between two markers a tab still counts, the line carrying the prefix either
way.

## Why only the paragraph branch

A paragraph is the one place where the line almost always says all there is to
know. CommonMark drops the leading spaces of a paragraph's continuation lines, so
nothing in a paragraph's text is entitled to them — a code span spanning two of
them is the exception, and #457. Everywhere else the indentation after the marker
belongs to the content often enough that the existing tests fix it in place:

- `>   * baz` is a nested list item, and `check_no_errors_list` expects silence
- `>  foo` between fences is code whose first character is a space, which cannot
  be written any other way
- `>     code` is an indented code block, and four of those spaces are what make
  it one

So the list and block branches stay on the AST, and `// TODO: Support multi-line
errors` stays with them: a code block or an HTML block is still reported once for
the whole block rather than per line. MD027 stays :hammer: in the README.

`check_errors_with_nested_block_quotes2` does move: of the six reports its
`// TODO: This results are expected` comment wrote down, four are now made. The
two still commented out are the outer markers on the line the quotes start at,
which the `_ =>` branch names as a span of every line.

## What is left

Each of these is filed rather than carried in this description alone:

- A blockquote's second and later children go unchecked, so `>  second para`
  after a blank `>` line is missed, which mdl misses too, and so is an outer
  marker on the line a later child starts at: `> a` / `>` / `>  >  b` reports
  `3:7` and not the two spaces after the outer marker, where mdl reports the
  line. #454.
- A line whose `>` is indented four spaces or more is prose to CommonMark, and
  this branch reads the indentation as a prefix and reports inside it:
  `> foo` / `    >  bar` reports `2:8`, where 0.3.2 reported `2:5` and mdl reports
  the line too. For a quote that starts at column 1 that is the same line at
  another column; for an indented one it is a line 0.3.2 did not report at all,
  `  > foo` / `    >    bar` being silent there and `2:10` here. The bound this
  wants is not three spaces flat, since a list item's indentation legitimately
  pushes a marker further right. #455, where this is written down.
- A document written with a bare `\r` is one line to `Document::lines` and
  several to comrak, so this branch measures the first line of such a document,
  none of the rest, and runs the end column to the end of what `lines` holds.
  MD027 joins nine other rules in reading `doc.lines`, and the split they all
  inherit is #453.
- A tab that is a list item's own indentation is not read as the prefix it is:
  `- >  first` / `\t>  second` leaves line 2 unmeasured, which mdl reports and
  0.3.2 did not. Same answer as 0.3.2, and #455 is where the bound gets settled.
- A list item between two quotes takes its indentation from in front of the inner
  marker on one line and from behind it on the next, and only the first of those
  is told from a space of the quote's own. `> - >  first` / `  >    second` goes
  unreported where 0.3.2 and mdl report it; the item's content offset is what
  would answer it. #456.
- The whitespace after a marker counts in characters while the whitespace before
  one counts in columns, so a tab is one space to the report and one to four
  columns to the bound: `>\tx` goes unreported where `>   x`, whose content begins
  at the same column, is reported, and `  >>alpha` / a tab-written `  >\t>\tbeta`
  loses the `2:7` that 0.3.2 reported. mdl does not report either tab form. #458.
- A code span spanning two quoted lines owns the spaces after the marker on the
  second, and they are reported: `` > `code `` / `` >  span` tail `` reports
  `2:4`, where 0.3.2 reported `2:9` and mdl reports the line too. The same space
  inside a fenced code block is left alone, by the branch that handles the block
  rather than by anything that knows why. #457.

## What moves for users

Which lines are reported, and at which column when a line is measured at an outer
marker: that is the column the marker's content begins at rather than the
innermost marker's. The changelog records the reports moving in both directions
under Fixed, where the reported-position fixes in 0.3.2 (#405, #407) are.

The end column of a reported position moves too — `>  *Emph* and text` was
`4:4-4:9` and is `4:4-4:18` — and no output format prints it: `concise`, `mdl` and
`markdownlint` all print `position().start`, so this is visible to a library
caller reading `Violation::position()` and to nobody running `mado check`. The
changelog says so in those terms, the file recording library-visible changes
elsewhere; four expectations in `check_errors_paragraph` carry it.

## Checks

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D
  warnings`, and `cargo test --locked --all-features --workspace` all pass
- Fourteen tests added: the four #439 documents as one clean case, the row-five and
  row-seven documents, a quote indented from the start of the line, a quote
  opened on a list item's line, a tab after the marker, the two-width nesting,
  the outer marker on a continuation line, the outer marker a line keeps when it
  drops the inner one, the same through a list item, a marker indented
  past its reach, a tab between two markers, a line of Unicode whitespace, the
  lazy continuation line, and the tab-indented one
- `mado check` over this repository is clean, and MD027 over
  `scripts/acceptance/data/markdownlint/test/rule_tests` is identical to 0.3.2's
  output, the same nine lines of `blockquote_spaces.md` that mdl reports
