### PR TITLE
fix: measure every block a blockquote holds in MD027

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,10 @@ parsed and therefore what gets reported.
   block carries names the line it starts at rather than every line it spans. An
   indented code block written anywhere but first is reported with the rest, the
   four spaces it needs on top of the marker's own being more than one, which is
-  #459 rather than anything this release settles (#454)
+  #459 rather than anything this release settles. Such a block is reported at the
+  first character after its spaces rather than at the column the block's content
+  begins, which moves the column right when it is written with more spaces than
+  the four it needs (#454)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,9 @@ parsed and therefore what gets reported.
   #459 rather than anything this release settles. Such a block is reported at the
   first character after its spaces rather than at the column the block's content
   begins, which moves the column right when it is written with more spaces than
-  the four it needs (#454)
+  the four it needs. A lazily continued line is measured for the first time as
+  well, which is how the misread #455 describes reaches documents it did not
+  before (#454)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ parsed and therefore what gets reported.
   carries runs from the content after the marker to the end of the line, where it
   ran to the end of the first inline on it; no output format prints that, so it is
   for a library caller reading `Violation::position()` (#439)
+- MD027: measure every block a quote holds rather than its first alone, so what
+  follows a blank quoted line is measured too. `> Quoted text` above a `>` and a
+  `>  More quoted text` reports the third line, as it already did when that line
+  was the quote's first block, and a nested quote written there is reported for
+  the outer marker as well as the inner one. An indented code block written
+  anywhere but first is reported with them, the four spaces it needs on top of the
+  marker's own being more than one, which is #459 rather than anything this
+  release settles (#454)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,15 @@ parsed and therefore what gets reported.
   follows a blank quoted line is measured too. `> Quoted text` above a `>` and a
   `>  More quoted text` reports the third line, as it already did when that line
   was the quote's first block, and a nested quote written there is reported for
-  the outer marker as well as the inner one. An indented code block written
-  anywhere but first is reported with them, the four spaces it needs on top of the
-  marker's own being more than one, which is #459 rather than anything this
-  release settles (#454)
+  the outer marker as well as the inner one. Each block is read on the line it
+  starts at rather than against the column the quote's first line put its marker
+  at, so a block whose marker is indented within what CommonMark allows is not
+  reported for that indentation, one whose marker sits further left than the
+  quote's first is reported for the spaces after it, and the position a reported
+  block carries names the line it starts at rather than every line it spans. An
+  indented code block written anywhere but first is reported with the rest, the
+  four spaces it needs on top of the marker's own being more than one, which is
+  #459 rather than anything this release settles (#454)
 
 ## [0.3.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,9 @@ parsed and therefore what gets reported.
   #459 rather than anything this release settles. Such a block is reported at the
   first character after its spaces rather than at the column the block's content
   begins, which moves the column right when it is written with more spaces than
-  the four it needs. A lazily continued line is measured for the first time as
-  well, which is how the misread #455 describes reaches documents it did not
-  before (#454)
+  the four it needs. A lazily continued line of a block after the first is
+  measured as well, which is how the misread #455 describes reaches documents it
+  did not before (#454)
 
 ## [0.3.2] - 2026-09-07
 

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -150,60 +150,65 @@ impl RuleLike for MD027 {
         let mut violations = vec![];
 
         for node in doc.ast.descendants() {
-            if node.data.borrow().value == NodeValue::BlockQuote
-                && let Some(child_node) = node.first_child()
-            {
-                match &child_node.data.borrow().value {
-                    NodeValue::Paragraph => {
-                        let block_quote_position = node.data.borrow().sourcepos;
-                        let paragraph_position = child_node.data.borrow().sourcepos;
-                        let depth = Self::block_quote_depth(node);
-                        let nested = Self::nested_block_quotes(node);
-                        for lineno in paragraph_position.start.line..=paragraph_position.end.line {
-                            // The quote's own marker on the line it starts at,
-                            // where comrak has already said which column it is at
-                            // and a list item's marker can precede it. Every line
-                            // after is read from its start, for the markers it
-                            // carries of the ones quoting it.
-                            let (markers, own_markers, offset) =
-                                if lineno == block_quote_position.start.line {
-                                    (1, 1, block_quote_position.start.column.saturating_sub(1))
-                                } else {
-                                    (depth, nested, 0)
-                                };
+            if node.data.borrow().value == NodeValue::BlockQuote {
+                let block_quote_position = node.data.borrow().sourcepos;
+                let expected_column = block_quote_position.start.column + 2;
+                let depth = Self::block_quote_depth(node);
+                let nested = Self::nested_block_quotes(node);
 
-                            let positions = Self::indented_content_positions(
-                                &doc.lines,
-                                lineno,
-                                markers,
-                                own_markers,
-                                offset,
-                            );
-                            for position in positions.into_iter().flatten() {
-                                let violation = self.to_violation(doc.path.clone(), position);
-                                violations.push(violation);
+                // Every block the quote holds, not only the first: a blank quoted
+                // line ends one and starts another, and the indentation of what
+                // follows is the quote's to answer for too.
+                for child_node in node.children() {
+                    match &child_node.data.borrow().value {
+                        NodeValue::Paragraph => {
+                            let paragraph_position = child_node.data.borrow().sourcepos;
+                            for lineno in
+                                paragraph_position.start.line..=paragraph_position.end.line
+                            {
+                                // The quote's own marker on the line it starts at,
+                                // where comrak has already said which column it is
+                                // at and a list item's marker can precede it. Every
+                                // line after is read from its start, for the markers
+                                // it carries of the ones quoting it.
+                                let (markers, own_markers, offset) =
+                                    if lineno == block_quote_position.start.line {
+                                        (1, 1, block_quote_position.start.column.saturating_sub(1))
+                                    } else {
+                                        (depth, nested, 0)
+                                    };
+
+                                let positions = Self::indented_content_positions(
+                                    &doc.lines,
+                                    lineno,
+                                    markers,
+                                    own_markers,
+                                    offset,
+                                );
+                                for position in positions.into_iter().flatten() {
+                                    let violation = self.to_violation(doc.path.clone(), position);
+                                    violations.push(violation);
+                                }
                             }
                         }
-                    }
-                    NodeValue::List(_) => {
-                        for item_node in child_node.children() {
-                            let block_quote_position = node.data.borrow().sourcepos;
-                            let item_position = item_node.data.borrow().sourcepos;
-                            let expected_column = block_quote_position.start.column + 2;
+                        NodeValue::List(_) => {
+                            for item_node in child_node.children() {
+                                let item_position = item_node.data.borrow().sourcepos;
 
-                            if item_position.start.column > expected_column {
-                                let violation = self.to_violation(doc.path.clone(), item_position);
-                                violations.push(violation);
+                                if item_position.start.column > expected_column {
+                                    let violation =
+                                        self.to_violation(doc.path.clone(), item_position);
+                                    violations.push(violation);
+                                }
                             }
                         }
-                    }
-                    _ => {
-                        // TODO: Support multi-line errors
-                        let parent_position = node.data.borrow().sourcepos;
-                        let child_position = child_node.data.borrow().sourcepos;
-                        if child_position.start.column > parent_position.start.column + 2 {
-                            let violation = self.to_violation(doc.path.clone(), child_position);
-                            violations.push(violation);
+                        _ => {
+                            // TODO: Support multi-line errors
+                            let child_position = child_node.data.borrow().sourcepos;
+                            if child_position.start.column > expected_column {
+                                let violation = self.to_violation(doc.path.clone(), child_position);
+                                violations.push(violation);
+                            }
                         }
                     }
                 }
@@ -401,6 +406,83 @@ mod tests {
         let expected = vec![
             rule.to_violation(path.clone(), Sourcepos::from((2, 4, 2, 15))),
             rule.to_violation(path, Sourcepos::from((2, 7, 2, 15))),
+        ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_later_paragraph() -> Result<()> {
+        let text = indoc! {"
+            > Quoted text
+            >
+            >  More quoted text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 4, 3, 19)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_later_list() -> Result<()> {
+        let text = indoc! {"
+            > Quoted text
+            >
+            >  * Item
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 4, 3, 9)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_later_code_block() -> Result<()> {
+        let text = indoc! {"
+            > Quoted text
+            >
+            >  ```
+            >  foo
+            >  ```
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 4, 5, 6)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_later_block_quote() -> Result<()> {
+        let text = indoc! {"
+            > Quoted text
+            >
+            >  >  More quoted text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((3, 4, 3, 22))),
+            rule.to_violation(path, Sourcepos::from((3, 7, 3, 22))),
         ];
         assert_eq!(actual, expected);
         Ok(())
@@ -672,6 +754,24 @@ mod tests {
         let text = indoc! {"
             > Quoted text
             \t>  More text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_no_errors_later_paragraph() -> Result<()> {
+        let text = indoc! {"
+            > Quoted text
+            >
+            > More quoted text
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -209,7 +209,9 @@ impl RuleLike for MD027 {
                             }
                         }
                         _ => {
-                            // TODO: Support multi-line errors
+                            // TODO: Support multi-line errors. A nested quote's
+                            // later lines are its own to measure, and measuring
+                            // them here as well would report them twice.
                             let lineno = child_position.start.line;
                             self.measure(doc, lineno, prefix(lineno), &mut violations);
                         }
@@ -523,6 +525,47 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![rule.to_violation(path, Sourcepos::from((3, 4, 3, 14)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_later_block_quote_without_blank_line() -> Result<()> {
+        let text = indoc! {"
+            > Quoted text
+            >  > More text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((2, 4, 2, 14)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: The outer quote's later block is measured before the walk reaches the
+    // quotes inside the item, so line 2 is reported before line 1. #462 asks
+    // whether a rule owes its caller source order.
+    #[test]
+    fn check_errors_later_block_quote_in_list_item() -> Result<()> {
+        let text = indoc! {"
+            > - > >  Quoted text
+              >  >  More text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![
+            rule.to_violation(path.clone(), Sourcepos::from((2, 6, 2, 17))),
+            rule.to_violation(path.clone(), Sourcepos::from((1, 10, 1, 20))),
+            rule.to_violation(path, Sourcepos::from((2, 9, 2, 17))),
+        ];
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -187,9 +187,11 @@ impl RuleLike for MD027 {
                     }
                 };
 
-                // Every block the quote holds, not only the first: a blank quoted
-                // line ends one and starts another, and the indentation of what
-                // follows is the quote's to answer for too.
+                // Every block comrak gives the quote a node for, not only the
+                // first: a blank quoted line ends one and starts another, and the
+                // indentation of what follows is the quote's to answer for too.
+                // A link reference definition is left no node and so unmeasured,
+                // which is #461.
                 for child_node in node.children() {
                     let child_position = child_node.data.borrow().sourcepos;
 
@@ -200,6 +202,7 @@ impl RuleLike for MD027 {
                             }
                         }
                         NodeValue::List(_) => {
+                            // TODO: Support multi-line errors
                             for item_node in child_node.children() {
                                 let lineno = item_node.data.borrow().sourcepos.start.line;
                                 self.measure(doc, lineno, prefix(lineno), &mut violations);

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -572,6 +572,24 @@ mod tests {
         Ok(())
     }
 
+    // NOTE: The four spaces after the marker's own are what make this a code
+    // block, so the report cannot be acted on. #459 is whether to make it.
+    #[test]
+    fn check_errors_indented_code_block() -> Result<()> {
+        let text = indoc! {"
+            >      code block
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((1, 8, 1, 17)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
     #[test]
     fn check_errors_html_block_single_line() -> Result<()> {
         let text = indoc! {"

--- a/src/rule/md027.rs
+++ b/src/rule/md027.rs
@@ -122,6 +122,25 @@ impl MD027 {
         })
     }
 
+    /// Appends what line `lineno` carries after the markers `prefix` describes:
+    /// how many quote the line, how many of those the quote owns, and the byte to
+    /// start reading them at.
+    fn measure(
+        &self,
+        doc: &Document,
+        lineno: usize,
+        prefix: (usize, usize, usize),
+        violations: &mut Vec<Violation>,
+    ) {
+        let (markers, own_markers, offset) = prefix;
+        let positions =
+            Self::indented_content_positions(&doc.lines, lineno, markers, own_markers, offset);
+
+        for position in positions.into_iter().flatten() {
+            violations.push(self.to_violation(doc.path.clone(), position));
+        }
+    }
+
     /// How many blockquotes `node`, itself a blockquote, is quoted by, itself
     /// included.
     fn block_quote_depth<'a>(node: &'a AstNode<'a>) -> usize {
@@ -152,63 +171,44 @@ impl RuleLike for MD027 {
         for node in doc.ast.descendants() {
             if node.data.borrow().value == NodeValue::BlockQuote {
                 let block_quote_position = node.data.borrow().sourcepos;
-                let expected_column = block_quote_position.start.column + 2;
                 let depth = Self::block_quote_depth(node);
                 let nested = Self::nested_block_quotes(node);
+
+                // The quote's own marker on the line it starts at, where comrak has
+                // already said which column it is at and a list item's marker can
+                // precede it. Every line after is read from its start, for the
+                // markers it carries of the ones quoting it, which is the only way
+                // to read a line the same nesting is written differently on.
+                let prefix = |lineno| {
+                    if lineno == block_quote_position.start.line {
+                        (1, 1, block_quote_position.start.column.saturating_sub(1))
+                    } else {
+                        (depth, nested, 0)
+                    }
+                };
 
                 // Every block the quote holds, not only the first: a blank quoted
                 // line ends one and starts another, and the indentation of what
                 // follows is the quote's to answer for too.
                 for child_node in node.children() {
+                    let child_position = child_node.data.borrow().sourcepos;
+
                     match &child_node.data.borrow().value {
                         NodeValue::Paragraph => {
-                            let paragraph_position = child_node.data.borrow().sourcepos;
-                            for lineno in
-                                paragraph_position.start.line..=paragraph_position.end.line
-                            {
-                                // The quote's own marker on the line it starts at,
-                                // where comrak has already said which column it is
-                                // at and a list item's marker can precede it. Every
-                                // line after is read from its start, for the markers
-                                // it carries of the ones quoting it.
-                                let (markers, own_markers, offset) =
-                                    if lineno == block_quote_position.start.line {
-                                        (1, 1, block_quote_position.start.column.saturating_sub(1))
-                                    } else {
-                                        (depth, nested, 0)
-                                    };
-
-                                let positions = Self::indented_content_positions(
-                                    &doc.lines,
-                                    lineno,
-                                    markers,
-                                    own_markers,
-                                    offset,
-                                );
-                                for position in positions.into_iter().flatten() {
-                                    let violation = self.to_violation(doc.path.clone(), position);
-                                    violations.push(violation);
-                                }
+                            for lineno in child_position.start.line..=child_position.end.line {
+                                self.measure(doc, lineno, prefix(lineno), &mut violations);
                             }
                         }
                         NodeValue::List(_) => {
                             for item_node in child_node.children() {
-                                let item_position = item_node.data.borrow().sourcepos;
-
-                                if item_position.start.column > expected_column {
-                                    let violation =
-                                        self.to_violation(doc.path.clone(), item_position);
-                                    violations.push(violation);
-                                }
+                                let lineno = item_node.data.borrow().sourcepos.start.line;
+                                self.measure(doc, lineno, prefix(lineno), &mut violations);
                             }
                         }
                         _ => {
                             // TODO: Support multi-line errors
-                            let child_position = child_node.data.borrow().sourcepos;
-                            if child_position.start.column > expected_column {
-                                let violation = self.to_violation(doc.path.clone(), child_position);
-                                violations.push(violation);
-                            }
+                            let lineno = child_position.start.line;
+                            self.measure(doc, lineno, prefix(lineno), &mut violations);
                         }
                     }
                 }
@@ -462,7 +462,7 @@ mod tests {
         let doc = Document::new(&arena, path.clone(), text)?;
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
-        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 4, 5, 6)))];
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 4, 3, 6)))];
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -484,6 +484,42 @@ mod tests {
             rule.to_violation(path.clone(), Sourcepos::from((3, 4, 3, 22))),
             rule.to_violation(path, Sourcepos::from((3, 7, 3, 22))),
         ];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_later_block_with_indented_block_quote() -> Result<()> {
+        let text = indoc! {"
+               > Quoted text
+               >
+            >  # Heading
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 4, 3, 12)))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn check_errors_later_block_in_nested_block_quote() -> Result<()> {
+        let text = indoc! {"
+            > > Quoted text
+            > >
+            >  > # Heading
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path.clone(), text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![rule.to_violation(path, Sourcepos::from((3, 4, 3, 14)))];
         assert_eq!(actual, expected);
         Ok(())
     }
@@ -526,9 +562,8 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![
-            rule.to_violation(path, Sourcepos::from((1, 4, 5, 6))),
+            rule.to_violation(path, Sourcepos::from((1, 4, 1, 6))),
             // TODO: This results are expected
-            // rule.to_violation(path.clone(), Sourcepos::from((1, 4, 1, 6))),
             // rule.to_violation(path.clone(), Sourcepos::from((2, 4, 2, 6))),
             // rule.to_violation(path.clone(), Sourcepos::from((4, 4, 4, 6))),
             // rule.to_violation(path, Sourcepos::from((5, 4, 5, 6))),
@@ -567,9 +602,8 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![
-            rule.to_violation(path, Sourcepos::from((1, 4, 3, 10))),
+            rule.to_violation(path, Sourcepos::from((1, 4, 1, 8))),
             // TODO: This results are expected
-            // rule.to_violation(path.clone(), Sourcepos::from((1, 4, 1, 8))),
             // rule.to_violation(path, Sourcepos::from((3, 4, 3, 10))),
         ];
         assert_eq!(actual, expected);
@@ -612,15 +646,12 @@ mod tests {
         let rule = MD027::new();
         let actual = rule.check(&doc)?;
         let expected = vec![
-            rule.to_violation(path.clone(), Sourcepos::from((1, 4, 3, 55))),
-            rule.to_violation(path.clone(), Sourcepos::from((1, 7, 3, 55))),
+            rule.to_violation(path.clone(), Sourcepos::from((1, 4, 1, 58))),
+            rule.to_violation(path.clone(), Sourcepos::from((1, 7, 1, 58))),
             rule.to_violation(path.clone(), Sourcepos::from((1, 10, 1, 58))),
             rule.to_violation(path.clone(), Sourcepos::from((3, 4, 3, 55))),
             rule.to_violation(path.clone(), Sourcepos::from((3, 7, 3, 55))),
             rule.to_violation(path, Sourcepos::from((3, 10, 3, 55))),
-            // TODO: The outer two are expected to name line 1 alone
-            // rule.to_violation(path.clone(), Sourcepos::from((1, 4, 1, 58))),
-            // rule.to_violation(path.clone(), Sourcepos::from((1, 7, 1, 58))),
         ];
         assert_eq!(actual, expected);
         Ok(())
@@ -772,6 +803,26 @@ mod tests {
             > Quoted text
             >
             > More quoted text
+        "}
+        .to_owned();
+        let path = Path::new("test.md").to_path_buf();
+        let arena = Arena::new();
+        let doc = Document::new(&arena, path, text)?;
+        let rule = MD027::new();
+        let actual = rule.check(&doc)?;
+        let expected = vec![];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    // NOTE: A continuation line may carry three spaces of indentation before the
+    // marker, and one space follows the marker on every line here.
+    #[test]
+    fn check_no_errors_later_block_with_indented_marker() -> Result<()> {
+        let text = indoc! {"
+            > Quoted text
+            >
+               > # Heading
         "}
         .to_owned();
         let path = Path::new("test.md").to_path_buf();


### PR DESCRIPTION
Closes #454.

## What this does

MD027 walks every child of a blockquote rather than its first. `node.first_child()`
becomes `node.children()`, the quote's position, depth and nesting move out of the
loop, being the quote's rather than any child's, and every branch reads the line a
block starts at the way the paragraph branch already read its lines.

A blank quoted line ends a block and starts another, and everything after the
first was unmeasured however it was written:

| document | main | this branch | mdl 0.17.0 |
|---|---|---|---|
| `> Quoted text` / `>` / `>  More quoted text` | none | `3:4` | none |
| `> Quoted text` / `>` / `>  * Item` | none | `3:4` | none |
| `> Quoted text` / `>` / `` >  ``` `` … | none | `3:4` | none |
| `> Quoted text` / `>` / `>  <div>x</div>` | none | `3:4` | none |
| `> Quoted text` / `>` / `>  >  More quoted text` | `3:7` | `3:4`, `3:7` | `3` |
| `> Quoted text` / `>` / `> More quoted text` | none | none | none |

The first row is the same line the rule already reported when it was the quote's
first block. The fifth is the other half of #454: the outer marker on the line a
later quote starts at belongs to the outer quote, whose first child is the
paragraph above it, so nothing measured it.

Two shapes filed while fixing #439 come out of it as well, without being the
subject here: `> a` / `>  > b` reports the outer marker's two spaces at `2:4`,
which mdl reports and `main` did not, and `> - > >  a` / `  >  >  b` reports
`2:6` alongside `2:9` — the second report #454's Reach section describes. Both
have a test, neither having been pinned by anything before.

## Why the columns are read per line

The `List` and `_ =>` branches compared a child's column against
`block_quote_position.start.column + 2`, which is where the marker sits on the
quote's *first* line. Only first children reached them before, and a first child
starts on that line; every child reaches them now, and a later line may indent its
marker up to three spaces or write the same nesting at another width:

| document | main | columns compared | per-line read |
|---|---|---|---|
| `> Quoted text` / `>` / `   > # Heading` | none | `3:6` | none |
| `   > a` / `   >` / `>  # H` | none | none | `3:4` |
| `> > a` / `> >` / `>  > # H` | none | `3:6` | `3:4` |

The first is the indentation CommonMark allows before a marker, with one space
after it. The second has two spaces after a marker the quote's first line put
further right. The third reports the `#`, which has one space in front of it,
rather than the outer marker's two spaces. Each is a regression test here.

A block therefore names the line it starts at rather than every line it spans:
`check_errors_code_block` moves from `1:4-5:6` to `1:4-1:6`,
`check_errors_html_block_multiple_lines` from `1:4-3:10` to `1:4-1:8`, and the two
outer markers of `check_errors_with_nested_block_quotes2` from spans to `1:4-1:58`
and `1:7-1:58` — which is what that test's `// TODO: The outer two are expected to
name line 1 alone` asked for, so it no longer carries one. No output format prints
an end column. The `_ =>` branch's own TODO stays: a block is still measured once
rather than line by line.

## What it does not change

- Each line a child covers belongs to that child alone, so nothing is reported
  twice. Verified over the shapes where the `_ =>` report and the paragraph branch
  meet (`>  >  x`, `> a` / `>` / `>  >  b`, `>  >  a` / `>  >  b`).
- A block comrak leaves no node for is still unmeasured: `>  [ref]: /url` is a
  quote with no children at all, and mdl reports the line. #461.
- A block is still measured on one line: the second line of `>  - item` followed by
  `>  continued` goes unreported, which the `List` arm now carries the `_ =>` arm's
  TODO for.
- What `mado check` prints stays in source order, `Command::check` sorting before
  it prints. `RuleLike::check` itself can now hand a caller a later line first —
  `> > a` / `>  b` / `>` / `>  c` returns `4:4` before `2:4`, the walk reaching the
  outer quote's later block before the nested quote — which no rule did while each
  measured one block per container. Whether a rule owes source order is #462, and
  it waits on #425 rather than being answered here.
- MD027 over `scripts/acceptance/data/markdownlint/test/rule_tests` is byte
  identical to `main`, and so is MD027 over the 1,522 files of
  `scripts/benchmarks/data/gitlab`. The shape this fixes is rare in prose.
- `mado check` over this repository stays clean.

The start column moves with it for one shape: an indented code block written with
more spaces than the four it needs. `>` and six spaces was `1:7`, the column comrak
reports after stripping four of them, and is `1:8`, the first character after the
spaces — which is what every other report of this rule names. Five spaces, the
narrowest the block can be written with, is `1:7` either way. A test holds the new
column, and the changelog says it moves.

## The one report worth arguing about

An indented code block needs four spaces on top of the marker's own space, so
MD027 reports every one of them — `>     code block` at `1:7`, in 0.3.2, on `main`
and here, mdl included. This branch widens that to a block written after a blank
quoted line. It is unactionable wherever it is reported, since removing a space
stops the block being a code block, so it is filed as #459 rather than answered
here; answering it means leaving a code block's own indentation unmeasured, which
is #457's ground as well.

## Checks

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D
  warnings`, `cargo test --locked --all-features --workspace` (406 + 28 + 3 + 3)
- Eleven tests added: a later paragraph, list, code block and block quote, the
  clean counterpart, the three shapes above, a quoted indented code block, and the
  two reports the walk gains on a quote's later quote. 39 MD027 tests in all, of
  which four expectations moved from a block's span to its first line
- Differential run of every document in this session's scratchpad corpus against a
  `main` build: 21 documents differ, all of them gaining a report, none losing one.
  One of those gains is a false positive rather than a fix: a lazily continued line
  is measured for the first time, so `> Quoted text` / `>` / `> More text` /
  `    >  even more` reports the last line, whose `>` CommonMark reads as text.
  That is #455's misread reaching a document it could not before, and the changelog
  says so
